### PR TITLE
Chat UX bundle + vLLM thinking traces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ test:
 
 ```
 curl -s -X POST http://localhost:3320/v1/embeddings \
-  -H "Authorization: Bearer llmd-3379c4e668fe175d2a279d64e3f664112833" \
+  -H "Authorization: Bearer <API_KEY>" \
   -H "Content-Type: application/json" \
   -d '{"model":"vllm-nomic-embed-text-v1.5","input":"search_document: hello"}'
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# LLM-Dock — Claude operational notes
+
+Tactical playbook for adding / running models in this llm-dock instance.
+The general developer guide is in `AGENTS.md`; this file holds gotchas
+that don't fit there.
+
+## Adding a new vLLM service from the CLI
+
+Workflow when the dashboard isn't open or you want a scripted change:
+
+1. **Download the model into the HF cache.** Containers run with
+   `HF_HUB_OFFLINE=1` (set in `dashboard/templates/vllm.j2`), so anything
+   the model needs must already be on disk before the container starts.
+   ```
+   /home/teodor/.local/bin/hf download <org>/<model>
+   ```
+2. **Append a service entry to `services.json`.** Keys: `alias`, `port`,
+   `api_key`, `model_name`, `params` (dict of CLI flags), `template_type:
+   "vllm"`. Pick a free port in 3300–3399 (used ports are visible in
+   `services.json` itself).
+3. **Rebuild `docker-compose.yml` from `services.json`.** Don't edit the
+   generated section directly — it's between `BEGIN DYNAMIC` /
+   `END DYNAMIC` markers and gets clobbered. Instead:
+   ```
+   cd /github/teo-mateo/llm-dock/dashboard && venv/bin/python -c "
+   from compose_manager import ComposeManager
+   mgr = ComposeManager('/github/teo-mateo/llm-dock/docker-compose.yml',
+                        '/github/teo-mateo/llm-dock/services.json')
+   mgr.rebuild_compose_file()"
+   ```
+4. **Bring the container up.** `cd /github/teo-mateo/llm-dock && docker
+   compose up -d <service-name>`. Use `--force-recreate` after editing
+   params on an existing service.
+5. **Tail logs to verify.** `docker logs -f <service-name>` — wait for
+   `Application startup complete` or `Uvicorn running on http://0.0.0.0:8000`.
+
+## Gotchas
+
+### vLLM ≥0.20 removed `--task`
+
+In vLLM 0.20.x (the version in `llm-dock-vllm`), the old `--task embed`
+flag is gone. Use:
+
+- `--runner pooling` — instead of `--task embed` (also `auto`, `draft`,
+  `generate`)
+- `--convert embed` — picks the embed pooler when the model could be used
+  for multiple pooling tasks (also `auto`, `classify`, `none`)
+
+To explore the current arg surface inside the image:
+
+```
+docker run --rm --gpus all --entrypoint vllm llm-dock-vllm serve --help=all 2>&1 | grep -- '--<flag>'
+```
+
+(Without `--gpus all`, `vllm serve --help` aborts in pydantic device
+validation before printing the parser.)
+
+### Custom-arch models need both their repos cached
+
+Models with `trust_remote_code` often reference Python modules in a
+*different* HF repo via `auto_map`. Example: `nomic-ai/nomic-embed-text-v1.5`'s
+config.json points to `nomic-ai/nomic-bert-2048--modeling_hf_nomic_bert`,
+so you must download **both**:
+
+```
+hf download nomic-ai/nomic-embed-text-v1.5
+hf download nomic-ai/nomic-bert-2048
+```
+
+Symptom if you forget: container exits with
+`OSError: We couldn't connect to 'https://huggingface.co' to load the
+files, and couldn't find them in the cached files.`
+
+### Embedding services should keep `--gpu-memory-utilization` low
+
+The big chat models commonly take 0.55–0.94. An embedding service running
+alongside them only needs a sliver — set it to ~0.10 or less so it
+doesn't try to grab KV cache that's already reserved.
+
+### Unknown flag names are silently dropped
+
+`render_cli_flag()` in `flag_metadata.py` is permissive: any string
+starting with `-` passes through to the rendered command unchanged.
+That's why arbitrary vLLM flags work in `params` without metadata
+entries — but it also means a **typo** in the flag name (e.g. `--gpu-mem`)
+ships to the container as-is and fails at startup, not at config time.
+Verify with `mgr.preview_service(name)` before bringing the container up.
+
+## Reference: working embedding service
+
+`vllm-nomic-embed-text-v1.5` (port 3320) — see `services.json`. Smoke
+test:
+
+```
+curl -s -X POST http://localhost:3320/v1/embeddings \
+  -H "Authorization: Bearer llmd-3379c4e668fe175d2a279d64e3f664112833" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"vllm-nomic-embed-text-v1.5","input":"search_document: hello"}'
+```
+
+Returns 768-dim float vectors. Use `search_document:` prefix on stored
+text and `search_query:` prefix on queries (Nomic's matryoshka task
+prefixes).

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -211,7 +211,11 @@ class ChatDB:
             )
         """
         params = list(conv_ids)
-        count = conn.execute(cte + "SELECT COUNT(*) FROM d", params).fetchone()[0]
+        # COUNT(DISTINCT id) — UNION ALL in the recursive arm means the CTE
+        # may yield duplicates when the input list already includes both a
+        # parent and one of its descendants. The subsequent DELETE dedupes
+        # naturally, but the raw COUNT(*) would over-report.
+        count = conn.execute(cte + "SELECT COUNT(DISTINCT id) FROM d", params).fetchone()[0]
         if count == 0:
             return 0
         conn.execute(cte + "DELETE FROM conversations WHERE id IN (SELECT id FROM d)", params)

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -194,12 +194,48 @@ class ChatDB:
         finally:
             self._close_conn(conn)
 
+    def _delete_conversations_recursive(self, conn: sqlite3.Connection, conv_ids: List[str]) -> int:
+        """Delete the named conversations and every descendant spinoff in one
+        recursive CTE. Messages cascade via FK. Returns the number of
+        conversation rows deleted (sqlite3 reports -1 for DELETE-with-subquery,
+        so we count via the same CTE first).
+        """
+        if not conv_ids:
+            return 0
+        placeholders = ",".join("?" for _ in conv_ids)
+        cte = f"""
+            WITH RECURSIVE d(id) AS (
+                SELECT id FROM conversations WHERE id IN ({placeholders})
+                UNION ALL
+                SELECT c.id FROM conversations c JOIN d ON c.parent_conversation_id = d.id
+            )
+        """
+        params = list(conv_ids)
+        count = conn.execute(cte + "SELECT COUNT(*) FROM d", params).fetchone()[0]
+        if count == 0:
+            return 0
+        conn.execute(cte + "DELETE FROM conversations WHERE id IN (SELECT id FROM d)", params)
+        return count
+
     def delete_conversation(self, conv_id: str) -> bool:
         conn = self._get_conn()
         try:
-            cursor = conn.execute("DELETE FROM conversations WHERE id = ?", (conv_id,))
+            rowcount = self._delete_conversations_recursive(conn, [conv_id])
             conn.commit()
-            return cursor.rowcount > 0
+            return rowcount > 0
+        finally:
+            self._close_conn(conn)
+
+    def delete_conversations(self, conv_ids: List[str]) -> int:
+        """Delete multiple conversations (plus their descendant spinoffs) in
+        one statement. Returns rowcount."""
+        if not conv_ids:
+            return 0
+        conn = self._get_conn()
+        try:
+            rowcount = self._delete_conversations_recursive(conn, list(conv_ids))
+            conn.commit()
+            return rowcount
         finally:
             self._close_conn(conn)
 

--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -105,7 +105,7 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
 
             # Accumulate content
             content_piece = delta.get("content", "")
-            reasoning_piece = delta.get("reasoning_content", "")
+            reasoning_piece = delta.get("reasoning_content") or delta.get("reasoning") or ""
             if content_piece:
                 collected_content += content_piece
             if reasoning_piece:

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -117,6 +117,17 @@ def delete_conversation(conv_id):
     return jsonify({"error": "Conversation not found"}), 404
 
 
+@chat_bp.route("/api/chat/conversations/delete", methods=["POST"])
+@require_auth
+def delete_conversations_batch():
+    data = request.get_json() or {}
+    ids = data.get("ids")
+    if not isinstance(ids, list) or not all(isinstance(x, str) for x in ids):
+        return jsonify({"error": "ids must be a list of strings"}), 400
+    deleted = _get_db().delete_conversations(ids)
+    return jsonify({"ok": True, "deleted": deleted})
+
+
 # -- Messages --
 
 def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_manager=None):

--- a/dashboard/frontend/src/components/Header.jsx
+++ b/dashboard/frontend/src/components/Header.jsx
@@ -1,6 +1,14 @@
 function Header() {
   return (
-    <header className="h-16 bg-gray-900/80 border-b border-gray-800 px-4 flex items-center">
+    <header className="h-16 bg-gray-900/80 border-b border-gray-800 px-4 flex items-center justify-end">
+      <a
+        href="/"
+        className="text-xs text-gray-500 hover:text-gray-300 flex items-center gap-1.5"
+        title="Switch to the legacy dashboard"
+      >
+        <i className="fa-solid fa-arrow-left text-[10px]"></i>
+        Back to v1
+      </a>
     </header>
   )
 }

--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -3,6 +3,19 @@ import { fetchAPI } from '../api'
 
 const LOG_POLL_INTERVAL = 3000
 const DEFAULT_TAIL = 200
+const FONT_SIZE_KEY = 'dashboard_logs_font_size'
+const FONT_SIZE_MIN = 10
+const FONT_SIZE_MAX = 22
+const FONT_SIZE_DEFAULT = 14
+const FONT_SIZE_STEP = 1
+
+function readFontSize() {
+  try {
+    const v = parseInt(localStorage.getItem(FONT_SIZE_KEY), 10)
+    if (Number.isFinite(v) && v >= FONT_SIZE_MIN && v <= FONT_SIZE_MAX) return v
+  } catch { /* ignore */ }
+  return FONT_SIZE_DEFAULT
+}
 
 export default function ServiceLogsPanel({ serviceName, runtime }) {
   const [logs, setLogs] = useState('')
@@ -10,9 +23,18 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
   const [lastUpdated, setLastUpdated] = useState(null)
   const [paused, setPaused] = useState(false)
   const [logError, setLogError] = useState(null)
+  const [fontSize, setFontSize] = useState(readFontSize)
   const logRef = useRef(null)
   const userScrolledRef = useRef(false)
   const mountedRef = useRef(true)
+
+  const bumpFontSize = useCallback((delta) => {
+    setFontSize(prev => {
+      const next = Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, prev + delta))
+      try { localStorage.setItem(FONT_SIZE_KEY, String(next)) } catch { /* ignore */ }
+      return next
+    })
+  }, [])
 
   const status = runtime?.status || 'not-created'
   const hasContainer = status !== 'not-created'
@@ -98,6 +120,27 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <div className="flex items-center text-gray-400" title="Log font size">
+            <button
+              onClick={() => bumpFontSize(-FONT_SIZE_STEP)}
+              disabled={fontSize <= FONT_SIZE_MIN}
+              className="p-1.5 hover:text-gray-200 disabled:opacity-40 cursor-pointer"
+              title="Smaller text"
+              aria-label="Decrease log font size"
+            >
+              <i className="fa-solid fa-minus text-xs"></i>
+            </button>
+            <span className="text-[10px] tabular-nums w-5 text-center select-none">{fontSize}</span>
+            <button
+              onClick={() => bumpFontSize(FONT_SIZE_STEP)}
+              disabled={fontSize >= FONT_SIZE_MAX}
+              className="p-1.5 hover:text-gray-200 disabled:opacity-40 cursor-pointer"
+              title="Larger text"
+              aria-label="Increase log font size"
+            >
+              <i className="fa-solid fa-plus text-xs"></i>
+            </button>
+          </div>
           <button
             onClick={handleRefresh}
             disabled={!hasContainer}
@@ -138,7 +181,10 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           className="flex-1 min-h-0 overflow-auto p-4"
         >
           {logs ? (
-            <pre className="font-mono text-sm text-gray-300 whitespace-pre-wrap leading-relaxed select-text">
+            <pre
+              className="font-mono text-gray-300 whitespace-pre-wrap leading-relaxed select-text"
+              style={{ fontSize: `${fontSize}px` }}
+            >
               {logs}
             </pre>
           ) : (

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -81,7 +81,7 @@ export default function ChatInput({ onSend, disabled, pendingInserts = [], onCle
     <div className="border-t border-gray-700">
       {/* Pending inserts */}
       {pendingInserts.length > 0 && (
-        <div className="px-4 pt-3 max-w-4xl mx-auto">
+        <div className="px-4 pt-3 max-w-6xl mx-auto">
           <div className="text-[10px] text-yellow-400 mb-1.5 uppercase tracking-wide">
             <i className="fa-solid fa-arrow-right-to-bracket mr-1"></i>
             Issues to include ({pendingInserts.length})
@@ -106,7 +106,7 @@ export default function ChatInput({ onSend, disabled, pendingInserts = [], onCle
 
       {/* Image previews */}
       {images.length > 0 && (
-        <div className="px-4 pt-3 max-w-4xl mx-auto">
+        <div className="px-4 pt-3 max-w-6xl mx-auto">
           <div className="flex gap-2 flex-wrap">
             {images.map((img, i) => (
               <div key={i} className="relative group">
@@ -129,7 +129,7 @@ export default function ChatInput({ onSend, disabled, pendingInserts = [], onCle
 
       {/* Input */}
       <form onSubmit={handleSubmit} className="p-4">
-        <div className="flex gap-3 items-end max-w-4xl mx-auto">
+        <div className="flex gap-3 items-end max-w-6xl mx-auto">
           <textarea
             ref={textareaRef}
             value={value}

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -56,20 +56,35 @@ export default function ChatPage() {
     navigate(`/chat/${id}`)
   }, [navigate])
 
-  const handleDelete = useCallback(async (id) => {
-    await remove(id)
-    if (convId === id) {
-      navigate('/chat')
+  // Deletes cascade to descendant spinoffs server-side. If the active
+  // conversation is one of the deleted rows OR a descendant of any of
+  // them, navigate away — otherwise the URL would point at a now-404
+  // conversation. Walk the parent chain client-side using the in-memory
+  // conversation list (captured before the delete fires).
+  const activeWillBeDeleted = useCallback((deletedIds) => {
+    if (!convId) return false
+    const deleted = new Set(deletedIds)
+    const byId = new Map(conversations.map(c => [c.id, c]))
+    let cursor = convId
+    while (cursor) {
+      if (deleted.has(cursor)) return true
+      cursor = byId.get(cursor)?.parent_conversation_id || null
     }
-  }, [remove, convId, navigate])
+    return false
+  }, [convId, conversations])
+
+  const handleDelete = useCallback(async (id) => {
+    const shouldNavigate = activeWillBeDeleted([id])
+    await remove(id)
+    if (shouldNavigate) navigate('/chat')
+  }, [remove, activeWillBeDeleted, navigate])
 
   const handleDeleteMany = useCallback(async (ids) => {
     if (!ids || ids.length === 0) return
+    const shouldNavigate = activeWillBeDeleted(ids)
     await removeMany(ids)
-    if (convId && ids.includes(convId)) {
-      navigate('/chat')
-    }
-  }, [removeMany, convId, navigate])
+    if (shouldNavigate) navigate('/chat')
+  }, [removeMany, activeWillBeDeleted, navigate])
 
   return (
     <div className="flex-1 flex overflow-hidden">

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -10,7 +10,7 @@ export default function ChatPage() {
   const convId = conversationId || null
   const navigate = useNavigate()
 
-  const { conversations, loading: convsLoading, refresh, create, remove } = useConversations()
+  const { conversations, loading: convsLoading, refresh, create, remove, removeMany } = useConversations()
   const {
     conversation,
     messages,
@@ -63,6 +63,14 @@ export default function ChatPage() {
     }
   }, [remove, convId, navigate])
 
+  const handleDeleteMany = useCallback(async (ids) => {
+    if (!ids || ids.length === 0) return
+    await removeMany(ids)
+    if (convId && ids.includes(convId)) {
+      navigate('/chat')
+    }
+  }, [removeMany, convId, navigate])
+
   return (
     <div className="flex-1 flex overflow-hidden">
       <ChatSidebar
@@ -71,6 +79,7 @@ export default function ChatPage() {
         onSelect={handleSelect}
         onCreate={handleCreate}
         onDelete={handleDelete}
+        onDeleteMany={handleDeleteMany}
       />
       <ChatArea
         conversation={conversation}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,21 +1,54 @@
 import { useState, useMemo } from 'react'
 
-function ConversationItem({ conv, activeId, depth, confirmDelete, setConfirmDelete, onSelect, onDelete }) {
+function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggleSelect, confirmDelete, setConfirmDelete, onSelect, onDelete }) {
   const isSpinoff = !!conv.parent_conversation_id
-  const icon = isSpinoff ? 'fa-code-branch' : 'fa-message'
-  const iconColor = isSpinoff ? 'text-purple-400' : ''
+
+  // Spinoffs keep their branch icon and swap to a checkbox on hover; main
+  // conversations show the checkbox permanently.
+  const checkboxShown = selectMode || selected
+  const spinoffIconVisibilityClass = checkboxShown ? 'opacity-0' : 'group-hover/iconslot:opacity-0'
+  const spinoffCheckboxVisibilityClass = checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
 
   return (
     <div
       onClick={() => onSelect(conv.id)}
       className={`group flex items-center gap-2 py-2 cursor-pointer border-b border-gray-800/30 ${
-        activeId === conv.id
-          ? 'bg-gray-800 text-white'
-          : 'text-gray-400 hover:bg-gray-800/50'
+        selected
+          ? 'bg-blue-900/30 text-white'
+          : activeId === conv.id
+            ? 'bg-gray-800 text-white'
+            : 'text-gray-400 hover:bg-gray-800/50'
       }`}
       style={{ paddingLeft: `${12 + depth * 16}px`, paddingRight: 12 }}
     >
-      <i className={`fa-solid ${icon} text-[10px] opacity-50 flex-shrink-0 ${iconColor}`}></i>
+      {isSpinoff ? (
+        <div className="group/iconslot relative w-7 h-7 -m-1.5 flex items-center justify-center flex-shrink-0">
+          <i
+            className={`fa-solid fa-code-branch text-[10px] opacity-50 text-purple-400 absolute inset-0 flex items-center justify-center transition-opacity ${spinoffIconVisibilityClass}`}
+          ></i>
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect(conv.id)}
+            onClick={e => e.stopPropagation()}
+            className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
+            title="Select"
+          />
+        </div>
+      ) : (
+        <div className="group/iconslot relative w-7 h-7 -m-1.5 flex items-center justify-center flex-shrink-0">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect(conv.id)}
+            onClick={e => e.stopPropagation()}
+            className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${
+              checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
+            }`}
+            title="Select"
+          />
+        </div>
+      )}
       <div className="flex-1 min-w-0">
         <div className="text-sm truncate">{conv.title}</div>
         <div className="text-[10px] text-gray-600">
@@ -45,8 +78,10 @@ function ConversationItem({ conv, activeId, depth, confirmDelete, setConfirmDele
   )
 }
 
-export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete }) {
+export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany }) {
   const [confirmDelete, setConfirmDelete] = useState(null)
+  const [selectedIds, setSelectedIds] = useState(() => new Set())
+  const [confirmBulk, setConfirmBulk] = useState(false)
 
   // Build tree: top-level conversations + their children
   const tree = useMemo(() => {
@@ -61,6 +96,44 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
     return { roots, childrenMap }
   }, [conversations])
 
+  const toggleSelect = (id) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const clearSelection = () => {
+    setSelectedIds(new Set())
+    setConfirmBulk(false)
+  }
+
+  const handleBulkDelete = async () => {
+    const ids = Array.from(selectedIds)
+    clearSelection()
+    if (onDeleteMany) await onDeleteMany(ids)
+  }
+
+  const selectionCount = selectedIds.size
+  // Once anything is selected, every row swaps its icon for a checkbox.
+  const selectMode = selectionCount > 0
+
+  const allRootsSelected = tree.roots.length > 0 && tree.roots.every(c => selectedIds.has(c.id))
+
+  const toggleSelectAllRoots = () => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (allRootsSelected) {
+        for (const c of tree.roots) next.delete(c.id)
+      } else {
+        for (const c of tree.roots) next.add(c.id)
+      }
+      return next
+    })
+  }
+
   function renderConv(conv, depth) {
     const children = tree.childrenMap[conv.id] || []
     return (
@@ -69,6 +142,9 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
           conv={conv}
           activeId={activeId}
           depth={depth}
+          selectMode={selectMode}
+          selected={selectedIds.has(conv.id)}
+          onToggleSelect={toggleSelect}
           confirmDelete={confirmDelete}
           setConfirmDelete={setConfirmDelete}
           onSelect={onSelect}
@@ -90,6 +166,65 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
           <i className="fa-solid fa-plus"></i>
           New Conversation
         </button>
+      </div>
+
+      {/* Always-visible header row: shows count + select-all in browse mode,
+          morphs to selection toolbar in select mode. Same outer div / height
+          either way so the conversation list never shifts vertically. */}
+      <div
+        className={`h-9 px-3 border-b border-gray-800 flex items-center justify-between text-xs ${
+          selectionCount > 0 ? 'bg-gray-800/60' : ''
+        }`}
+      >
+        {selectionCount === 0 ? (
+          <>
+            <span className="text-gray-500">
+              {conversations.length} {conversations.length === 1 ? 'chat' : 'chats'}
+            </span>
+            {tree.roots.length > 0 && (
+              <button
+                onClick={toggleSelectAllRoots}
+                className="text-[11px] text-gray-500 hover:text-gray-300"
+                title="Selects only top-level conversations; spinoffs follow their parent"
+              >
+                {allRootsSelected ? 'Deselect all' : 'Select all'}
+              </button>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="text-gray-300">{selectionCount} selected</span>
+            <div className="flex items-center gap-2">
+              {confirmBulk ? (
+                <>
+                  <button
+                    onClick={handleBulkDelete}
+                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white"
+                  >Delete {selectionCount}</button>
+                  <button
+                    onClick={() => setConfirmBulk(false)}
+                    className="px-2 py-1 bg-gray-600 hover:bg-gray-500 rounded text-white"
+                  >Cancel</button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={() => setConfirmBulk(true)}
+                    className="px-2 py-1 text-red-400 hover:text-red-300 hover:bg-red-900/30 rounded"
+                    title="Delete selected"
+                  >
+                    <i className="fa-solid fa-trash"></i>
+                  </button>
+                  <button
+                    onClick={clearSelection}
+                    className="px-2 py-1 text-gray-400 hover:text-gray-200"
+                    title="Clear selection"
+                  >Clear</button>
+                </>
+              )}
+            </div>
+          </>
+        )}
       </div>
 
       {/* Conversation tree */}

--- a/dashboard/frontend/src/components/chat/CopyablePre.jsx
+++ b/dashboard/frontend/src/components/chat/CopyablePre.jsx
@@ -11,15 +11,41 @@ function extractText(node) {
 export default function CopyablePre({ children, ...rest }) {
   const [copied, setCopied] = useState(false)
 
-  const handleCopy = (e) => {
+  const handleCopy = async (e) => {
     e.stopPropagation()
     const codeNode = Children.toArray(children).find(isValidElement)
     const text = extractText(codeNode || children)
     if (!text) return
-    navigator.clipboard.writeText(text).then(() => {
+
+    const flash = () => {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
-    }).catch(() => { /* ignore */ })
+    }
+
+    // navigator.clipboard is unavailable on insecure origins (HTTP from
+    // another host — common when the dashboard is reached over the tunnel
+    // without TLS termination). Use the legacy textarea + execCommand path
+    // as a fallback so the button works regardless of origin.
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text)
+        flash()
+        return
+      } catch { /* fall through to legacy path */ }
+    }
+
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.top = '-1000px'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    try {
+      if (document.execCommand('copy')) flash()
+    } catch { /* clipboard genuinely unavailable */ }
+    document.body.removeChild(ta)
   }
 
   return (

--- a/dashboard/frontend/src/components/chat/CopyablePre.jsx
+++ b/dashboard/frontend/src/components/chat/CopyablePre.jsx
@@ -1,0 +1,43 @@
+import { useState, Children, isValidElement } from 'react'
+
+function extractText(node) {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement(node)) return extractText(node.props.children)
+  return ''
+}
+
+export default function CopyablePre({ children, ...rest }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = (e) => {
+    e.stopPropagation()
+    const codeNode = Children.toArray(children).find(isValidElement)
+    const text = extractText(codeNode || children)
+    if (!text) return
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    }).catch(() => { /* ignore */ })
+  }
+
+  return (
+    <div className="group/code relative my-2">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute top-1.5 right-1.5 z-10 px-2 py-1 text-[10px] font-medium rounded bg-gray-700/80 text-gray-300 hover:bg-gray-600 hover:text-white opacity-0 group-hover/code:opacity-100 focus:opacity-100 transition-opacity"
+        title={copied ? 'Copied' : 'Copy code'}
+        aria-label={copied ? 'Code copied' : 'Copy code'}
+      >
+        {copied ? (
+          <><i className="fa-solid fa-check mr-1"></i>Copied</>
+        ) : (
+          <><i className="fa-solid fa-copy mr-1"></i>Copy</>
+        )}
+      </button>
+      <pre {...rest}>{children}</pre>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -8,6 +8,9 @@ import 'katex/dist/katex.min.css'
 import ThinkingBlock from './ThinkingBlock'
 import CritiqueButton from './CritiqueButton'
 import ArtifactRenderer from './ArtifactRenderer'
+import CopyablePre from './CopyablePre'
+
+const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function MessageBubble({ message, critique, critiqueLoading, hasSidekick, onCritique, onEdit, isActiveCritique, artifacts }) {
   const [editing, setEditing] = useState(false)
@@ -37,7 +40,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} group`}>
-      <div className={`max-w-[80%] ${isUser ? 'order-1' : ''}`}>
+      <div className={`max-w-[90%] ${isUser ? 'order-1' : ''}`}>
         {/* Role label */}
         <div className={`text-[10px] text-gray-500 mb-1 ${isUser ? 'text-right' : ''}`}>
           {isUser ? 'You' : message.model_service || 'Assistant'}
@@ -109,13 +112,13 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
 
           {/* Text content */}
           {editing ? (
-            <div>
+            <div className="w-[60vw] max-w-[800px]">
               <textarea
                 value={editValue}
                 onChange={e => setEditValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
-                rows={3}
-                className="w-full bg-blue-700 text-white rounded px-2 py-1 text-sm resize-none focus:outline-none"
+                rows={6}
+                className="w-full min-h-[140px] bg-blue-700 text-white rounded px-3 py-2 text-sm resize-y focus:outline-none"
                 autoFocus
               />
               <div className="flex gap-2 mt-2 text-xs">
@@ -128,7 +131,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
           ) : (
             message.content && (
               <div className="text-sm prose prose-invert prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]}>
+                <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                   {message.content}
                 </ReactMarkdown>
               </div>

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -7,6 +7,9 @@ import rehypeKatex from 'rehype-katex'
 import MessageBubble from './MessageBubble'
 import ThinkingBlock from './ThinkingBlock'
 import ArtifactRenderer from './ArtifactRenderer'
+import CopyablePre from './CopyablePre'
+
+const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function MessageList({
   messages,
@@ -47,7 +50,7 @@ export default function MessageList({
       onScroll={handleScroll}
       className="flex-1 overflow-auto p-4 space-y-4"
     >
-      <div className="max-w-4xl mx-auto space-y-4">
+      <div className="max-w-6xl mx-auto space-y-4">
         {messages.map(msg => (
           <MessageBubble
             key={msg.id}
@@ -67,7 +70,7 @@ export default function MessageList({
           <div className="space-y-1.5">
             {toolEvents.map((evt, i) => (
               <div key={i} className="flex justify-start">
-                <div className="max-w-[80%]">
+                <div className="max-w-[90%]">
                   {/* Reasoning before this tool call */}
                   {evt.type === 'call' && evt.reasoning && (
                     <div className="mb-1">
@@ -105,7 +108,7 @@ export default function MessageList({
 
         {/* Streaming artifacts — show as soon as they arrive, before the response */}
         {streaming && streamingArtifacts.length > 0 && (
-          <div className="max-w-[80%]">
+          <div className="max-w-[90%]">
             {streamingArtifacts.map((art, i) => (
               <ArtifactRenderer key={i} artifact={art} />
             ))}
@@ -115,7 +118,7 @@ export default function MessageList({
         {/* Streaming response */}
         {streaming && (
           <div className="flex justify-start">
-            <div className="max-w-[80%]">
+            <div className="max-w-[90%]">
               <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
               {streamingReasoning && (
                 <ThinkingBlock content={streamingReasoning} />
@@ -123,7 +126,7 @@ export default function MessageList({
               {streamingContent ? (
                 <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700 text-gray-200">
                   <div className="text-sm prose prose-invert prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                    <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]}>
+                    <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                       {streamingContent}
                     </ReactMarkdown>
                   </div>

--- a/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
@@ -6,6 +6,9 @@ import rehypeRaw from 'rehype-raw'
 import rehypeKatex from 'rehype-katex'
 import { streamChat } from '../../services/sse'
 import { createConversation, getConversation } from '../../services/chat'
+import CopyablePre from './CopyablePre'
+
+const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function SpinoffWindow({ id, conversationId: initialConvId, selectedText, serviceName, parentConversationId, position, onClose, onMinimize, onFocus, onConversationCreated, zIndex }) {
   const [convId, setConvId] = useState(initialConvId || null)
@@ -217,7 +220,7 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
             }`}>
               {msg.role === 'assistant' ? (
                 <div className="prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                     {msg.content}
                   </ReactMarkdown>
                 </div>
@@ -232,7 +235,7 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
           <div className="flex justify-start">
             <div className="max-w-[85%] rounded-lg px-3 py-2 text-xs bg-gray-800 border border-gray-700 text-gray-200">
               <div className="prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]}>
+                <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                   {streamingContent}
                 </ReactMarkdown>
               </div>

--- a/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
+++ b/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
@@ -4,6 +4,9 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeRaw from 'rehype-raw'
 import rehypeKatex from 'rehype-katex'
+import CopyablePre from './CopyablePre'
+
+const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function ThinkingBlock({ content }) {
   const [open, setOpen] = useState(false)
@@ -22,7 +25,7 @@ export default function ThinkingBlock({ content }) {
       </button>
       {open && (
         <div className="mt-1 p-3 bg-gray-900/50 border border-gray-700 rounded text-xs text-gray-400 max-h-60 overflow-auto prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]}>
+          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
             {content}
           </ReactMarkdown>
         </div>

--- a/dashboard/frontend/src/hooks/useConversations.js
+++ b/dashboard/frontend/src/hooks/useConversations.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { listConversations, createConversation, deleteConversation, updateConversation } from '../services/chat'
+import { listConversations, createConversation, deleteConversation, deleteConversations, updateConversation } from '../services/chat'
 
 export default function useConversations() {
   const [conversations, setConversations] = useState([])
@@ -36,10 +36,16 @@ export default function useConversations() {
     await refresh()
   }, [refresh])
 
+  const removeMany = useCallback(async (ids) => {
+    if (!ids || ids.length === 0) return
+    await deleteConversations(ids)
+    await refresh()
+  }, [refresh])
+
   const rename = useCallback(async (id, title) => {
     await updateConversation(id, { title })
     await refresh()
   }, [refresh])
 
-  return { conversations, loading, refresh, create, remove, rename }
+  return { conversations, loading, refresh, create, remove, removeMany, rename }
 }

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -28,6 +28,13 @@ export async function deleteConversation(id) {
   })
 }
 
+export async function deleteConversations(ids) {
+  return fetchAPI('/chat/conversations/delete', {
+    method: 'POST',
+    body: JSON.stringify({ ids }),
+  })
+}
+
 export async function requestCritique(messageId, { contextWindow = 10, extraInstructions = '' } = {}) {
   return fetchAPI(`/chat/messages/${messageId}/critique`, {
     method: 'POST',

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -87,7 +87,7 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
           if (delta) {
             onDelta?.({
               content: delta.content || '',
-              reasoning_content: delta.reasoning_content || '',
+              reasoning_content: delta.reasoning_content || delta.reasoning || '',
             })
           }
         } catch {

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -391,7 +391,12 @@
         <header class="mb-8">
             <div class="flex justify-between items-start mb-4">
                 <div>
-                    <h1 class="text-3xl font-bold">LLM Service Dashboard</h1>
+                    <div class="flex items-baseline gap-3">
+                        <h1 class="text-3xl font-bold">LLM Service Dashboard</h1>
+                        <a href="/v2" class="text-sm text-blue-400 hover:text-blue-300 hover:underline">
+                            Try v2 <i class="fa-solid fa-arrow-up-right-from-square text-xs ml-0.5"></i>
+                        </a>
+                    </div>
                     <div id="image-metadata" class="text-xs text-gray-500 mt-1"></div>
                 </div>
                 <div class="flex items-center gap-4">


### PR DESCRIPTION
Five focused commits bundled together.

## Commits

1. **`feat(chat): multi-select with recursive cascade delete`** — sidebar gets hover-to-checkbox affordance on root conversations and a morphing header bar (`N chats / Select all` ↔ `N selected / trash / Clear`). Backend gets a batch `/api/chat/conversations/delete` route. Deletes now use a recursive SQLite CTE so spinoffs go with their parent instead of orphaning in the DB.

2. **`feat(chat): widen layout, larger edit textarea, copy button on code blocks`** — chat response area `max-w-4xl → max-w-6xl`, bubbles `80% → 90%`. Editing a past message opens a 60vw / 140px-min textarea instead of one bounded by the original bubble. New `CopyablePre` wraps every code block (main, spinoffs, thinking) with a hover-revealed copy button.

3. **`feat(dashboard): cross-frontend nav links + log font-size controls`** — `Try v2 ↗` on legacy index, subtle `← Back to v1` on v2 header. `ServiceLogsPanel` gets −/+ font-size buttons (persisted to localStorage, clamped 10–22px).

4. **`fix(chat): stream vLLM thinking traces in real time`** — vLLM's qwen3 reasoning parser emits `delta.reasoning`, not `delta.reasoning_content` (which llama-server uses). Accept either field in both proxy and SSE parser so the `ThinkingBlock` renders token-by-token for both backends.

5. **`docs: add project CLAUDE.md`** — runbook for adding vLLM services from the CLI plus a few gotchas (`--task` removal in 0.20, custom-arch repo caching, embedding `--gpu-memory-utilization`, silent flag typos).

## Test plan

- [ ] `cd dashboard/frontend && npm run build` — already verified locally
- [ ] Multi-select: pick a parent with spinoffs, bulk delete, confirm spinoffs vanish from sidebar AND `sqlite3 dashboard/chat.db 'SELECT count(*) FROM conversations'` reflects the reduction
- [ ] Edit past message: opens wide textarea regardless of original message length
- [ ] Copy buttons: hover any code block in chat / spinoff / thinking, click copy → check clipboard
- [ ] Log font-size: ±, reload page, value persists
- [ ] vLLM thinking: ask Qwen3.6 anything via dashboard, confirm `<think>` content streams into `ThinkingBlock` as it generates (not just at end)
- [ ] Nav links: `/` → `/v2`, back; both ways