### PR TITLE
Benchmark UI, parameter metadata overhaul, and search

### DIFF
--- a/dashboard/flag_metadata.py
+++ b/dashboard/flag_metadata.py
@@ -731,7 +731,7 @@ LLAMACPP_LLAMA_BENCH_FLAGS = {
         "cli": "--numa",
         "type": "string",
         "description": "NUMA scheduling (distribute|isolate|numactl)",
-        "default": "disabled",
+        "default": "",
         "tip": "NUMA scheduling mode: <code>distribute</code> (spread across all nodes), <code>isolate</code> (current node only), or <code>numactl</code> (use numactl CPU map). <b>Essential for multi-socket systems</b> to optimize memory access. <code>distribute</code> with memory interleave often provides the best throughput.",
     },
     "n_cpu_moe": {

--- a/dashboard/frontend/src/components/BenchmarkHistory.jsx
+++ b/dashboard/frontend/src/components/BenchmarkHistory.jsx
@@ -1,0 +1,86 @@
+const STATUS_ICONS = {
+  completed: <span className="text-green-400"><i className="fa-solid fa-check"></i> Completed</span>,
+  failed: <span className="text-red-400"><i className="fa-solid fa-xmark"></i> Failed</span>,
+  running: <span className="text-yellow-400"><i className="fa-solid fa-spinner fa-spin"></i> Running</span>,
+  pending: <span className="text-gray-400"><i className="fa-solid fa-clock"></i> Pending</span>,
+  cancelled: <span className="text-gray-400"><i className="fa-solid fa-ban"></i> Cancelled</span>,
+}
+
+export default function BenchmarkHistory({ history, onRerun, onApply, onDelete }) {
+  return (
+    <div className="bg-gray-800 rounded-lg p-5">
+      <h2 className="text-lg font-semibold mb-3">
+        <i className="fa-solid fa-clock-rotate-left mr-2 text-gray-400"></i>History
+      </h2>
+
+      {history.length === 0 ? (
+        <p className="text-gray-500 text-sm mt-3">No benchmark history yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-gray-400 text-left border-b border-gray-700">
+                <th className="pb-2 pr-3">Date</th>
+                <th className="pb-2 pr-3">PP t/s</th>
+                <th className="pb-2 pr-3">TG t/s</th>
+                <th className="pb-2 pr-3">Key Params</th>
+                <th className="pb-2 pr-3">Status</th>
+                <th className="pb-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map(row => {
+                const allParams = Object.entries(row.params || {})
+                  .map(([flag, val]) => val ? `${flag} ${val}` : flag)
+                  .join('  ')
+
+                return (
+                  <tr key={row.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
+                    <td className="py-2.5 pr-3 text-gray-300 text-xs whitespace-nowrap">{row.date}</td>
+                    <td className={`py-2.5 pr-3 font-mono ${row.pp_ts ? 'text-white' : 'text-gray-500'}`}>
+                      {row.pp_ts ? row.pp_ts.toFixed(1) : '\u2014'}
+                    </td>
+                    <td className={`py-2.5 pr-3 font-mono ${row.tg_ts ? 'text-white' : 'text-gray-500'}`}>
+                      {row.tg_ts ? row.tg_ts.toFixed(1) : '\u2014'}
+                    </td>
+                    <td className="py-2.5 pr-3 text-gray-400 text-xs font-mono">{allParams}</td>
+                    <td className="py-2.5 pr-3 text-xs">
+                      {STATUS_ICONS[row.status] || <span className="text-gray-400">{row.status}</span>}
+                    </td>
+                    <td className="py-2.5">
+                      <div className="flex gap-1">
+                        <button
+                          onClick={() => onRerun(row.id)}
+                          className="text-xs bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded cursor-pointer"
+                          title="Re-run with these params"
+                        >
+                          <i className="fa-solid fa-rotate-right"></i> Re-run
+                        </button>
+                        {row.status === 'completed' && (
+                          <button
+                            onClick={() => onApply(row.id)}
+                            className="text-xs bg-blue-700 hover:bg-blue-600 px-2 py-1 rounded cursor-pointer"
+                            title="Apply config to service"
+                          >
+                            <i className="fa-solid fa-upload"></i> Apply
+                          </button>
+                        )}
+                        <button
+                          onClick={() => onDelete(row.id)}
+                          className="text-xs bg-red-700 hover:bg-red-600 px-2 py-1 rounded cursor-pointer"
+                          title="Delete"
+                        >
+                          <i className="fa-solid fa-trash"></i>
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/BenchmarkLiveOutput.jsx
+++ b/dashboard/frontend/src/components/BenchmarkLiveOutput.jsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react'
+
+const STATUS_CONFIG = {
+  idle: { text: 'Idle', className: 'bg-gray-700 text-gray-400' },
+  running: { text: 'Running', className: 'bg-yellow-900 text-yellow-300' },
+  completed: { text: 'Completed', className: 'bg-green-900 text-green-300' },
+  failed: { text: 'Failed', className: 'bg-red-900 text-red-300' },
+  cancelled: { text: 'Cancelled', className: 'bg-red-900 text-red-300' },
+}
+
+export default function BenchmarkLiveOutput({ output, outputClass, runStatus }) {
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    if (runStatus === 'running') setExpanded(true)
+  }, [runStatus])
+
+  const status = STATUS_CONFIG[runStatus] || STATUS_CONFIG.idle
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-5 mb-6">
+      <div
+        className="flex items-center justify-between cursor-pointer select-none"
+        onClick={() => setExpanded(e => !e)}
+      >
+        <h2 className="text-lg font-semibold">
+          <i className={`fa-solid fa-chevron-down mr-1.5 text-gray-500 text-xs transition-transform ${
+            !expanded ? 'rotate-[-90deg]' : ''
+          }`}></i>
+          <i className="fa-solid fa-terminal mr-2 text-gray-400"></i>Live Output
+        </h2>
+        <span className={`px-2 py-0.5 rounded text-xs font-semibold ${status.className}`}>
+          {status.text}
+        </span>
+      </div>
+      {expanded && (
+        <div className="mt-3">
+          <div className={`font-mono text-sm leading-relaxed whitespace-pre-wrap break-all bg-gray-950 rounded p-4 h-64 overflow-y-auto ${outputClass}`}>
+            {output}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/BenchmarkParamReference.jsx
+++ b/dashboard/frontend/src/components/BenchmarkParamReference.jsx
@@ -1,0 +1,189 @@
+import { useState, useMemo, useRef, useCallback } from 'react'
+import { BENCHMARK_ONLY_FLAGS, AUTO_ADDED_FLAGS } from '../hooks/useBenchmark'
+
+function ParamTooltip({ html, tipRef, tipPos }) {
+  return (
+    <div
+      ref={tipRef}
+      style={tipPos ? { top: tipPos.top, left: tipPos.left } : undefined}
+      className="fixed w-[280px] bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-xs text-slate-300 leading-relaxed shadow-[0_4px_20px_rgba(0,0,0,0.4)] z-[9999] opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none [&_b]:text-white [&_b]:font-semibold [&_code]:text-blue-300 [&_code]:bg-slate-700 [&_code]:px-1 [&_code]:rounded"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
+function RefRow({ p, alreadyAdded, onAdd }) {
+  const rowRef = useRef(null)
+  const tipRef = useRef(null)
+  const [tipPos, setTipPos] = useState(null)
+
+  const handleMouseEnter = useCallback(() => {
+    const row = rowRef.current
+    if (!row) return
+    const rect = row.getBoundingClientRect()
+    const tipHeight = tipRef.current?.offsetHeight || 120
+    const top = rect.top - tipHeight - 8 < 0
+      ? rect.bottom + 8
+      : rect.top - tipHeight - 8
+    setTipPos({ top, left: rect.left })
+  }, [])
+
+  const flagText = p.flag || p.long
+  const isBenchOnly = BENCHMARK_ONLY_FLAGS.has(p.flag) || BENCHMARK_ONLY_FLAGS.has(p.long)
+  const isAutoAdded = AUTO_ADDED_FLAGS.has(p.flag) || AUTO_ADDED_FLAGS.has(p.long)
+  const flagColor = isBenchOnly ? 'text-orange-400' : 'text-yellow-400'
+  const rowBorder = isBenchOnly ? 'border-l-2 border-orange-500/40' : 'border-l-2 border-transparent'
+  const clickable = !isAutoAdded && !alreadyAdded
+
+  const primaryFlag = p.flag || p.long
+  const secondaryFlag = p.flag && p.long ? p.long : null
+
+  return (
+    <div
+      ref={rowRef}
+      onMouseEnter={p.tip ? handleMouseEnter : undefined}
+      onClick={() => clickable && onAdd(flagText, p.def)}
+      className={`group rounded-r mx-1 px-2 py-1.5 relative transition-colors ${rowBorder} ${
+        isAutoAdded ? 'opacity-60'
+        : clickable ? 'hover:bg-gray-700/50 cursor-pointer'
+        : ''
+      }`}
+      title={!p.tip ? (
+        isAutoAdded ? 'Auto-added, cannot be modified'
+        : alreadyAdded ? 'Already in parameters'
+        : (isBenchOnly ? 'Benchmark-only \u2014 not applied to service config. ' : '') + `Click to add ${flagText} to parameters`
+      ) : undefined}
+    >
+      <div className="flex items-center gap-1 text-xs">
+        <span className={`${flagColor} font-mono font-semibold`}>{primaryFlag}</span>
+        {secondaryFlag && <span className="text-gray-600">{secondaryFlag}</span>}
+        {isBenchOnly && (
+          <span className="text-[9px] uppercase tracking-wide font-semibold bg-orange-500/15 text-orange-400 px-1 py-0.5 rounded">
+            {isAutoAdded ? 'auto' : 'bench'}
+          </span>
+        )}
+        {p.def && <span className="text-gray-600 ml-auto pl-2 whitespace-nowrap">{p.def}</span>}
+      </div>
+      <div className="text-gray-400 text-xs leading-snug mt-0.5">{p.desc}</div>
+      {p.tip && <ParamTooltip tipRef={tipRef} html={p.tip} tipPos={tipPos} />}
+    </div>
+  )
+}
+
+export default function BenchmarkParamReference({ paramReference, params, onAddParam }) {
+  const [search, setSearch] = useState('')
+
+  const query = search.toLowerCase()
+
+  const existingFlags = useMemo(
+    () => new Set(params.filter(p => !p.isEmpty && p.flag).map(p => p.flag)),
+    [params]
+  )
+
+  const { groups, hasResults } = useMemo(() => {
+    let currentCat = ''
+    const groups = []
+    let hasResults = false
+
+    paramReference.forEach(p => {
+      const searchable = `${p.flag} ${p.long} ${p.desc} ${p.cat}`.toLowerCase()
+      if (query && !searchable.includes(query)) return
+
+      hasResults = true
+
+      if (p.cat !== currentCat) {
+        currentCat = p.cat
+        groups.push({ type: 'category', name: currentCat })
+      }
+      groups.push({ type: 'param', param: p })
+    })
+
+    return { groups, hasResults }
+  }, [paramReference, query])
+
+  if (!paramReference || paramReference.length === 0) return null
+
+  return (
+    <div className="bg-gray-800 rounded-lg border border-gray-700 h-full flex flex-col">
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-gray-700 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <i className="fa-solid fa-book text-gray-500 text-xs"></i>
+          <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Parameter Reference</span>
+        </div>
+        <a
+          href="https://github.com/ggml-org/llama.cpp/blob/master/tools/llama-bench/README.md"
+          target="_blank"
+          rel="noreferrer"
+          className="text-gray-500 hover:text-gray-300 text-xs"
+          title="llama-bench docs"
+        >
+          <i className="fa-solid fa-arrow-up-right-from-square"></i>
+        </a>
+      </div>
+
+      {/* Search */}
+      <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
+        <div className="relative">
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search flags..."
+            className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 pr-7 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 cursor-pointer"
+              aria-label="Clear search"
+            >
+              <i className="fa-solid fa-xmark text-xs"></i>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
+        <div className="flex gap-3 text-[10px] text-gray-500">
+          <span>
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-orange-400 mr-1"></span>
+            Benchmark-only (not applied to service)
+          </span>
+          <span>
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-yellow-400 mr-1"></span>
+            Runtime param
+          </span>
+        </div>
+      </div>
+
+      {/* Flag list */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {!hasResults ? (
+          <p className="text-gray-500 text-xs italic px-3 py-3">No matching parameters.</p>
+        ) : (
+          groups.map((item, i) => {
+            if (item.type === 'category') {
+              return (
+                <div key={`cat-${item.name}`} className="text-gray-500 uppercase tracking-wider text-[10px] font-semibold mt-2 mb-1 px-3">
+                  {item.name}
+                </div>
+              )
+            }
+            const p = item.param
+            const flagKey = p.flag || p.long
+            return (
+              <RefRow
+                key={flagKey}
+                p={p}
+                alreadyAdded={existingFlags.has(flagKey)}
+                onAdd={onAddParam}
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/BenchmarkParamsPanel.jsx
+++ b/dashboard/frontend/src/components/BenchmarkParamsPanel.jsx
@@ -1,0 +1,110 @@
+import { BENCHMARK_ONLY_FLAGS } from '../hooks/useBenchmark'
+
+export default function BenchmarkParamsPanel({
+  params,
+  isRunning,
+  commandPreview,
+  onFlagChange,
+  onValueChange,
+  onRemove,
+  onReset,
+  onRun,
+}) {
+  return (
+    <div>
+      {/* Parameters */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 mb-4">
+        <div className="px-5 py-4 border-b border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-200">
+            <i className="fa-solid fa-sliders mr-2 text-gray-400"></i>Parameters
+          </h2>
+        </div>
+        <div className="p-5">
+        <div className="flex flex-col gap-2 mb-3">
+          {params.map(p => {
+            const isBench = BENCHMARK_ONLY_FLAGS.has(p.flag)
+            return (
+              <div
+                key={p.id}
+                className={`flex gap-2 items-center border-l-2 rounded-r pl-1 ${
+                  isBench ? 'border-orange-500/50' : 'border-transparent'
+                }`}
+              >
+                <input
+                  type="text"
+                  value={p.flag}
+                  placeholder="-flag"
+                  onChange={e => onFlagChange(p.id, e.target.value)}
+                  className={`bg-gray-700 border border-gray-600 rounded px-2 py-1 text-sm w-40 font-mono focus:outline-none focus:border-blue-500 ${
+                    isBench ? 'text-orange-400' : ''
+                  }`}
+                />
+                <input
+                  type="text"
+                  value={p.value}
+                  placeholder="value (empty = boolean flag)"
+                  onChange={e => onValueChange(p.id, e.target.value)}
+                  className="bg-gray-700 border border-gray-600 rounded px-2 py-1 text-sm flex-1 font-mono focus:outline-none focus:border-blue-500"
+                />
+                {isBench && (
+                  <span className="text-[9px] uppercase tracking-wide font-semibold bg-orange-500/15 text-orange-400 px-1.5 py-0.5 rounded whitespace-nowrap">
+                    bench
+                  </span>
+                )}
+                <button
+                  onClick={() => onRemove(p.id)}
+                  className={`text-red-400 hover:text-red-300 px-2 py-1 cursor-pointer ${
+                    p.isEmpty ? 'invisible' : ''
+                  }`}
+                  title="Remove"
+                >
+                  <i className="fa-solid fa-xmark"></i>
+                </button>
+              </div>
+            )
+          })}
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={onReset}
+            className="text-sm bg-gray-700 hover:bg-gray-600 px-3 py-1.5 rounded cursor-pointer"
+          >
+            <i className="fa-solid fa-rotate-left mr-1"></i> Reset
+          </button>
+        </div>
+        </div>
+      </div>
+
+      {/* Command Preview */}
+      <div className="bg-gray-800 rounded-lg p-5 mb-4">
+        <h2 className="text-sm font-semibold text-gray-400 mb-2">Command Preview</h2>
+        <div className="font-mono text-sm text-green-400 bg-gray-950 rounded p-3 break-all">
+          {commandPreview}
+        </div>
+      </div>
+
+      {/* Run Button */}
+      <div className="flex gap-3">
+        <button
+          onClick={onRun}
+          disabled={isRunning}
+          className={`px-5 py-2.5 rounded font-semibold text-sm cursor-pointer ${
+            isRunning
+              ? 'bg-gray-600 !cursor-not-allowed'
+              : 'bg-green-600 hover:bg-green-700'
+          }`}
+        >
+          {isRunning ? (
+            <>
+              <i className="fa-solid fa-spinner fa-spin mr-1"></i> Running...
+            </>
+          ) : (
+            <>
+              <i className="fa-solid fa-play mr-1"></i> Run Benchmark
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/BenchmarkTab.jsx
+++ b/dashboard/frontend/src/components/BenchmarkTab.jsx
@@ -1,0 +1,128 @@
+import useBenchmark from '../hooks/useBenchmark'
+import BenchmarkParamsPanel from './BenchmarkParamsPanel'
+import BenchmarkParamReference from './BenchmarkParamReference'
+import BenchmarkLiveOutput from './BenchmarkLiveOutput'
+import BenchmarkHistory from './BenchmarkHistory'
+
+export default function BenchmarkTab({ serviceName, config, onSuccess, onError }) {
+  const {
+    params,
+    isRunning,
+    runStatus,
+    liveOutput,
+    liveOutputClass,
+    history,
+    paramReference,
+    commandPreview,
+    setParamFlag,
+    setParamValue,
+    removeParam,
+    addParam,
+    resetToDefaults,
+    runBenchmark,
+    rerunFromHistory,
+    getApplyPreview,
+    applyToService,
+    deleteRun,
+  } = useBenchmark(serviceName, config?.model_path)
+
+  const handleRun = async () => {
+    const result = await runBenchmark()
+    if (result.success) {
+      onSuccess('Benchmark started')
+    } else {
+      onError(result.error || 'Failed to start benchmark')
+    }
+  }
+
+  const handleReset = () => {
+    resetToDefaults()
+    onSuccess('Parameters reset to defaults')
+  }
+
+  const handleRerun = (runId) => {
+    rerunFromHistory(runId)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+    onSuccess('Parameters loaded from history run')
+  }
+
+  const handleApply = async (runId) => {
+    const preview = getApplyPreview(runId)
+    if (!preview) return
+
+    if (Object.keys(preview.applicable).length === 0) {
+      onError('No applicable parameters to apply (all are benchmark-only flags)')
+      return
+    }
+
+    const msg = `Apply to ${serviceName}?\n\nParams: ${preview.appliedStr}\nSkipped: ${preview.skipped.join(', ')}\n\nService must be restarted for changes to take effect.`
+    if (!window.confirm(msg)) return
+
+    const result = await applyToService(runId)
+    if (result.success) {
+      onSuccess(result.message)
+    } else {
+      onError(result.error || 'Failed to apply')
+    }
+  }
+
+  const handleDelete = async (runId) => {
+    const result = await deleteRun(runId)
+    if (result.success) {
+      onSuccess('Benchmark run deleted')
+    } else {
+      onError(result.error || 'Failed to delete')
+    }
+  }
+
+  const handleAddParam = (flag, defaultValue) => {
+    const added = addParam(flag, defaultValue)
+    if (added) {
+      onSuccess(`Added ${flag}`)
+    } else {
+      onError(`${flag} is already in your parameters`)
+    }
+  }
+
+  return (
+    <div>
+      {/* Two-column: Parameters (left) + Reference (right) */}
+      <div className="grid grid-cols-1 xl:grid-cols-[60%_1fr] gap-6 mb-4">
+        <div>
+          <BenchmarkParamsPanel
+            params={params}
+            isRunning={isRunning}
+            commandPreview={commandPreview}
+            onFlagChange={setParamFlag}
+            onValueChange={setParamValue}
+            onRemove={removeParam}
+            onReset={handleReset}
+            onRun={handleRun}
+          />
+        </div>
+        <div className="relative min-h-0 overflow-hidden">
+          <div className="absolute inset-0 overflow-hidden">
+            <BenchmarkParamReference
+              paramReference={paramReference}
+              params={params}
+              onAddParam={handleAddParam}
+            />
+          </div>
+        </div>
+      </div>
+
+      <BenchmarkLiveOutput
+        output={liveOutput}
+        outputClass={liveOutputClass}
+        runStatus={runStatus}
+      />
+
+      <BenchmarkHistory
+        history={history}
+        onRerun={handleRerun}
+        onApply={handleApply}
+        onDelete={handleDelete}
+      />
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/ParameterReference.jsx
+++ b/dashboard/frontend/src/components/ParameterReference.jsx
@@ -98,9 +98,20 @@ export default function ParameterReference({ flagMetadata, existingFlags, onAddF
 
   return (
     <div className="bg-gray-800 rounded-lg border border-gray-700 h-full flex flex-col">
-      <div className="px-3 py-2 border-b border-gray-700 flex items-center gap-2 flex-shrink-0">
-        <i className="fa-solid fa-book text-gray-500 text-xs"></i>
-        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Parameter Reference</span>
+      <div className="px-3 py-2 border-b border-gray-700 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <i className="fa-solid fa-book text-gray-500 text-xs"></i>
+          <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Parameter Reference</span>
+        </div>
+        <a
+          href="https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md"
+          target="_blank"
+          rel="noreferrer"
+          className="text-gray-500 hover:text-gray-300 text-xs"
+          title="llama-server docs"
+        >
+          <i className="fa-solid fa-arrow-up-right-from-square"></i>
+        </a>
       </div>
       <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
         <div className="relative">

--- a/dashboard/frontend/src/components/ServiceConfigPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceConfigPanel.jsx
@@ -177,7 +177,9 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
     <div className="bg-gray-800 rounded-lg border border-gray-700">
       {/* Header */}
       <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
-        <h2 className="text-lg font-semibold text-gray-200">Configuration</h2>
+        <h2 className="text-lg font-semibold text-gray-200">
+          <i className="fa-solid fa-gear mr-2 text-gray-400"></i>Configuration
+        </h2>
         {isDirty && (
           <span className="text-yellow-400 text-sm flex items-center gap-1" role="status" aria-live="polite">
             <i className="fa-solid fa-circle-exclamation"></i>
@@ -241,13 +243,13 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
               <i className="fa-solid fa-plus mr-1"></i>Add parameter
             </button>
           </div>
-          <div className="space-y-0.5">
+          <div className="flex flex-col gap-2">
             {params.map(({ id, flag, value }, idx) => {
               const tooltip = getTooltip(flag)
               const isDuplicate = flag && duplicateFlags.has(flag)
               const isTrailingEmpty = idx === params.length - 1 && !flag && !value
               return (
-                <div key={id} className="flex items-center gap-2 rounded px-3 py-1">
+                <div key={id} className={`flex gap-2 items-center border-l-2 rounded-r pl-1 ${isDuplicate ? 'border-red-500' : 'border-transparent'}`}>
                   <input
                     ref={el => { if (el && justAddedIdRef.current === id) { el.focus(); justAddedIdRef.current = null } }}
                     value={flag}
@@ -267,7 +269,7 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
                   <button
                     onClick={() => handleParamRemove(id)}
                     disabled={saving || isTrailingEmpty}
-                    className={`disabled:opacity-50 cursor-pointer ${isTrailingEmpty ? 'invisible' : 'text-gray-500 hover:text-red-400'}`}
+                    className={`disabled:opacity-50 cursor-pointer ${isTrailingEmpty ? 'invisible' : 'text-red-400 hover:text-red-300'}`}
                     aria-label={`Remove parameter ${flag || '(empty)'}`}
                   >
                     <i className="fa-solid fa-xmark"></i>

--- a/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
+++ b/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 
 function CopyButton({ text, label }) {
   const [copied, setCopied] = useState(false)
@@ -409,11 +409,15 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
 }
 
 export default function ServiceDetailsHeader({ serviceName, config, runtime, transitioning, actions, onRename, onSuccess, onError }) {
-  const navigate = useNavigate()
-  const status = runtime?.status || 'not-created'
-  const isRunning = status === 'running'
-  const templateType = config?.template_type
-  const [editing, setEditing] = useState(false)
+   const navigate = useNavigate()
+   const location = useLocation()
+   const status = runtime?.status || 'not-created'
+   const isRunning = status === 'running'
+   const templateType = config?.template_type
+   const [editing, setEditing] = useState(false)
+   
+   // Get the previous search query from state if available, or use browser history
+   const prevSearch = location.state?.search || ''
 
   const canRename = !isRunning && !transitioning
 
@@ -432,7 +436,7 @@ export default function ServiceDetailsHeader({ serviceName, config, runtime, tra
       {/* Row 1: Identity */}
       <div className="flex items-center gap-4 flex-wrap">
         <button
-          onClick={() => navigate('/')}
+          onClick={() => navigate(-1)}
           className="flex items-center gap-2 text-gray-400 hover:text-gray-200 cursor-pointer"
           aria-label="Back to services list"
         >

--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -85,18 +85,16 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
   return (
     <div className="h-full bg-gray-800 rounded-lg border border-gray-700 flex flex-col">
       {/* Header */}
-      <div className="px-5 py-3 border-b border-gray-700 flex justify-between items-center">
-        <div className="flex items-center gap-3">
-          <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
-            Container Logs
-          </h2>
+      <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-gray-200">
+          <i className="fa-solid fa-terminal mr-2 text-gray-400"></i>Container Logs
           {hasContainer && !paused && (
             <span
-              className="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse"
+              className="inline-block w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse ml-3 align-middle"
               aria-label="Log updates active"
             />
           )}
-        </div>
+        </h2>
         <div className="flex items-center gap-2">
           <button
             onClick={handleRefresh}

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -173,11 +173,12 @@ function Toast({ message, onDone }) {
 }
 
 export default function ServicesTable() {
-  const navigate = useNavigate()
-  const [services, setServices] = useState(null)
-  const [error, setError] = useState(null)
-  const [transitioning, setTransitioning] = useState({})
-  const [toast, setToast] = useState(null)
+   const navigate = useNavigate()
+   const [services, setServices] = useState(null)
+   const [error, setError] = useState(null)
+   const [transitioning, setTransitioning] = useState({})
+   const [toast, setToast] = useState(null)
+   const [searchQuery, setSearchQuery] = useState('')
 
   const fetchServices = useCallback(async () => {
     try {
@@ -262,54 +263,58 @@ export default function ServicesTable() {
     return <p className="text-gray-500 mt-6">Loading services...</p>
   }
 
-  if (!services.length) {
-    return <p className="text-gray-400 mt-6">No services configured</p>
-  }
+if (!services.length) {
+     return <p className="text-gray-400 mt-6">No services configured</p>
+   }
 
-  return (
-    <div className="mt-6">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-lg font-semibold text-gray-200">Services</h2>
-        <button
-          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition-colors"
-        >
-          + New Service
-        </button>
-      </div>
-      <div className="overflow-x-auto rounded-lg border border-gray-700">
-        <table className="w-full text-sm text-left">
-          <thead className="bg-gray-800 text-gray-400 uppercase text-xs">
-            <tr>
-              <th className="px-6 py-3">Service</th>
-              <th className="px-6 py-3">Status</th>
-              <th className="px-6 py-3">Port</th>
-              <th className="px-6 py-3">Engine</th>
-              <th className="px-6 py-3">Size</th>
-              <th className="px-6 py-3">Open WebUI</th>
-              <th className="px-6 py-3">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {services.map(svc => (
-              <ServiceRow
-                key={svc.name}
-                service={svc}
-                transitioning={transitioning}
-                onStart={handleStart}
-                onStop={handleStop}
-                onRestart={handleRestart}
-                onSetPublicPort={handleSetPublicPort}
-                onEdit={handleEdit}
-                onViewLogs={handleViewLogs}
-                onDelete={handleDelete}
-              />
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {toast && <Toast message={toast} onDone={() => setToast(null)} />}
-    </div>
-  )
+   const hasMatch = searchQuery.length >= 3
+
+   return (
+     <div className="mt-6">
+<div className="flex flex-col items-center mb-3">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search services (min 3 chars)"
+            className="px-4 py-2 bg-gray-700 border border-gray-600 rounded text-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full max-w-md"
+          />
+        </div>
+<div className="overflow-x-auto rounded-lg border border-gray-700">
+          <table className="w-full text-sm text-left">
+           <thead className="bg-gray-800 text-gray-400 uppercase text-xs">
+             <tr>
+               <th className="px-6 py-3">Service</th>
+               <th className="px-6 py-3">Status</th>
+               <th className="px-6 py-3">Port</th>
+               <th className="px-6 py-3">Engine</th>
+               <th className="px-6 py-3">Size</th>
+               <th className="px-6 py-3">Open WebUI</th>
+               <th className="px-6 py-3">Actions</th>
+             </tr>
+           </thead>
+           <tbody>
+             {services.map(svc => (
+               <ServiceRow
+                 key={svc.name}
+                 service={svc}
+                 transitioning={transitioning}
+                 onStart={handleStart}
+                 onStop={handleStop}
+                 onRestart={handleRestart}
+                 onSetPublicPort={handleSetPublicPort}
+                 onEdit={handleEdit}
+                 onViewLogs={handleViewLogs}
+                 onDelete={handleDelete}
+                 searchQuery={searchQuery}
+               />
+             ))}
+</tbody>
+         </table>
+       </div>
+       {toast && <Toast message={toast} onDone={() => setToast(null)} />}
+     </div>
+   )
 }
 
 function PortCell({ service, onSetPublicPort }) {
@@ -356,12 +361,20 @@ function PortCell({ service, onSetPublicPort }) {
   )
 }
 
-function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onEdit, onViewLogs, onDelete }) {
-  const engine = getEngine(service.name)
-  const infra = isInfra(service.name)
+function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onEdit, onViewLogs, onDelete, searchQuery }) {
+   const engine = getEngine(service.name)
+   const infra = isInfra(service.name)
+   const hasMatch = searchQuery.length >= 3
+   const isMatch = hasMatch && service.name.toLowerCase().includes(searchQuery.toLowerCase())
 
-  return (
-    <tr className="border-b border-gray-700 bg-gray-800/50 hover:bg-gray-700/50 transition-colors">
+const rowClasses = hasMatch
+      ? isMatch
+        ? 'border-b border-gray-700 bg-gray-800/50 hover:bg-gray-700/50 transition-all'
+        : 'border-b border-gray-700 bg-gray-800/50 opacity-40 blur-subtle transition-all'
+      : 'border-b border-gray-700 bg-gray-800/50 hover:bg-gray-700/50 transition-colors'
+
+   return (
+     <tr className={rowClasses}>
       <td className="px-6 py-3">
         <div className="flex flex-col">
           <div className="flex items-center font-medium text-gray-200">

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { fetchAPI } from '../api'
 import { startService, stopService, restartService } from '../services/lifecycle'
 
@@ -178,7 +178,8 @@ export default function ServicesTable() {
    const [error, setError] = useState(null)
    const [transitioning, setTransitioning] = useState({})
    const [toast, setToast] = useState(null)
-   const [searchQuery, setSearchQuery] = useState('')
+   const [searchParams, setSearchParams] = useSearchParams()
+   const searchQuery = searchParams.get('search') || ''
 
   const fetchServices = useCallback(async () => {
     try {
@@ -238,11 +239,11 @@ export default function ServicesTable() {
   }
 
   const handleEdit = (name) => {
-    navigate(`/services/${name}`)
+    navigate(`/services/${name}`, { state: { search: searchQuery } })
   }
 
   const handleViewLogs = (name) => {
-    navigate(`/services/${name}/logs`)
+    navigate(`/services/${name}/logs`, { state: { search: searchQuery } })
   }
 
   const handleDelete = async (name) => {
@@ -275,7 +276,15 @@ if (!services.length) {
           <input
             type="text"
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value
+              if (value) {
+                searchParams.set('search', value)
+              } else {
+                searchParams.delete('search')
+              }
+              setSearchParams(searchParams)
+            }}
             placeholder="Search services (min 3 chars)"
             className="px-4 py-2 bg-gray-700 border border-gray-600 rounded text-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full max-w-md"
           />

--- a/dashboard/frontend/src/hooks/useBenchmark.js
+++ b/dashboard/frontend/src/hooks/useBenchmark.js
@@ -1,0 +1,323 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { fetchAPI } from '../api'
+
+export const BENCHMARK_ONLY_FLAGS = new Set(['-m', '-p', '-n', '-r', '-o', '-pg', '-d', '-oe', '-v', '--delay', '--list-devices'])
+export const AUTO_ADDED_FLAGS = new Set(['-m', '-o'])
+export const SAFE_DEFAULTS = { '-p': '512', '-n': '128', '-r': '3' }
+export const APPLY_DENYLIST = ['-p', '-n', '-r', '-o', '-m']
+const POLL_INTERVAL = 2000
+
+let nextId = 1
+
+function makeParamRows(paramsObj) {
+  const entries = Object.entries(paramsObj)
+  const bench = entries.filter(([flag]) => BENCHMARK_ONLY_FLAGS.has(flag))
+  const rest = entries.filter(([flag]) => !BENCHMARK_ONLY_FLAGS.has(flag))
+  const rows = bench.concat(rest).map(([flag, value]) => ({
+    id: nextId++,
+    flag,
+    value,
+    isEmpty: false,
+  }))
+  rows.push({ id: nextId++, flag: '', value: '', isEmpty: true })
+  return rows
+}
+
+export default function useBenchmark(serviceName, modelPath) {
+  const [params, setParams] = useState(() => makeParamRows(SAFE_DEFAULTS))
+  const [isRunning, setIsRunning] = useState(false)
+  const [currentRunId, setCurrentRunId] = useState(null)
+  const [runStatus, setRunStatus] = useState('idle')
+  const [liveOutput, setLiveOutput] = useState('Waiting for benchmark run...')
+  const [liveOutputClass, setLiveOutputClass] = useState('text-gray-400')
+  const [history, setHistory] = useState([])
+  const [paramReference, setParamReference] = useState([])
+  const pollRef = useRef(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [])
+
+  const refreshHistory = useCallback(async () => {
+    try {
+      const data = await fetchAPI(`/benchmarks?service_name=${encodeURIComponent(serviceName)}&limit=50`)
+      if (mountedRef.current) {
+        setHistory((data.runs || []).map(r => ({
+          id: r.id,
+          date: r.created_at ? r.created_at.replace('T', ' ').substring(0, 19) : '',
+          pp_ts: r.pp_avg_ts,
+          tg_ts: r.tg_avg_ts,
+          params: r.params || {},
+          status: r.status,
+        })))
+      }
+    } catch (e) {
+      console.error('Failed to refresh history:', e)
+    }
+  }, [serviceName])
+
+  // Init: load recent params, history, and param reference
+  useEffect(() => {
+    if (!serviceName) return
+
+    async function init() {
+      try {
+        const histData = await fetchAPI(`/benchmarks?service_name=${encodeURIComponent(serviceName)}&limit=1`)
+        if (histData.runs && histData.runs.length > 0) {
+          if (mountedRef.current) setParams(makeParamRows(histData.runs[0].params || {}))
+        }
+      } catch {
+        // fall back to SAFE_DEFAULTS (already set)
+      }
+
+      await refreshHistory()
+
+      try {
+        const data = await fetchAPI('/flag-metadata/llamacpp_bench')
+        const flags = data.optional_flags || {}
+        const ref = Object.values(flags).map(f => {
+          const isLong = f.cli.startsWith('--')
+          return {
+            cat: f.category || 'Other',
+            flag: isLong ? '' : f.cli,
+            long: isLong ? f.cli : '',
+            desc: f.description || '',
+            def: f.default || '',
+            tip: f.tip || '',
+          }
+        })
+        if (mountedRef.current) setParamReference(ref)
+      } catch {
+        if (mountedRef.current) setParamReference([])
+      }
+    }
+
+    init()
+  }, [serviceName, refreshHistory])
+
+  // Command preview
+  const commandPreview = useMemo(() => {
+    const nonEmpty = params.filter(p => !p.isEmpty && p.flag)
+    let cmd = `llama-bench -m ${modelPath || '<model>'} -o json`
+    nonEmpty.forEach(p => {
+      cmd += ` ${p.flag}`
+      if (p.value) cmd += ` ${p.value}`
+    })
+    return cmd
+  }, [params, modelPath])
+
+  // Param management helpers
+  const ensureEmptyRow = useCallback((rows) => {
+    if (rows.some(r => r.isEmpty)) return rows
+    return [...rows, { id: nextId++, flag: '', value: '', isEmpty: true }]
+  }, [])
+
+  const setParamFlag = useCallback((id, flag) => {
+    setParams(prev => {
+      const updated = prev.map(p => {
+        if (p.id !== id) return p
+        if (p.isEmpty) return { ...p, flag, isEmpty: false }
+        return { ...p, flag }
+      })
+      return ensureEmptyRow(updated)
+    })
+  }, [ensureEmptyRow])
+
+  const setParamValue = useCallback((id, value) => {
+    setParams(prev => {
+      const updated = prev.map(p => {
+        if (p.id !== id) return p
+        if (p.isEmpty) return { ...p, value, isEmpty: false }
+        return { ...p, value }
+      })
+      return ensureEmptyRow(updated)
+    })
+  }, [ensureEmptyRow])
+
+  const removeParam = useCallback((id) => {
+    setParams(prev => {
+      const row = prev.find(p => p.id === id)
+      if (!row || row.isEmpty) return prev
+      return ensureEmptyRow(prev.filter(p => p.id !== id))
+    })
+  }, [ensureEmptyRow])
+
+  const addParam = useCallback((flag, value) => {
+    let added = false
+    setParams(prev => {
+      if (prev.some(p => !p.isEmpty && p.flag === flag)) return prev
+      added = true
+      const newRow = { id: nextId++, flag, value, isEmpty: false }
+      const emptyIdx = prev.findIndex(p => p.isEmpty)
+      if (emptyIdx >= 0) {
+        const updated = [...prev]
+        updated.splice(emptyIdx, 0, newRow)
+        return updated
+      }
+      return ensureEmptyRow([...prev, newRow])
+    })
+    return added
+  }, [ensureEmptyRow])
+
+  const resetToDefaults = useCallback(() => {
+    setParams(makeParamRows(SAFE_DEFAULTS))
+  }, [])
+
+  const loadParams = useCallback((paramsObj) => {
+    setParams(makeParamRows(paramsObj))
+  }, [])
+
+  // Polling
+  useEffect(() => {
+    if (!currentRunId) return
+
+    const poll = async () => {
+      try {
+        const run = await fetchAPI(`/benchmarks/${currentRunId}`)
+
+        if (run.status === 'running') {
+          setRunStatus('running')
+        } else if (run.status === 'completed') {
+          if (pollRef.current) clearInterval(pollRef.current)
+          pollRef.current = null
+          setIsRunning(false)
+          setCurrentRunId(null)
+          setRunStatus('completed')
+
+          let resultText = 'Benchmark completed.\n'
+          if (run.pp_avg_ts != null) resultText += `\nPrompt Processing: ${run.pp_avg_ts.toFixed(2)} t/s`
+          if (run.pp_stddev_ts != null) resultText += ` (stddev: ${run.pp_stddev_ts.toFixed(2)})`
+          if (run.tg_avg_ts != null) resultText += `\nText Generation:   ${run.tg_avg_ts.toFixed(2)} t/s`
+          if (run.tg_stddev_ts != null) resultText += ` (stddev: ${run.tg_stddev_ts.toFixed(2)})`
+          if (run.build_commit) resultText += `\n\nbuild: ${run.build_commit}`
+          if (run.gpu_info) resultText += `\ngpu:   ${run.gpu_info}`
+          if (run.raw_output) resultText += `\n\n--- Raw Output ---\n${run.raw_output}`
+
+          setLiveOutput(resultText)
+          setLiveOutputClass('text-green-400')
+          await refreshHistory()
+        } else if (run.status === 'failed' || run.status === 'cancelled') {
+          if (pollRef.current) clearInterval(pollRef.current)
+          pollRef.current = null
+          setIsRunning(false)
+          setCurrentRunId(null)
+          setRunStatus(run.status)
+
+          setLiveOutput(`Benchmark ${run.status}.\n\n${run.error_message || ''}`)
+          setLiveOutputClass('text-red-400')
+          await refreshHistory()
+        }
+      } catch (e) {
+        console.error('Poll error:', e)
+      }
+    }
+
+    pollRef.current = setInterval(poll, POLL_INTERVAL)
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+    }
+  }, [currentRunId, refreshHistory])
+
+  // Run benchmark
+  const runBenchmark = useCallback(async () => {
+    if (isRunning) return { success: false, error: 'Already running' }
+
+    const paramsObj = {}
+    params.forEach(p => {
+      if (!p.isEmpty && p.flag) paramsObj[p.flag] = p.value
+    })
+
+    setIsRunning(true)
+    setRunStatus('running')
+    setLiveOutputClass('text-green-400')
+
+    try {
+      const data = await fetchAPI('/benchmarks', {
+        method: 'POST',
+        body: JSON.stringify({ service_name: serviceName, params: paramsObj }),
+      })
+
+      setCurrentRunId(data.id)
+      setLiveOutput(`Benchmark started (${data.id}).\nWaiting for results...\n`)
+      return { success: true }
+    } catch (e) {
+      setIsRunning(false)
+      setRunStatus('idle')
+      return { success: false, error: e.message }
+    }
+  }, [isRunning, params, serviceName])
+
+  // History actions
+  const rerunFromHistory = useCallback((runId) => {
+    const row = history.find(r => r.id === runId)
+    if (!row) return
+    loadParams(row.params)
+  }, [history, loadParams])
+
+  const getApplyPreview = useCallback((runId) => {
+    const row = history.find(r => r.id === runId)
+    if (!row) return null
+
+    const applicable = {}
+    const skipped = []
+    Object.entries(row.params).forEach(([flag, value]) => {
+      if (APPLY_DENYLIST.includes(flag)) skipped.push(flag)
+      else applicable[flag] = value
+    })
+
+    const appliedStr = Object.entries(applicable)
+      .map(([k, v]) => v ? `${k} ${v}` : k)
+      .join(', ')
+
+    return { applicable, skipped, appliedStr }
+  }, [history])
+
+  const applyToService = useCallback(async (runId) => {
+    try {
+      const data = await fetchAPI(`/benchmarks/${runId}/apply`, { method: 'PUT' })
+      return { success: true, message: data.message || 'Configuration applied' }
+    } catch (e) {
+      return { success: false, error: e.message }
+    }
+  }, [])
+
+  const deleteRun = useCallback(async (runId) => {
+    try {
+      await fetchAPI(`/benchmarks/${runId}`, { method: 'DELETE' })
+      await refreshHistory()
+      return { success: true }
+    } catch (e) {
+      return { success: false, error: e.message }
+    }
+  }, [refreshHistory])
+
+  return {
+    params,
+    isRunning,
+    runStatus,
+    liveOutput,
+    liveOutputClass,
+    history,
+    paramReference,
+    commandPreview,
+    setParamFlag,
+    setParamValue,
+    removeParam,
+    addParam,
+    resetToDefaults,
+    loadParams,
+    runBenchmark,
+    rerunFromHistory,
+    getApplyPreview,
+    applyToService,
+    deleteRun,
+  }
+}

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -1,1 +1,7 @@
 @import "tailwindcss";
+
+@layer components {
+  .blur-subtle {
+    filter: blur(1px);
+  }
+}


### PR DESCRIPTION
## Summary
- Overhauled `flag_metadata.py` with updated llama-bench parameters and documentation links
- Added full benchmark UI: tab, params panel, param reference, history, and live output components with `useBenchmark` hook
- Polished service config/logs panels and parameter reference component
- Implemented search (phase 1): filtering in services table with URL-persisted query and back-navigation preservation

## Test plan
- [ ] Verify benchmark tab renders and parameters load correctly on service details page
- [ ] Test search filtering on services table (min 3 chars)
- [ ] Confirm search query persists in URL and survives back navigation
- [ ] Check parameter reference docs links work