### PR TITLE
Drop polling for v2 service-detail runtime and GPU stats

### DIFF
--- a/dashboard/frontend/src/components/GpuMonitor.jsx
+++ b/dashboard/frontend/src/components/GpuMonitor.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
-import { fetchAPI } from '../api'
+import useGpuSSE from '../hooks/useGpuSSE'
 import GpuStats from './GpuStats'
 import GpuGraph from './GpuGraph'
 
-const MAX_POINTS = 20 // 20 points × 3s = 60s of history
-const POLL_INTERVAL = 3000
+const MAX_POINTS = 20 // 20 frames × ~3s server tick = ~60s of history
 
 function updateHistories(prev, gpus) {
   const next = { ...prev }
@@ -22,32 +21,14 @@ function updateHistories(prev, gpus) {
 }
 
 export default function GpuMonitor() {
-  const [gpus, setGpus] = useState(null)
+  const { gpus, error } = useGpuSSE()
   const [histories, setHistories] = useState({})
-  const [error, setError] = useState(null)
 
   useEffect(() => {
-    let active = true
-
-    async function poll() {
-      try {
-        const data = await fetchAPI('/gpu')
-        if (!active) return
-        const list = data.gpus || []
-        setGpus(list)
-        setError(null)
-        if (list.length) {
-          setHistories(prev => updateHistories(prev, list))
-        }
-      } catch (err) {
-        if (active) setError(err.message)
-      }
+    if (gpus && gpus.length) {
+      setHistories(prev => updateHistories(prev, gpus))
     }
-
-    poll()
-    const id = setInterval(poll, POLL_INTERVAL)
-    return () => { active = false; clearInterval(id) }
-  }, [])
+  }, [gpus])
 
   if (error) {
     return <p className="text-red-400">GPU: {error}</p>

--- a/dashboard/frontend/src/hooks/useGpuSSE.js
+++ b/dashboard/frontend/src/hooks/useGpuSSE.js
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getToken, API_BASE } from '../api'
+
+const RECONNECT_DELAY = 3000
+
+/**
+ * Hook for subscribing to real-time GPU stats via the /api/gpu/stream SSE
+ * endpoint. Replaces the old polling loop. Each frame emitted by the
+ * backend becomes a new `gpus` value.
+ *
+ * @returns {{ gpus: Array<Object> | null, error: string | null, connected: boolean }}
+ */
+export default function useGpuSSE() {
+  const [gpus, setGpus] = useState(null)
+  const [error, setError] = useState(null)
+  const [connected, setConnected] = useState(false)
+
+  const mountedRef = useRef(true)
+  const abortControllerRef = useRef(null)
+  const reconnectTimerRef = useRef(null)
+  const startStreamRef = useRef(null)
+
+  const stopStream = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+  }, [])
+
+  const startStream = useCallback(() => {
+    const token = getToken()
+    if (!token) {
+      if (mountedRef.current) setError('Not authenticated')
+      return
+    }
+
+    if (abortControllerRef.current) abortControllerRef.current.abort()
+    if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null }
+
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    fetch(`${API_BASE}/gpu/stream`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+      signal: controller.signal,
+    })
+      .then(async response => {
+        if (!response.ok) {
+          if (mountedRef.current) {
+            setError(`HTTP ${response.status}`)
+            setConnected(false)
+          }
+          return
+        }
+
+        if (mountedRef.current) { setConnected(true); setError(null) }
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        try {
+          while (true) {
+            if (controller.signal.aborted) break
+            const { done, value } = await reader.read()
+            if (done) break
+
+            buffer += decoder.decode(value, { stream: true })
+            const parts = buffer.split('\n')
+            buffer = parts.pop()
+
+            for (const line of parts) {
+              if (!line.startsWith('data: ')) continue
+              try {
+                const data = JSON.parse(line.slice(6))
+                if (!mountedRef.current) break
+                if (data.error) {
+                  setError(data.error)
+                } else {
+                  setGpus(data.gpus || [])
+                  setError(null)
+                }
+              } catch { /* malformed line */ }
+            }
+          }
+        } catch (err) {
+          if (err.name !== 'AbortError' && mountedRef.current) {
+            setError(`Stream error: ${err.message}`)
+          }
+        } finally {
+          if (mountedRef.current) {
+            setConnected(false)
+            if (!controller.signal.aborted) {
+              reconnectTimerRef.current = setTimeout(
+                () => { if (mountedRef.current) startStreamRef.current() },
+                RECONNECT_DELAY,
+              )
+            }
+          }
+        }
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError' && mountedRef.current) {
+          setError(`Connection failed: ${err.message}`)
+          setConnected(false)
+          reconnectTimerRef.current = setTimeout(
+            () => { if (mountedRef.current) startStreamRef.current() },
+            RECONNECT_DELAY,
+          )
+        }
+      })
+  }, [])
+
+  startStreamRef.current = startStream
+
+  useEffect(() => {
+    mountedRef.current = true
+    startStream()
+    return () => {
+      mountedRef.current = false
+      stopStream()
+    }
+  }, [startStream, stopStream])
+
+  return { gpus, error, connected }
+}

