### PR TITLE
feat(chat): push auto-generated titles via SSE + larger checkbox hit area

### DIFF
--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import os
-import threading
 import uuid
+from typing import Optional
 
 from flask import Blueprint, jsonify, request, current_app, Response, stream_with_context
 
@@ -215,42 +215,53 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
         yield f"data: {json.dumps({'error': 'Stream ended unexpectedly'})}\n\n"
 
 
-def _auto_generate_title(app, db_path: str, conv_id: str, first_user_content: str, service_name: str):
-    """Background thread to auto-generate a conversation title."""
-    try:
-        from .db import ChatDB as _ChatDB
-        _db = _ChatDB(db_path)
-        conv = _db.get_conversation(conv_id)
-        if conv is None or conv.title != "New Conversation":
-            return
+def _auto_generate_title(db, conv_id: str, first_user_content: str, service_name: str) -> Optional[str]:
+    """Generate a 3–6 word title for a fresh conversation and persist it.
 
-        title_messages = [
-            {"role": "system", "content": "Generate a concise 3-6 word title for a conversation that starts with the following message. Return ONLY the title, nothing else. Do not explain or add anything."},
-            {"role": "user", "content": first_user_content},
-        ]
+    Runs synchronously inside the SSE response that delivered the assistant
+    reply — see send_message. Returns the new title on success so the caller
+    can emit a conversation_updated event to the open client, or None if
+    nothing should be pushed (manual rename already won, model produced
+    empty output, etc).
+    """
+    conv = db.get_conversation(conv_id)
+    if conv is None or conv.title != "New Conversation":
+        return None
 
-        full_content = ""
-        full_reasoning = ""
-        for event_type, data in stream_chat_completion(service_name, title_messages):
-            if event_type == "delta":
-                full_content += data.get("content", "")
-            elif event_type == "done":
-                full_content = data["content"]
-                full_reasoning = data.get("reasoning_content") or ""
-                break
+    title_messages = [
+        {"role": "system", "content": "Generate a concise 3-6 word title for a conversation that starts with the following message. Return ONLY the title, nothing else. Do not explain or add anything."},
+        {"role": "user", "content": first_user_content},
+    ]
 
-        # Some models put short responses in reasoning_content instead of content
-        title = full_content.strip() or full_reasoning.strip()
-        # Extract last non-empty line as the likely title if reasoning is verbose
-        if '\n' in title:
-            lines = [l.strip().strip('"\'').strip() for l in title.split('\n') if l.strip()]
-            title = lines[-1] if lines else title
-        title = title.strip('"\'*#').strip()
-        if title:
-            _db.update_conversation(conv_id, title=title[:100])
-            logger.info(f"Auto-generated title for {conv_id}: {title}")
-    except Exception:
-        logger.exception("Failed to auto-generate conversation title")
+    full_content = ""
+    full_reasoning = ""
+    for event_type, data in stream_chat_completion(service_name, title_messages):
+        if event_type == "delta":
+            full_content += data.get("content", "")
+        elif event_type == "done":
+            full_content = data["content"]
+            full_reasoning = data.get("reasoning_content") or ""
+            break
+
+    # Some models put short responses in reasoning_content instead of content
+    title = full_content.strip() or full_reasoning.strip()
+    if '\n' in title:
+        lines = [l.strip().strip('"\'').strip() for l in title.split('\n') if l.strip()]
+        title = lines[-1] if lines else title
+    title = title.strip('"\'*#').strip()
+    if not title:
+        return None
+
+    # Re-check before write: a rename arriving DURING the model call would
+    # otherwise be clobbered.
+    conv2 = db.get_conversation(conv_id)
+    if conv2 is None or conv2.title != "New Conversation":
+        return None
+
+    final = title[:100]
+    db.update_conversation(conv_id, title=final)
+    logger.info(f"Auto-generated title for {conv_id}: {final}")
+    return final
 
 
 @chat_bp.route("/api/chat/conversations/<conv_id>/messages", methods=["POST"])
@@ -288,15 +299,16 @@ def send_message(conv_id):
 
     def generate():
         yield from _stream_response(db, conv, user_msg, mcp_manager=mcp_manager)
-        # Generate title after the main response is done (same model, single slot)
+        # Generate the title inline so we can push it to the client over the
+        # same SSE pipe before closing — otherwise the sidebar shows
+        # "New Conversation" until the next manual refetch.
         if is_first:
-            db_path = db.db_path
-            t = threading.Thread(
-                target=_auto_generate_title,
-                args=(None, db_path, conv_id, content, conv.main_service),
-                daemon=True,
-            )
-            t.start()
+            try:
+                new_title = _auto_generate_title(db, conv_id, content, conv.main_service)
+                if new_title:
+                    yield f"data: {json.dumps({'type': 'conversation_updated', 'id': conv_id, 'title': new_title})}\n\n"
+            except Exception:
+                logger.exception("auto-title failed")
 
     return Response(stream_with_context(generate()), mimetype="text/event-stream",
                     headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -10,7 +10,7 @@ export default function ChatPage() {
   const convId = conversationId || null
   const navigate = useNavigate()
 
-  const { conversations, loading: convsLoading, refresh, create, remove, removeMany } = useConversations()
+  const { conversations, loading: convsLoading, refresh, create, remove, removeMany, patchConversation } = useConversations()
   const {
     conversation,
     messages,
@@ -27,7 +27,9 @@ export default function ChatPage() {
     sendMessage,
     editMessage,
     stopStreaming,
-  } = useChat()
+  } = useChat({
+    onConversationUpdated: (evt) => patchConversation(evt.id, { title: evt.title }),
+  })
 
   // Load conversation when URL changes
   useEffect(() => {

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -22,9 +22,14 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       style={{ paddingLeft: `${12 + depth * 16}px`, paddingRight: 12 }}
     >
       {isSpinoff ? (
-        <div className="group/iconslot relative w-7 h-7 -m-1.5 flex items-center justify-center flex-shrink-0">
+        <div
+          className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
+          onClick={e => {
+            if (checkboxShown) { e.stopPropagation(); onToggleSelect(conv.id) }
+          }}
+        >
           <i
-            className={`fa-solid fa-code-branch text-[10px] opacity-50 text-purple-400 absolute inset-0 flex items-center justify-center transition-opacity ${spinoffIconVisibilityClass}`}
+            className={`fa-solid fa-code-branch text-[10px] opacity-50 text-purple-400 absolute inset-0 flex items-center justify-center transition-opacity pointer-events-none ${spinoffIconVisibilityClass}`}
           ></i>
           <input
             type="checkbox"
@@ -36,7 +41,12 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
           />
         </div>
       ) : (
-        <div className="group/iconslot relative w-7 h-7 -m-1.5 flex items-center justify-center flex-shrink-0">
+        <div
+          className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
+          onClick={e => {
+            if (checkboxShown) { e.stopPropagation(); onToggleSelect(conv.id) }
+          }}
+        >
           <input
             type="checkbox"
             checked={selected}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -73,9 +73,11 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       ) : (
         <button
           onClick={e => { e.stopPropagation(); setConfirmDelete(conv.id) }}
-          className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 flex-shrink-0"
+          className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+          title="Delete conversation"
+          aria-label="Delete conversation"
         >
-          <i className="fa-solid fa-trash text-[10px]"></i>
+          <i className="fa-solid fa-trash text-xs"></i>
         </button>
       )}
     </div>

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -22,11 +22,9 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       style={{ paddingLeft: `${12 + depth * 16}px`, paddingRight: 12 }}
     >
       {isSpinoff ? (
-        <div
+        <label
           className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
-          onClick={e => {
-            if (checkboxShown) { e.stopPropagation(); onToggleSelect(conv.id) }
-          }}
+          onClick={e => e.stopPropagation()}
         >
           <i
             className={`fa-solid fa-code-branch text-[10px] opacity-50 text-purple-400 absolute inset-0 flex items-center justify-center transition-opacity pointer-events-none ${spinoffIconVisibilityClass}`}
@@ -35,29 +33,25 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => onToggleSelect(conv.id)}
-            onClick={e => e.stopPropagation()}
             className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
             title="Select"
           />
-        </div>
+        </label>
       ) : (
-        <div
+        <label
           className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
-          onClick={e => {
-            if (checkboxShown) { e.stopPropagation(); onToggleSelect(conv.id) }
-          }}
+          onClick={e => e.stopPropagation()}
         >
           <input
             type="checkbox"
             checked={selected}
             onChange={() => onToggleSelect(conv.id)}
-            onClick={e => e.stopPropagation()}
             className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${
               checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
             }`}
             title="Select"
           />
-        </div>
+        </label>
       )}
       <div className="flex-1 min-w-0">
         <div className="text-sm truncate">{conv.title}</div>

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { getConversation } from '../services/chat'
 import { streamChat } from '../services/sse'
 
-export default function useChat() {
+export default function useChat({ onConversationUpdated } = {}) {
   const [conversation, setConversation] = useState(null)
   const [messages, setMessages] = useState([])
   const [critiques, setCritiques] = useState({})
@@ -102,6 +102,7 @@ export default function useChat() {
         onDone: () => {
           // Will be followed by message_saved
         },
+        onConversationUpdated,
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -134,7 +135,7 @@ export default function useChat() {
         },
       }
     )
-  }, [conversation, messages, streaming, loadConversation])
+  }, [conversation, messages, streaming, loadConversation, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
     if (!conversation || streaming) return
@@ -175,6 +176,7 @@ export default function useChat() {
           }
         },
         onDone: () => {},
+        onConversationUpdated,
         onMessageSaved: () => {
           setStreamingContent('')
           setStreamingReasoning('')
@@ -190,7 +192,7 @@ export default function useChat() {
         },
       }
     )
-  }, [conversation, messages, streaming, loadConversation])
+  }, [conversation, messages, streaming, loadConversation, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
     if (abortRef.current) {

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -14,6 +14,12 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [streamingArtifacts, setStreamingArtifacts] = useState([])
   const [error, setError] = useState(null)
   const abortRef = useRef(null)
+  // True between message_saved and stream-end — the title-tail phase where
+  // the backend is generating the auto-title and about to emit one more
+  // conversation_updated event. Skip aborting in this window so the title
+  // event still arrives (and the backend isn't BrokenPiped mid-generation).
+  // Reset on every new send/load/stop so it can't be stuck on stale.
+  const drainingRef = useRef(false)
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -32,11 +38,17 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [])
 
   const loadConversation = useCallback(async (convId) => {
-    // Abort any in-flight stream before switching
+    // Abort any in-flight stream before switching, UNLESS it's draining the
+    // post-message_saved title tail (see drainingRef). Aborting that tail
+    // would cancel auto-title generation server-side and drop the trailing
+    // conversation_updated event. The drained stream's callbacks remain
+    // valid via closures and will still patch the original conversation's
+    // title in the sidebar.
     if (abortRef.current) {
-      abortRef.current.abort()
+      if (!drainingRef.current) abortRef.current.abort()
       abortRef.current = null
     }
+    drainingRef.current = false
     setStreaming(false)
     setStreamingContent('')
     setStreamingReasoning('')
@@ -67,6 +79,7 @@ export default function useChat({ onConversationUpdated } = {}) {
 
     const controller = new AbortController()
     abortRef.current = controller
+    drainingRef.current = false
 
     let fullContent = ''
     let fullReasoning = ''
@@ -129,6 +142,10 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreamingContent('')
           setStreamingReasoning('')
           setStreaming(false)
+          // Enter drain: keep abortRef alive so the trailing
+          // conversation_updated event can arrive, but tell loadConversation
+          // not to abort if the user switches conversations now.
+          drainingRef.current = true
           // Refetch from DB to get the real message IDs. MUST NOT call
           // loadConversation here — it would abort the SSE pipe and we'd
           // miss the trailing conversation_updated event (auto-title).
@@ -139,6 +156,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreaming(false)
           setStreamingContent('')
           setStreamingReasoning('')
+          drainingRef.current = false
           // Remove temp message on error
           setMessages(prev => prev.filter(m => m.id !== 'temp-user'))
         },
@@ -164,6 +182,7 @@ export default function useChat({ onConversationUpdated } = {}) {
 
     const controller = new AbortController()
     abortRef.current = controller
+    drainingRef.current = false
 
     let fullContent = ''
     let fullReasoning = ''
@@ -190,7 +209,10 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreamingContent('')
           setStreamingReasoning('')
           setStreaming(false)
-          // See note in sendMessage: refetch only, don't abort the stream.
+          // See note in sendMessage: refetch only, don't abort the stream,
+          // and enter the drain window so loadConversation also leaves it
+          // alone if the user navigates now.
+          drainingRef.current = true
           refetchMessages(conversation.id)
         },
         onError: (msg) => {
@@ -198,6 +220,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreaming(false)
           setStreamingContent('')
           setStreamingReasoning('')
+          drainingRef.current = false
           loadConversation(conversation.id)
         },
       }
@@ -208,8 +231,9 @@ export default function useChat({ onConversationUpdated } = {}) {
     if (abortRef.current) {
       abortRef.current.abort()
       abortRef.current = null
-      setStreaming(false)
     }
+    drainingRef.current = false
+    setStreaming(false)
   }, [])
 
   // Abort streaming on unmount (e.g. navigating away)

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -15,6 +15,22 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [error, setError] = useState(null)
   const abortRef = useRef(null)
 
+  // Refetch the conversation from the server WITHOUT touching the active
+  // SSE stream. Used by the message_saved handler so we don't cancel our
+  // own pipe before the trailing conversation_updated event (auto-title)
+  // arrives.
+  const refetchMessages = useCallback(async (convId) => {
+    try {
+      const data = await getConversation(convId)
+      setConversation(data)
+      setMessages(data.messages || [])
+      setCritiques(data.critiques || {})
+      setArtifacts(data.artifacts || {})
+    } catch (err) {
+      setError(err.message)
+    }
+  }, [])
+
   const loadConversation = useCallback(async (convId) => {
     // Abort any in-flight stream before switching
     if (abortRef.current) {
@@ -27,17 +43,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     setToolEvents([])
     setStreamingArtifacts([])
     setError(null)
-
-    try {
-      const data = await getConversation(convId)
-      setConversation(data)
-      setMessages(data.messages || [])
-      setCritiques(data.critiques || {})
-      setArtifacts(data.artifacts || {})
-    } catch (err) {
-      setError(err.message)
-    }
-  }, [])
+    await refetchMessages(convId)
+  }, [refetchMessages])
 
   const sendMessage = useCallback(async (content, images) => {
     if (!conversation || streaming) return
@@ -122,8 +129,10 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreamingContent('')
           setStreamingReasoning('')
           setStreaming(false)
-          // Reload to get proper IDs from server
-          loadConversation(conversation.id)
+          // Refetch from DB to get the real message IDs. MUST NOT call
+          // loadConversation here — it would abort the SSE pipe and we'd
+          // miss the trailing conversation_updated event (auto-title).
+          refetchMessages(conversation.id)
         },
         onError: (msg) => {
           setError(msg)
@@ -135,7 +144,7 @@ export default function useChat({ onConversationUpdated } = {}) {
         },
       }
     )
-  }, [conversation, messages, streaming, loadConversation, onConversationUpdated])
+  }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
     if (!conversation || streaming) return
@@ -181,7 +190,8 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreamingContent('')
           setStreamingReasoning('')
           setStreaming(false)
-          loadConversation(conversation.id)
+          // See note in sendMessage: refetch only, don't abort the stream.
+          refetchMessages(conversation.id)
         },
         onError: (msg) => {
           setError(msg)
@@ -192,7 +202,7 @@ export default function useChat({ onConversationUpdated } = {}) {
         },
       }
     )
-  }, [conversation, messages, streaming, loadConversation, onConversationUpdated])
+  }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
     if (abortRef.current) {

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -20,6 +20,12 @@ export default function useChat({ onConversationUpdated } = {}) {
   // event still arrives (and the backend isn't BrokenPiped mid-generation).
   // Reset on every new send/load/stop so it can't be stuck on stale.
   const drainingRef = useRef(false)
+  // All controllers whose streams have not yet ended (active + draining).
+  // Tracked separately from abortRef so the unmount cleanup can abort a
+  // controller that loadConversation detached from abortRef but left
+  // running on purpose (post-message_saved drain phase). Entries are
+  // removed in the streamChat `finally` block when the stream resolves.
+  const liveControllersRef = useRef(new Set())
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -80,6 +86,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    liveControllersRef.current.add(controller)
 
     let fullContent = ''
     let fullReasoning = ''
@@ -87,7 +94,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     const body = { content }
     if (images && images.length > 0) body.images = images
 
-    await streamChat(
+    try {
+      await streamChat(
       `/chat/conversations/${conversation.id}/messages`,
       body,
       {
@@ -161,7 +169,10 @@ export default function useChat({ onConversationUpdated } = {}) {
           setMessages(prev => prev.filter(m => m.id !== 'temp-user'))
         },
       }
-    )
+      )
+    } finally {
+      liveControllersRef.current.delete(controller)
+    }
   }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
@@ -183,48 +194,53 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    liveControllersRef.current.add(controller)
 
     let fullContent = ''
     let fullReasoning = ''
 
-    await streamChat(
-      `/chat/conversations/${conversation.id}/messages/${msgId}`,
-      { content },
-      {
-        method: 'PUT',
-        signal: controller.signal,
-        onDelta: ({ content: c, reasoning_content: r }) => {
-          if (c) {
-            fullContent += c
-            setStreamingContent(prev => prev + c)
-          }
-          if (r) {
-            fullReasoning += r
-            setStreamingReasoning(prev => prev + r)
-          }
-        },
-        onDone: () => {},
-        onConversationUpdated,
-        onMessageSaved: () => {
-          setStreamingContent('')
-          setStreamingReasoning('')
-          setStreaming(false)
-          // See note in sendMessage: refetch only, don't abort the stream,
-          // and enter the drain window so loadConversation also leaves it
-          // alone if the user navigates now.
-          drainingRef.current = true
-          refetchMessages(conversation.id)
-        },
-        onError: (msg) => {
-          setError(msg)
-          setStreaming(false)
-          setStreamingContent('')
-          setStreamingReasoning('')
-          drainingRef.current = false
-          loadConversation(conversation.id)
-        },
-      }
-    )
+    try {
+      await streamChat(
+        `/chat/conversations/${conversation.id}/messages/${msgId}`,
+        { content },
+        {
+          method: 'PUT',
+          signal: controller.signal,
+          onDelta: ({ content: c, reasoning_content: r }) => {
+            if (c) {
+              fullContent += c
+              setStreamingContent(prev => prev + c)
+            }
+            if (r) {
+              fullReasoning += r
+              setStreamingReasoning(prev => prev + r)
+            }
+          },
+          onDone: () => {},
+          onConversationUpdated,
+          onMessageSaved: () => {
+            setStreamingContent('')
+            setStreamingReasoning('')
+            setStreaming(false)
+            // See note in sendMessage: refetch only, don't abort the stream,
+            // and enter the drain window so loadConversation also leaves it
+            // alone if the user navigates now.
+            drainingRef.current = true
+            refetchMessages(conversation.id)
+          },
+          onError: (msg) => {
+            setError(msg)
+            setStreaming(false)
+            setStreamingContent('')
+            setStreamingReasoning('')
+            drainingRef.current = false
+            loadConversation(conversation.id)
+          },
+        }
+      )
+    } finally {
+      liveControllersRef.current.delete(controller)
+    }
   }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
@@ -236,13 +252,17 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreaming(false)
   }, [])
 
-  // Abort streaming on unmount (e.g. navigating away)
+  // Abort streaming on unmount (e.g. navigating away). Aborts BOTH the
+  // active stream (abortRef) and any detached draining streams whose
+  // controllers loadConversation cleared from abortRef but left running so
+  // the auto-title event could land. Without the liveControllersRef sweep,
+  // those fetches would outlive the component and keep firing callbacks
+  // against an unmounted React tree.
   useEffect(() => {
     return () => {
-      if (abortRef.current) {
-        abortRef.current.abort()
-        abortRef.current = null
-      }
+      for (const c of liveControllersRef.current) c.abort()
+      liveControllersRef.current.clear()
+      abortRef.current = null
     }
   }, [])
 

--- a/dashboard/frontend/src/hooks/useConversations.js
+++ b/dashboard/frontend/src/hooks/useConversations.js
@@ -47,5 +47,12 @@ export default function useConversations() {
     await refresh()
   }, [refresh])
 
-  return { conversations, loading, refresh, create, remove, removeMany, rename }
+  // In-place patch — used by the SSE conversation_updated handler so the
+  // server-pushed auto-title lands in the sidebar without a full refetch
+  // (and without racing one).
+  const patchConversation = useCallback((id, patch) => {
+    setConversations(prev => prev.map(c => c.id === id ? { ...c, ...patch } : c))
+  }, [])
+
+  return { conversations, loading, refresh, create, remove, removeMany, rename, patchConversation }
 }

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -8,7 +8,7 @@ const API_BASE = window.location.hostname === 'localhost' || window.location.hos
  * Stream a chat completion via SSE.
  * Uses fetch + ReadableStream because EventSource doesn't support auth headers.
  */
-export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolResult, onArtifact, signal, method = 'POST' }) {
+export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolResult, onArtifact, onConversationUpdated, signal, method = 'POST' }) {
   const token = getToken()
   if (!token) throw new Error('Not authenticated')
 
@@ -73,6 +73,10 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
           }
           if (parsed.type === 'artifact') {
             onArtifact?.(parsed)
+            continue
+          }
+          if (parsed.type === 'conversation_updated') {
+            onConversationUpdated?.(parsed)
             continue
           }
 


### PR DESCRIPTION
## Summary

Two related chat-UX fixes:

1. **Auto-titles now appear in the sidebar without a refetch race** — the first-turn title was being generated in a Python daemon thread spawned *after* the SSE response had already closed. The existing ChatPage \`useEffect [streaming] -> refresh()\` fires on \`message_saved\` (strictly before the daemon's model call + DB write completes), so it kept getting \"New Conversation\" back. The title only landed on the next navigation/reload.

   Fix: run title gen inline at the tail of the same SSE response, then emit one more \`{type: \"conversation_updated\", id, title}\` event over the open pipe. Frontend patches the conversations list in place via a new \`patchConversation\` helper on \`useConversations\`. No extra HTTP roundtrip, no per-conversation pub-sub channel, no polling.

   Cost: SSE response stays open ~1–3s longer than today. \`streaming\` still flips false on \`message_saved\`, so the input box re-enables and the user can fire the next turn immediately — that turn just queues behind title gen at the inference layer (a serialization that already existed at the single-slot model).

   Subtle correctness bits:
   - The existing \`title != \"New Conversation\"\` guard is preserved AND re-checked immediately before the DB write, so a manual rename arriving DURING the model call still wins.
   - Title-gen wrapped in try/except — failures can't abort the assistant response.
   - The existing \`[streaming] -> refresh()\` effect is kept for \`updated_at\` ordering; the SSE event arrives strictly after that refresh, so last-write-wins is correct.
   - Dropped unused \`threading\` import.

2. **Conversation checkbox hit area** — the 14px input inside the 28px slot meant clicks landing in the slot but not on the input fell through to the row's \`onSelect\` (selecting the conversation instead of toggling). Slot is now 32px and is itself the toggle target when the checkbox is shown.

## Files

- \`dashboard/chat/routes.py\` — \`_auto_generate_title\` refactored to sync + return-the-title; \`send_message.generate()\` calls it inline and yields the event.
- \`dashboard/frontend/src/services/sse.js\` — new \`onConversationUpdated\` handler.
- \`dashboard/frontend/src/hooks/useChat.js\` — accepts \`{ onConversationUpdated }\`, forwards to both \`streamChat\` calls.
- \`dashboard/frontend/src/hooks/useConversations.js\` — new \`patchConversation(id, patch)\`.
- \`dashboard/frontend/src/components/chat/ChatPage.jsx\` — wires \`patchConversation\` through \`useChat\`.
- \`dashboard/frontend/src/components/chat/ChatSidebar.jsx\` — enlarged checkbox slot + slot-as-target onClick.

## Test plan

- [ ] Restart the dashboard backend (route change).
- [ ] New conversation → send first message → sidebar entry flips from \"New Conversation\" to the model-generated title within ~1–3s of the assistant text rendering, no reload needed. DevTools Network: \`POST /api/chat/conversations/<id>/messages\` SSE stays open after the assistant text appears, then closes.
- [ ] Thinking model (Qwen reasoning service as \`main_service\`): title still generated (verifies the \`reasoning_content\` fallback).
- [ ] Manual rename mid-flight: rename the conversation while the assistant is still streaming the first turn — the manual title persists.
- [ ] Navigate away mid-flight: switch conversations the moment the assistant text fully renders. The DB row should still get the new title; the next \`refresh()\` shows it in the sidebar.
- [ ] Second message on the same conversation: no \`conversation_updated\` event fires (\`is_first\` is false server-side).
- [ ] Conversation checkbox: clicking anywhere in the slot toggles the checkbox; clicking the row outside the slot still navigates to the conversation.