### PR TITLE
Replace log polling with SSE streaming

### DIFF
--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -15,9 +15,9 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
   )
 
   // Track last activity time for footer display
-  const lastUpdatedRef = useRef(null)
+  const [lastUpdated, setLastUpdated] = useState(null)
   useEffect(() => {
-    if (lines.length > 0) lastUpdatedRef.current = new Date()
+    if (lines.length > 0) setLastUpdated(new Date())
   }, [lines.length])
 
   // Auto-scroll unless the user scrolled up
@@ -70,9 +70,9 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
         <div className="flex items-center gap-2">
           <button
             onClick={handleRefresh}
-            disabled={!hasContainer}
-            className="p-1.5 text-gray-400 hover:text-gray-200 disabled:opacity-50 cursor-pointer"
-            title="Refresh logs"
+            disabled={!hasContainer || paused}
+            className="p-1.5 text-gray-400 hover:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            title={paused ? 'Resume to refresh' : 'Refresh logs'}
           >
             <i className="fa-solid fa-rotate-right text-sm"></i>
           </button>
@@ -118,7 +118,7 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
 
       {/* Footer */}
       <div className="px-5 py-2 border-t border-gray-700 text-xs text-gray-500 flex justify-between">
-        <span>Last updated: {formatTime(lastUpdatedRef.current)} | {lines.length} lines</span>
+        <span>Last updated: {formatTime(lastUpdated)} | {lines.length} lines</span>
         <span>{footerStatus()}</span>
       </div>
     </div>

--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -1,85 +1,52 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { fetchAPI } from '../api'
-
-const LOG_POLL_INTERVAL = 3000
-const DEFAULT_TAIL = 200
+import useServiceLogsSSE from '../hooks/useServiceLogsSSE'
 
 export default function ServiceLogsPanel({ serviceName, runtime }) {
-  const [logs, setLogs] = useState('')
-  const [lineCount, setLineCount] = useState(0)
-  const [lastUpdated, setLastUpdated] = useState(null)
   const [paused, setPaused] = useState(false)
-  const [logError, setLogError] = useState(null)
   const logRef = useRef(null)
   const userScrolledRef = useRef(false)
-  const mountedRef = useRef(true)
 
   const status = runtime?.status || 'not-created'
   const hasContainer = status !== 'not-created'
 
-  const fetchLogs = useCallback(async () => {
-    try {
-      const data = await fetchAPI(`/services/${serviceName}/logs?tail=${DEFAULT_TAIL}`)
-      if (mountedRef.current) {
-        setLogs(data.logs || '')
-        setLineCount(data.lines || 0)
-        setLastUpdated(new Date())
-        setLogError(null)
-      }
-    } catch (err) {
-      if (mountedRef.current) {
-        if (err.message.includes('not been created')) {
-          setLogError(null)
-          setLogs('')
-        } else {
-          setLogError(err.message)
-        }
-      }
-    }
-  }, [serviceName])
+  const { lines, connected, loading, error, streamEnded, refresh } = useServiceLogsSSE(
+    serviceName,
+    { enabled: hasContainer && !paused, tail: 200 },
+  )
 
-  // Unmount guard (independent of polling state)
+  // Track last activity time for footer display
+  const lastUpdatedRef = useRef(null)
   useEffect(() => {
-    mountedRef.current = true
-    return () => { mountedRef.current = false }
-  }, [])
+    if (lines.length > 0) lastUpdatedRef.current = new Date()
+  }, [lines.length])
 