--- a/dashboard/frontend/src/hooks/useServiceDetails.js
+++ b/dashboard/frontend/src/hooks/useServiceDetails.js
@@ -1,111 +1,94 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { fetchAPI } from '../api'
 import { startService, stopService, restartService } from '../services/lifecycle'
-
-const POLL_INTERVAL = 3000
+import useServicesSSE from './useServicesSSE'
 
 export default function useServiceDetails(serviceName) {
   const [config, setConfig] = useState(null)
-  const [runtime, setRuntime] = useState(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
+  const [configError, setConfigError] = useState(null)
+  const [configLoading, setConfigLoading] = useState(true)
   const [transitioning, setTransitioning] = useState(null)
   const mountedRef = useRef(true)
+
+  // Runtime state (status, container_id, host_port, etc.) comes from the
+  // shared SSE stream. No polling here; lifecycle actions don't need to
+  // call back to refresh because the Docker event manager pushes a delta
+  // within ~1s of the container state change.
+  const { services, loading: sseLoading, error: sseError } = useServicesSSE()
+  const runtime = useMemo(() => {
+    if (!services) return null
+    return services.find(s => s.name === serviceName) || null
+  }, [services, serviceName])
 
   const fetchConfig = useCallback(async () => {
     try {
       const data = await fetchAPI(`/services/${serviceName}`)
       if (mountedRef.current) {
         setConfig(data.config)
+        setConfigError(null)
       }
     } catch (err) {
       if (mountedRef.current) {
         if (err.message.includes('404') || err.message.includes('not found')) {
-          setError('not-found')
+          setConfigError('not-found')
         } else {
-          setError(err.message)
+          setConfigError(err.message)
         }
       }
     }
   }, [serviceName])
 
-  const fetchRuntime = useCallback(async () => {
-    try {
-      const data = await fetchAPI('/services')
-      if (mountedRef.current) {
-        const svc = (data.services || []).find(s => s.name === serviceName)
-        if (svc) {
-          setRuntime(svc)
-          setError(null)
-        } else {
-          // Don't set 'not-found' here — the list endpoint may be transiently
-          // incomplete during compose reloads. fetchConfig hitting the
-          // per-service endpoint is the authoritative existence check.
-          setRuntime(null)
-        }
-      }
-    } catch (err) {
-      if (mountedRef.current) {
-        setError(err.message)
-      }
-    }
-  }, [serviceName])
-
-  // Initial fetch: config + runtime in parallel
+  // Initial config fetch (and refetch when serviceName changes)
   useEffect(() => {
     mountedRef.current = true
-    setLoading(true)
-    setError(null)
-
-    Promise.all([fetchConfig(), fetchRuntime()]).then(() => {
-      if (mountedRef.current) setLoading(false)
+    setConfigLoading(true)
+    setConfigError(null)
+    fetchConfig().finally(() => {
+      if (mountedRef.current) setConfigLoading(false)
     })
-
     return () => { mountedRef.current = false }
-  }, [fetchConfig, fetchRuntime])
+  }, [fetchConfig])
 
-  // Poll runtime every 3s
-  useEffect(() => {
-    if (loading || error === 'not-found') return
-
-    const id = setInterval(fetchRuntime, POLL_INTERVAL)
-    return () => clearInterval(id)
-  }, [loading, error, fetchRuntime])
+  // 'not-found' from the config endpoint is authoritative — it's the only
+  // surface that distinguishes "deleted" from "transiently absent from the
+  // list during compose reloads". SSE errors are surfaced as a secondary
+  // signal (connection problems), and the SSE snapshot may take a tick
+  // longer than the config call to arrive.
+  const error = configError === 'not-found' ? 'not-found' : (configError || sseError)
+  const loading = configLoading || sseLoading
 
   const refetchConfig = useCallback(async () => {
     await fetchConfig()
   }, [fetchConfig])
 
-  // Lifecycle actions
+  // Lifecycle actions. No manual runtime refresh — the SSE stream will
+  // deliver the new status as soon as docker emits the event.
   const start = useCallback(async () => {
     setTransitioning('starting')
     try {
       await startService(serviceName)
-      await fetchRuntime()
     } finally {
       if (mountedRef.current) setTransitioning(null)
     }
-  }, [serviceName, fetchRuntime])
+  }, [serviceName])
 
   const stop = useCallback(async () => {
     setTransitioning('stopping')
     try {
       await stopService(serviceName)
-      await fetchRuntime()
     } finally {
       if (mountedRef.current) setTransitioning(null)
     }
-  }, [serviceName, fetchRuntime])
+  }, [serviceName])
 
   const restart = useCallback(async () => {
     setTransitioning('restarting')
     try {
       await restartService(serviceName)
-      await fetchRuntime()
     } finally {
       if (mountedRef.current) setTransitioning(null)
     }
-  }, [serviceName, fetchRuntime])
+  }, [serviceName])
 
   const rename = useCallback(async (newName) => {
     await fetchAPI(`/services/${serviceName}/rename`, {
@@ -120,10 +103,12 @@ export default function useServiceDetails(serviceName) {
 
   const setPublicPort = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/set-public-port`, { method: 'POST' })
-    await fetchRuntime()
+    // set-public-port changes the host port, which is part of the config
+    // (services.json) — runtime status is unaffected, but config needs a
+    // refresh because the change isn't on the SSE feed.
     await fetchConfig()
     return data
-  }, [serviceName, fetchRuntime, fetchConfig])
+  }, [serviceName, fetchConfig])
 
   const fetchYamlPreview = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/preview`)
@@ -132,15 +117,13 @@ export default function useServiceDetails(serviceName) {
 
   const registerOpenWebUI = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/register-openwebui`, { method: 'POST' })
-    await fetchRuntime()
     return data
-  }, [serviceName, fetchRuntime])
+  }, [serviceName])
 
   const unregisterOpenWebUI = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/unregister-openwebui`, { method: 'POST' })
-    await fetchRuntime()
     return data
-  }, [serviceName, fetchRuntime])
+  }, [serviceName])
 
   return {
     config, runtime, loading, error, transitioning,

--- a/dashboard/frontend/src/hooks/useServiceDetails.js
+++ b/dashboard/frontend/src/hooks/useServiceDetails.js
@@ -14,7 +14,7 @@ export default function useServiceDetails(serviceName) {
   // shared SSE stream. No polling here; lifecycle actions don't need to
   // call back to refresh because the Docker event manager pushes a delta
   // within ~1s of the container state change.
-  const { services, loading: sseLoading, error: sseError } = useServicesSSE()
+  const { services, loading: sseLoading, error: sseError, refresh: refreshSSE } = useServicesSSE()
   const runtime = useMemo(() => {
     if (!services) return null
     return services.find(s => s.name === serviceName) || null
@@ -103,12 +103,15 @@ export default function useServiceDetails(serviceName) {
 
   const setPublicPort = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/set-public-port`, { method: 'POST' })
-    // set-public-port changes the host port, which is part of the config
-    // (services.json) — runtime status is unaffected, but config needs a
-    // refresh because the change isn't on the SSE feed.
+    // set-public-port mutates the host port. The SSE delta channel
+    // carries only lifecycle fields (name/status/container_id), so the
+    // cached runtime.host_port would otherwise stay stale until a full
+    // reload. Re-open the SSE stream to pull a fresh snapshot, and
+    // refresh the per-service config too.
     await fetchConfig()
+    refreshSSE()
     return data
-  }, [serviceName, fetchConfig])
+  }, [serviceName, fetchConfig, refreshSSE])
 
   const fetchYamlPreview = useCallback(async () => {
     const data = await fetchAPI(`/services/${serviceName}/preview`)


### PR DESCRIPTION
Two leftover pollers in v2 were re-fetching data that the backend already exposes over SSE.

## Changes

### `useServiceDetails`
- Was hitting `GET /api/services` every 3s just to pluck one row, doubling load on top of the existing `/api/services/stream` subscription.
- Now derives `runtime` from `useServicesSSE` via a `useMemo` selector. Same pattern as `useRunningServices`.
- Manual `fetchRuntime()` calls after `start` / `stop` / `restart` / `registerOpenWebUI` / `unregisterOpenWebUI` are gone — Docker event manager pushes a delta within ~1s of any container state change.
- `'not-found'` remains sourced from the per-service config endpoint (the authoritative existence check, robust against transient absence during compose reloads). SSE errors flow through as a secondary signal.
- Public return shape unchanged: `{ config, runtime, loading, error, transitioning, refetchConfig, actions }` — `ServiceDetailsPage` destructures these unchanged.

### `GpuMonitor`
- Was polling `GET /api/gpu` on a 3s `setInterval`.
- `GET /api/gpu/stream` has existed since the legacy dashboard's GPU SSE work but v2 never adopted it.
- New `useGpuSSE` hook follows the same `fetch` + `ReadableStream` pattern as `useServiceLogsSSE`, with reconnect-on-drop.
- `GpuMonitor` just consumes it and keeps the existing 20-point history buffer.

## Out of scope (intentionally)

`useServiceMetrics` still polls `/api/services/<name>/metrics` because there's no SSE backend for per-service metrics yet. Worth a follow-up — `event_manager.py` already runs per-container probes, so it could carry metrics in the same delta channel.

## Test plan

- [ ] `npm run build` — clean
- [ ] Open `/v2/service/<name>` — runtime status (starting/running/stopped pill) updates live within ~1s of `docker compose start/stop` from another shell
- [ ] DevTools Network: no recurring `GET /api/services` from the detail page (just the long-lived SSE)
- [ ] GPU monitor on `/v2` updates every ~3s with a single open `/api/gpu/stream` connection in Network tab (no recurring `/api/gpu` polls)
- [ ] Pull cable / pause backend: GPU + service-detail panels reconnect on their own within a few seconds