### PR TITLE
Re-attach log SSE when container goes back to running

### DIFF
--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -37,6 +37,22 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
     { enabled: hasContainer && !paused, tail: 200 },
   )
 
+  // Re-attach the SSE stream when the container transitions INTO 'running'.
+  // The hook itself doesn't reconnect after a clean stream_end (which fires
+  // when the container exits), and `enabled` doesn't change on a normal
+  // stop→start cycle, so without this the panel would freeze at "Container
+  // stopped" until a page reload. Also handles --force-recreate via the
+  // container_id dep. The !paused guard keeps an explicit pause sticky.
+  const prevStatusRef = useRef(status)
+  const containerId = runtime?.container_id
+  useEffect(() => {
+    const prev = prevStatusRef.current
+    prevStatusRef.current = status
+    if (prev !== 'running' && status === 'running' && !paused) {
+      refresh()
+    }
+  }, [status, containerId, paused, refresh])
+
   // Track last activity time for footer display
   const [lastUpdated, setLastUpdated] = useState(null)
   useEffect(() => {


### PR DESCRIPTION
## Problem

On the v2 service-details Logs tab, stopping then starting a service (or hitting Restart) leaves the log panel empty/frozen until a manual page refresh, even though the container is healthy and emitting logs.

## Root cause

1. The SSE hook's effect re-runs only on `[enabled, serviceName]` changes. Neither flips during a normal stop→start: `hasContainer = status !== 'not-created'` stays true for `exited`.
2. Backend sends `stream_end` when the container exits; hook sets `streamEnded=true` and the `finally` block intentionally **skips** reconnect for clean ends.
3. When the container returns to `running`, nothing kicks the hook out of its terminal post-`stream_end` state.

## Fix

`ServiceLogsPanel.jsx` watches `runtime.status` (and `container_id` for `--force-recreate`) and calls the hook's `refresh()` on the transition **into** `'running'`. `prevStatusRef` remembers prior status to detect the edge.

Trade-offs considered:
- Re-keying the hook's `useEffect` on `status` would also restart on `running→exited`, opening a new connection just to receive `stream_end` again — wasteful churn. Transitioning-into is exactly when we want a fresh stream.
- `!paused` guard keeps an explicit pause sticky — don't ambush the user with a new stream after they hit Pause.
- Hook signature unchanged. The consumer owns the "when to reconnect" policy.

## Test plan

- [ ] Open `/v2/service/<svc>/logs` on a running container → "Live", lines streaming
- [ ] Click Stop → footer "Container stopped"
- [ ] Click Start → within ~1–2s the panel reconnects, footer "Live", new lines arrive — no page reload
- [ ] Click Restart → same end-to-end
- [ ] Pause → Stop → Start → stream stays paused (no auto-resume); Resume → reattaches
- [ ] `docker compose up -d --force-recreate <svc>` from a shell while panel is open → panel re-attaches to the new container id
- [ ] DevTools Network: one new `/api/services/<svc>/logs/stream` opens per resume, no leftover connections after stop/start cycles
- [ ] `npm run build` clean