-  // Fetch immediately then poll
-  useEffect(() => {
-    if (!hasContainer || paused) return
-    const initialId = setTimeout(() => {
-      setLogs('')
-      setLineCount(0)
-      setLogError(null)
-      fetchLogs()
-    }, 0)
-    const intervalId = setInterval(fetchLogs, LOG_POLL_INTERVAL)
-    return () => { clearTimeout(initialId); clearInterval(intervalId) }
-  }, [hasContainer, paused, fetchLogs])
-
-  // Auto-scroll to bottom unless user scrolled up
+  // Auto-scroll unless the user scrolled up
   useEffect(() => {
     const el = logRef.current
     if (!el || userScrolledRef.current) return
     el.scrollTop = el.scrollHeight
-  }, [logs])
+  }, [lines])
 
   const handleScroll = useCallback(() => {
     const el = logRef.current
     if (!el) return
-    // If user is within 50px of the bottom, consider it "at bottom"
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50
-    userScrolledRef.current = !atBottom
+    userScrolledRef.current = el.scrollHeight - el.scrollTop - el.clientHeight > 50
   }, [])
 
   const handleRefresh = useCallback(() => {
-    fetchLogs()
     userScrolledRef.current = false
-  }, [fetchLogs])
+    refresh()
+  }, [refresh])
 
-  const formatTime = (date) => {
-    if (!date) return '--:--:--'
-    return date.toLocaleTimeString()
+  const formatTime = (date) => date ? date.toLocaleTimeString() : '--:--:--'
+
+  const footerStatus = () => {
+    if (!hasContainer) return 'No container'
+    if (paused) return 'Paused'
+    if (streamEnded) return 'Container stopped'
+    if (connected) return 'Live'
+    if (loading) return 'Connecting…'
+    return 'Reconnecting…'
   }
 
   return (
@@ -90,11 +57,14 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
             Container Logs
           </h2>
-          {hasContainer && !paused && (
-            <span
-              className="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse"
-              aria-label="Log updates active"
-            />
+          {hasContainer && !paused && connected && (
+            <span className="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse" />
+          )}
+          {hasContainer && !paused && !connected && !streamEnded && (
+            <span className="w-2.5 h-2.5 rounded-full bg-yellow-500 animate-pulse" />
+          )}
+          {streamEnded && (
+            <span className="text-xs text-gray-500 italic">stopped</span>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -110,8 +80,7 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
             onClick={() => setPaused(prev => !prev)}
             disabled={!hasContainer}
             className="p-1.5 text-gray-400 hover:text-gray-200 disabled:opacity-50 cursor-pointer"
-            title={paused ? 'Resume auto-refresh' : 'Pause auto-refresh'}
-            aria-label={paused ? 'Log updates paused' : 'Log updates active'}
+            title={paused ? 'Resume' : 'Pause'}
           >
             <i className={`fa-solid ${paused ? 'fa-play' : 'fa-pause'} text-sm`}></i>
           </button>
@@ -125,11 +94,9 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
             Service has not been started. Start the service to see logs.
           </p>
         </div>
-      ) : logError ? (
+      ) : error ? (
         <div className="flex-1 flex items-center justify-center">
-          <p className="text-red-400 text-sm">
-            Failed to load logs: {logError}
-          </p>
+          <p className="text-red-400 text-sm">Failed to load logs: {error}</p>
         </div>
       ) : (
         <div
@@ -137,10 +104,12 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           onScroll={handleScroll}
           className="flex-1 min-h-0 overflow-auto p-4"
         >
-          {logs ? (
+          {lines.length > 0 ? (
             <pre className="font-mono text-sm text-gray-300 whitespace-pre-wrap leading-relaxed select-text">
-              {logs}
+              {lines.join('\n')}
             </pre>
+          ) : loading ? (
+            <p className="text-gray-500 italic text-sm">Loading logs…</p>
           ) : (
             <p className="text-gray-500 italic text-sm">No log output yet.</p>
           )}
@@ -148,9 +117,9 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
       )}
 
       {/* Footer */}
-      <div className="px-5 py-2 border-t border-gray-700 text-xs text-gray-500 flex justify-between" aria-live="polite">
-        <span>Last updated: {formatTime(lastUpdated)} | {lineCount} lines</span>
-        <span>{paused ? 'Paused' : 'Polling every 3s'}</span>
+      <div className="px-5 py-2 border-t border-gray-700 text-xs text-gray-500 flex justify-between">
+        <span>Last updated: {formatTime(lastUpdatedRef.current)} | {lines.length} lines</span>
+        <span>{footerStatus()}</span>
       </div>
     </div>
   )

--- a/dashboard/frontend/src/hooks/useServiceLogsSSE.js
+++ b/dashboard/frontend/src/hooks/useServiceLogsSSE.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { getToken, API_BASE } from '../api'
 
 const RECONNECT_DELAY = 3000
+const MAX_LINES = 2000
 
 export default function useServiceLogsSSE(serviceName, { enabled = true, tail = 200 } = {}) {
   const [lines, setLines] = useState([])
@@ -84,7 +85,12 @@ export default function useServiceLogsSSE(serviceName, { enabled = true, tail = 
                 const data = JSON.parse(line.slice(6))
                 if (!mountedRef.current) break
                 if (data.type === 'snapshot_start') { setLines([]); setLoading(true) }
-                else if (data.type === 'log') setLines(prev => [...prev, data.line])
+                else if (data.type === 'log') setLines(prev => {
+                  const next = prev.length >= MAX_LINES
+                    ? [...prev.slice(prev.length - MAX_LINES + 1), data.line]
+                    : [...prev, data.line]
+                  return next
+                })
                 else if (data.type === 'snapshot_end') setLoading(false)
                 else if (data.type === 'stream_end') { cleanEnd = true; setStreamEnded(true); setConnected(false) }
                 else if (data.type === 'error') { setError(data.message); setConnected(false) }

--- a/dashboard/frontend/src/hooks/useServiceLogsSSE.js
+++ b/dashboard/frontend/src/hooks/useServiceLogsSSE.js
@@ -1,0 +1,142 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getToken, API_BASE } from '../api'
+
+const RECONNECT_DELAY = 3000
+
+export default function useServiceLogsSSE(serviceName, { enabled = true, tail = 200 } = {}) {
+  const [lines, setLines] = useState([])
+  const [connected, setConnected] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [streamEnded, setStreamEnded] = useState(false)
+
+  const mountedRef = useRef(true)
+  const abortControllerRef = useRef(null)
+  const reconnectTimerRef = useRef(null)
+  const startStreamRef = useRef(null)
+
+  const stopStream = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+    if (mountedRef.current) setConnected(false)
+  }, [])
+
+  const startStream = useCallback(() => {
+    const token = getToken()
+    if (!token) {
+      if (mountedRef.current) { setError('Not authenticated'); setLoading(false) }
+      return
+    }
+
+    if (abortControllerRef.current) abortControllerRef.current.abort()
+    if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null }
+
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    if (mountedRef.current) {
+      setLines([])
+      setError(null)
+      setStreamEnded(false)
+      setLoading(true)
+      setConnected(false)
+    }
+
+    fetch(`${API_BASE}/services/${encodeURIComponent(serviceName)}/logs/stream?tail=${tail}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+      signal: controller.signal,
+    })
+      .then(async response => {
+        if (!response.ok) {
+          const text = await response.text()
+          let msg = `HTTP ${response.status}`
+          try { msg = JSON.parse(text).error || msg } catch { /* not JSON */ }
+          if (mountedRef.current) { setError(msg); setLoading(false); setConnected(false) }
+          return
+        }
+
+        if (mountedRef.current) { setConnected(true); setError(null) }
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let cleanEnd = false
+
+        try {
+          while (true) {
+            if (controller.signal.aborted) break
+            const { done, value } = await reader.read()
+            if (done) break
+
+            buffer += decoder.decode(value, { stream: true })
+            const parts = buffer.split('\n')
+            buffer = parts.pop()
+
+            for (const line of parts) {
+              if (!line.startsWith('data: ')) continue
+              try {
+                const data = JSON.parse(line.slice(6))
+                if (!mountedRef.current) break
+                if (data.type === 'snapshot_start') { setLines([]); setLoading(true) }
+                else if (data.type === 'log') setLines(prev => [...prev, data.line])
+                else if (data.type === 'snapshot_end') setLoading(false)
+                else if (data.type === 'stream_end') { cleanEnd = true; setStreamEnded(true); setConnected(false) }
+                else if (data.type === 'error') { setError(data.message); setConnected(false) }
+              } catch { /* malformed line */ }
+            }
+          }
+        } catch (err) {
+          if (err.name !== 'AbortError' && mountedRef.current) {
+            setError(`Stream error: ${err.message}`)
+            setConnected(false)
+          }
+        } finally {
+          if (mountedRef.current) {
+            setConnected(false)
+            setLoading(false)
+            // Reconnect only on unexpected drops — not clean stream_end, not user abort
+            if (!controller.signal.aborted && !cleanEnd) {
+              reconnectTimerRef.current = setTimeout(
+                () => { if (mountedRef.current) startStreamRef.current() },
+                RECONNECT_DELAY,
+              )
+            }
+          }
+        }
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError' && mountedRef.current) {
+          setError(`Connection failed: ${err.message}`)
+          setConnected(false)
+          setLoading(false)
+          reconnectTimerRef.current = setTimeout(
+            () => { if (mountedRef.current) startStreamRef.current() },
+            RECONNECT_DELAY,
+          )
+        }
+      })
+  }, [serviceName, tail])
+
+  startStreamRef.current = startStream
+
+  useEffect(() => {
+    mountedRef.current = true
+    if (enabled) {
+      startStreamRef.current()
+    } else {
+      stopStream()
+    }
+    return () => {
+      mountedRef.current = false
+      stopStream()
+    }
+  }, [enabled, serviceName, stopStream])
+
+  return { lines, connected, loading, error, streamEnded, refresh: startStream }
+}

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 import subprocess
 from datetime import datetime
@@ -618,6 +619,18 @@ def set_public_port(service_name):
 
 
 # ============================================
+# SSE helpers
+# ============================================
+
+def _sse_data(payload: dict) -> str:
+    return "data: " + json.dumps(payload) + "\n\n"
+
+
+def _now() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+# ============================================
 # SSE Stream Endpoint
 # ============================================
 
@@ -695,6 +708,56 @@ def services_stream():
         stream_with_context(generate()),
         mimetype="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ============================================
+# Service Logs SSE Endpoint
+# ============================================
+
+
+@services_bp.route("/api/services/<service_name>/logs/stream", methods=["GET"])
+@require_auth
+def stream_service_logs(service_name):
+    """Stream container logs over SSE.
+
+    Sends an initial tail snapshot followed by live appended lines.
+    Keepalives are sent every ~5 s when the container is quiet.
+    The existing JSON endpoint /api/services/<name>/logs is unchanged.
+    """
+    from services.log_stream import iter_log_events
+
+    container = get_service_container(service_name)
+    if not container:
+        return jsonify({"error": "Service has not been created yet"}), 404
+
+    tail = request.args.get("tail", default=200, type=int)
+    tail = min(max(tail, 1), 1000)
+
+    def generate():
+        stop = threading.Event()
+        try:
+            yield _sse_data({"type": "snapshot_start", "service": service_name, "timestamp": _now()})
+            for event_type, data in iter_log_events(container, tail, stop):
+                if event_type == "log":
+                    yield _sse_data({"type": "log", "service": service_name, "line": data})
+                elif event_type == "snapshot_end":
+                    yield _sse_data({"type": "snapshot_end", "service": service_name, "timestamp": _now()})
+                elif event_type == "stream_end":
+                    yield _sse_data({"type": "stream_end", "service": service_name, "timestamp": _now()})
+                elif event_type == "error":
+                    yield _sse_data({"type": "error", "service": service_name, "message": data})
+                elif event_type == "keepalive":
+                    yield ": keepalive\n\n"
+        except GeneratorExit:
+            pass
+        finally:
+            stop.set()
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
     )
 
 

--- a/dashboard/services/log_stream.py
+++ b/dashboard/services/log_stream.py
@@ -1,0 +1,60 @@
+import queue
+import threading
+from datetime import datetime, timezone
+
+
+def iter_log_events(container, tail: int, stop_event: threading.Event):
+    """
+    Yield (event_type, data) tuples from a Docker container's log stream.
+
+    Yields:
+        ('log', line_str)       — one complete log line
+        ('snapshot_end', None)  — after the initial tail is drained
+        ('stream_end', None)    — Docker stream closed cleanly
+        ('error', message_str)  — unrecoverable exception in reader thread
+        ('keepalive', None)     — emitted when queue is idle for ~5 s
+
+    The caller is responsible for setting stop_event to terminate the reader
+    thread early (e.g. on client disconnect).
+    """
+    q = queue.Queue(maxsize=500)
+
+    def _reader():
+        try:
+            # Capture T₀ before the phase-1 fetch so the follow window
+            # overlaps slightly rather than leaving a gap.
+            since = datetime.now(timezone.utc)
+
+            raw = container.logs(tail=tail, timestamps=True, stream=False)
+            for line in raw.decode("utf-8", errors="replace").splitlines():
+                if stop_event.is_set():
+                    return
+                if line:
+                    q.put(("log", line))
+            q.put(("snapshot_end", None))
+
+            if stop_event.is_set():
+                return
+
+            for chunk in container.logs(since=since, stream=True, follow=True, timestamps=True):
+                if stop_event.is_set():
+                    break
+                for line in chunk.decode("utf-8", errors="replace").splitlines():
+                    if line:
+                        q.put(("log", line))
+
+            q.put(("stream_end", None))
+        except Exception as exc:
+            q.put(("error", str(exc)))
+
+    t = threading.Thread(target=_reader, daemon=True)
+    t.start()
+
+    while True:
+        try:
+            item = q.get(timeout=5.0)
+            yield item
+            if item[0] in ("stream_end", "error"):
+                break
+        except queue.Empty:
+            yield ("keepalive", None)

--- a/dashboard/services/log_stream.py
+++ b/dashboard/services/log_stream.py
@@ -18,6 +18,13 @@ def iter_log_events(container, tail: int, stop_event: threading.Event):
     thread early (e.g. on client disconnect).
     """
     q = queue.Queue(maxsize=500)
+    # Mutable holder so the consumer can close the follow stream from outside
+    # the reader thread. Docker's logs(follow=True) generator is a blocking
+    # iterator backed by an HTTP socket; setting stop_event alone only kicks
+    # in *between* chunks, so a quiet container would leak a thread+socket
+    # per abandoned connection. Closing the generator unblocks the socket
+    # read and the for-loop unwinds.
+    follow_holder = {"stream": None}
 
     def _reader():
         try:
@@ -36,12 +43,20 @@ def iter_log_events(container, tail: int, stop_event: threading.Event):
             if stop_event.is_set():
                 return
 
-            for chunk in container.logs(since=since, stream=True, follow=True, timestamps=True):
-                if stop_event.is_set():
-                    break
-                for line in chunk.decode("utf-8", errors="replace").splitlines():
-                    if line:
-                        q.put(("log", line))
+            follow = container.logs(since=since, stream=True, follow=True, timestamps=True)
+            follow_holder["stream"] = follow
+            try:
+                for chunk in follow:
+                    if stop_event.is_set():
+                        break
+                    for line in chunk.decode("utf-8", errors="replace").splitlines():
+                        if line:
+                            q.put(("log", line))
+            finally:
+                try:
+                    follow.close()
+                except Exception:
+                    pass
 
             q.put(("stream_end", None))
         except Exception as exc:
@@ -50,11 +65,23 @@ def iter_log_events(container, tail: int, stop_event: threading.Event):
     t = threading.Thread(target=_reader, daemon=True)
     t.start()
 
-    while True:
-        try:
-            item = q.get(timeout=5.0)
-            yield item
-            if item[0] in ("stream_end", "error"):
-                break
-        except queue.Empty:
-            yield ("keepalive", None)
+    try:
+        while True:
+            try:
+                item = q.get(timeout=5.0)
+                yield item
+                if item[0] in ("stream_end", "error"):
+                    break
+            except queue.Empty:
+                yield ("keepalive", None)
+    finally:
+        # Consumer aborted (GeneratorExit on disconnect) or normal exit.
+        # Set the flag and force-close the docker follow stream so the
+        # reader thread unblocks immediately.
+        stop_event.set()
+        follow = follow_holder["stream"]
+        if follow is not None:
+            try:
+                follow.close()
+            except Exception:
+                pass

--- a/dashboard/tests/test_service_logs_sse.py
+++ b/dashboard/tests/test_service_logs_sse.py
@@ -1,0 +1,338 @@
+import io
+import json
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+TEST_TOKEN = "test-token-logs-sse"
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TEST_TOKEN}"}
+
+
+def _parse_sse(raw: bytes) -> list[dict]:
+    """Parse SSE frames from raw bytes. Returns list of parsed JSON payloads.
+    Keepalive comments are returned as {'type': 'keepalive'}."""
+    events = []
+    for line in raw.decode("utf-8").splitlines():
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                pass
+        elif line.startswith(": keepalive"):
+            events.append({"type": "keepalive"})
+    return events
+
+
+def _make_container(log_lines: list[str], follow_chunks: list[bytes] | None = None):
+    """Build a mock Docker container whose .logs() behaves predictably."""
+    container = MagicMock()
+    initial_bytes = ("\n".join(log_lines) + ("\n" if log_lines else "")).encode()
+
+    def logs_side_effect(*args, **kwargs):
+        if kwargs.get("stream") or kwargs.get("follow"):
+            return iter(follow_chunks or [])
+        return initial_bytes
+
+    container.logs.side_effect = logs_side_effect
+    return container
+
+
+@pytest.fixture(autouse=True)
+def env(tmp_path):
+    os.environ["DASHBOARD_TOKEN"] = TEST_TOKEN
+    os.environ["COMPOSE_PROJECT_NAME"] = "llm-dock-test"
+
+    compose = tmp_path / "docker-compose.yml"
+    compose.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "networks:\n  llm-network:\n    driver: bridge\n"
+    )
+    (tmp_path / "services.json").write_text("{}")
+    os.environ["COMPOSE_FILE"] = str(compose)
+    yield
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    return create_app(config={
+        "TESTING": True,
+        "DASHBOARD_TOKEN": TEST_TOKEN,
+        "COMPOSE_FILE": os.environ["COMPOSE_FILE"],
+    })
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# T1 – auth
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def test_unauthenticated_returns_401(self, client):
+        r = client.get("/api/services/my-svc/logs/stream")
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# T2 – 404 when no container
+# ---------------------------------------------------------------------------
+
+class TestNotFound:
+    def test_service_not_found_returns_404(self, client):
+        with patch("routes.services.get_service_container", return_value=None):
+            r = client.get("/api/services/ghost-svc/logs/stream", headers=_auth())
+        assert r.status_code == 404
+        body = r.get_json()
+        assert "error" in body
+
+
+# ---------------------------------------------------------------------------
+# T3 / T4 – content-type and headers
+# ---------------------------------------------------------------------------
+
+class TestHeaders:
+    def _get(self, client):
+        container = _make_container([])
+        with patch("routes.services.get_service_container", return_value=container):
+            return client.get("/api/services/my-svc/logs/stream", headers=_auth())
+
+    def test_content_type_is_event_stream(self, client):
+        r = self._get(client)
+        assert r.status_code == 200
+        assert r.mimetype == "text/event-stream"
+
+    def test_cache_control_no_cache(self, client):
+        r = self._get(client)
+        assert "no-cache" in r.headers.get("Cache-Control", "")
+
+    def test_x_accel_buffering_no(self, client):
+        r = self._get(client)
+        assert r.headers.get("X-Accel-Buffering") == "no"
+
+
+# ---------------------------------------------------------------------------
+# T5 – event sequence
+# ---------------------------------------------------------------------------
+
+class TestEventSequence:
+    def test_snapshot_event_sequence(self, client):
+        lines = ["2026-05-03T00:00:01Z line one", "2026-05-03T00:00:02Z line two"]
+        container = _make_container(lines)
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        raw = b"".join(r.response)
+        events = _parse_sse(raw)
+
+        types = [e["type"] for e in events]
+        assert types[0] == "snapshot_start"
+
+        log_events = [e for e in events if e["type"] == "log"]
+        assert len(log_events) == 2
+        assert log_events[0]["line"] == lines[0]
+        assert log_events[1]["line"] == lines[1]
+
+        assert "snapshot_end" in types
+        assert "stream_end" in types
+
+        # order: snapshot_start < all logs < snapshot_end < stream_end
+        idx = {t: types.index(t) for t in ("snapshot_start", "snapshot_end", "stream_end")}
+        first_log_idx = next(i for i, e in enumerate(events) if e["type"] == "log")
+        assert idx["snapshot_start"] < first_log_idx
+        assert first_log_idx < idx["snapshot_end"]
+        assert idx["snapshot_end"] < idx["stream_end"]
+
+    def test_service_name_in_every_event(self, client):
+        container = _make_container(["line"])
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        events = _parse_sse(b"".join(r.response))
+        for e in events:
+            if e.get("type") != "keepalive":
+                assert e.get("service") == "my-svc"
+
+    def test_empty_log_still_has_lifecycle_events(self, client):
+        container = _make_container([])
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        types = [e["type"] for e in _parse_sse(b"".join(r.response))]
+        assert "snapshot_start" in types
+        assert "snapshot_end" in types
+        assert "stream_end" in types
+
+
+# ---------------------------------------------------------------------------
+# T6 / T7 / T8 – tail clamping
+# ---------------------------------------------------------------------------
+
+class TestTailClamping:
+    def _tail_used(self, client, query=""):
+        container = _make_container([])
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get(f"/api/services/my-svc/logs/stream{query}", headers=_auth())
+            b"".join(r.response)  # drain so stream_with_context executes
+        # first call is non-streaming (phase 1)
+        call_kwargs = container.logs.call_args_list[0][1]
+        return call_kwargs["tail"]
+
+    def test_tail_defaults_to_200(self, client):
+        assert self._tail_used(client) == 200
+
+    def test_tail_clamped_to_1000(self, client):
+        assert self._tail_used(client, "?tail=9999") == 1000
+
+    def test_tail_minimum_clamped_to_1(self, client):
+        assert self._tail_used(client, "?tail=0") == 1
+
+    def test_tail_valid_value_passed_through(self, client):
+        assert self._tail_used(client, "?tail=50") == 50
+
+
+# ---------------------------------------------------------------------------
+# T9 – Docker error produces error event
+# ---------------------------------------------------------------------------
+
+class TestDockerError:
+    def test_docker_error_emits_error_event(self, client):
+        container = MagicMock()
+        container.logs.side_effect = RuntimeError("docker daemon gone")
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        events = _parse_sse(b"".join(r.response))
+        error_events = [e for e in events if e["type"] == "error"]
+        assert len(error_events) >= 1
+        assert "docker daemon gone" in error_events[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# T10 – multi-line chunks split correctly
+# ---------------------------------------------------------------------------
+
+class TestLineSplitting:
+    def test_log_lines_split_correctly(self, client):
+        # Docker may return multiple lines in one .logs() call (no streaming)
+        multi = "line A\nline B\nline C"
+        container = _make_container([])
+        container.logs.side_effect = None
+        container.logs.return_value = multi.encode()
+
+        # Make follow iteration empty
+        def logs_se(*a, **kw):
+            if kw.get("stream") or kw.get("follow"):
+                return iter([])
+            return multi.encode()
+        container.logs.side_effect = logs_se
+
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        events = _parse_sse(b"".join(r.response))
+        log_events = [e for e in events if e["type"] == "log"]
+        assert len(log_events) == 3
+        assert [e["line"] for e in log_events] == ["line A", "line B", "line C"]
+
+    def test_empty_lines_not_emitted(self, client):
+        container = _make_container([])
+        container.logs.side_effect = None
+
+        def logs_se(*a, **kw):
+            if kw.get("stream") or kw.get("follow"):
+                return iter([])
+            return b"line A\n\nline B\n\n"
+        container.logs.side_effect = logs_se
+
+        with patch("routes.services.get_service_container", return_value=container):
+            r = client.get("/api/services/my-svc/logs/stream", headers=_auth())
+        log_events = [e for e in _parse_sse(b"".join(r.response)) if e["type"] == "log"]
+        assert len(log_events) == 2
+
+
+# ---------------------------------------------------------------------------
+# T11–T13 – iter_log_events unit tests (helper in isolation)
+# ---------------------------------------------------------------------------
+
+class TestIterLogEvents:
+    def _drain(self, container, tail=10, timeout=3.0):
+        """Collect all events from iter_log_events with a wall-clock timeout."""
+        from services.log_stream import iter_log_events
+        stop = threading.Event()
+        events = []
+        deadline = time.monotonic() + timeout
+        for item in iter_log_events(container, tail, stop):
+            events.append(item)
+            if item[0] in ("stream_end", "error"):
+                break
+            if time.monotonic() > deadline:
+                stop.set()
+                break
+        return events
+
+    def test_iter_log_events_sequence(self):
+        container = _make_container(["alpha", "beta"])
+        events = self._drain(container)
+        types = [e[0] for e in events]
+        assert "log" in types
+        assert "snapshot_end" in types
+        assert "stream_end" in types
+        log_lines = [e[1] for e in events if e[0] == "log"]
+        assert log_lines == ["alpha", "beta"]
+
+    def test_stop_event_terminates_reader(self):
+        """Reader thread should respect stop_event during phase 2."""
+        from services.log_stream import iter_log_events
+
+        stop = threading.Event()
+
+        container = MagicMock()
+        container.logs.side_effect = None
+
+        def logs_se(*a, **kw):
+            if kw.get("stream") or kw.get("follow"):
+                def _slow():
+                    for _ in range(100):
+                        if stop.is_set():
+                            return
+                        time.sleep(0.05)
+                        yield b"tick\n"
+                return _slow()
+            return b""
+        container.logs.side_effect = logs_se
+
+        events = []
+        deadline = time.monotonic() + 1.0
+        for item in iter_log_events(container, 10, stop):
+            events.append(item)
+            if item[0] == "snapshot_end":
+                stop.set()
+                break
+            if time.monotonic() > deadline:
+                break
+
+        # After stop, reader must finish quickly
+        time.sleep(0.3)
+        assert stop.is_set()
+
+    def test_invalid_utf8_replaced_not_crashed(self):
+        container = MagicMock()
+
+        def logs_se(*a, **kw):
+            if kw.get("stream") or kw.get("follow"):
+                return iter([])
+            return b"valid line\nbroken \xff\xfe line\n"
+        container.logs.side_effect = logs_se
+
+        events = self._drain(container)
+        log_lines = [e[1] for e in events if e[0] == "log"]
+        assert len(log_lines) == 2
+        assert "broken" in log_lines[1]


### PR DESCRIPTION
## Summary

- Replaces the 3-second polling loop in `ServiceLogsPanel` with a real Server-Sent Events stream, so log lines arrive as Docker emits them instead of being re-fetched in 200-line chunks every tick.
- New backend endpoint `GET /api/services/<name>/logs/stream` uses a queue + daemon reader thread (two-phase: snapshot tail then follow), keepalives every 5s, clean `stream_end` on container exit, and a `stop_event` for safe cleanup on client disconnect.
- New `useServiceLogsSSE` hook on the frontend mirrors the existing services SSE fetch + ReadableStream pattern; pausing aborts the stream, refresh reconnects, footer shows Live / Paused / Container stopped.
- Log-streaming logic extracted into `dashboard/services/log_stream.py` for testability.

## Test plan

- [ ] `cd dashboard && venv/bin/pytest tests/test_service_logs_sse.py` — 18 included unit tests cover auth, 404, headers, event ordering, tail clamping, error propagation, UTF-8 safety
- [ ] `cd dashboard/frontend && npm run build` succeeds
- [ ] Manual: open a running service's log panel in /v2 — confirm lines arrive in real time (no 3s lag); pause stops updates; refresh reconnects; stop the container and confirm footer flips to "Container stopped"
- [ ] Manual: kill the dashboard backend mid-stream — confirm the stream closes cleanly on the client without spinning

## Notes

This is one of four parallel implementations of the same feature (`feature/sse-logs-{claude,deepseek-v4flash,mistral-api,qwen27b-bf16}`). This is the Claude one. The qwen branch is a week newer and already rebased on top of the recent SSE-snapshot fallback fix on main; the others (including this one) were authored on 2026-05-03.

Will conflict with the uncommitted font-size +/- additions to `ServiceLogsPanel.jsx` currently in the working tree on main — handle when committing those.