### PR TITLE
feat(chat): Copy / Quote / Critique items in the selection context menu

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -36,6 +36,19 @@ export default function ChatArea({
   const [pendingInserts, setPendingInserts] = useState([])
   const [spinoffs, setSpinoffs] = useState([]) // [{id, text, minimized, zIndex}]
   const topZRef = useRef(100)
+  const composerRef = useRef(null)
+
+  const quoteSelection = useCallback((text) => {
+    if (!text) return
+    const quoted = text.split('\n').map(line => `> ${line}`).join('\n')
+    composerRef.current?.insertText(quoted)
+  }, [])
+
+  const critiqueSelection = useCallback((text) => {
+    if (!text) return
+    const quoted = text.split('\n').map(line => `> ${line}`).join('\n')
+    composerRef.current?.insertText(`Please critique the following:\n\n${quoted}`)
+  }, [])
 
   const createSpinoff = useCallback((text) => {
     const id = ++spinoffCounter
@@ -173,6 +186,7 @@ export default function ChatArea({
 
         {/* Input */}
         <ChatInput
+          ref={composerRef}
           onSend={(msg, images) => { onSend(msg, images); setPendingInserts([]) }}
           disabled={streaming || !conversation.main_service}
           pendingInserts={pendingInserts}
@@ -194,7 +208,11 @@ export default function ChatArea({
       )}
 
       {/* Context menu for text selection */}
-      <TextContextMenu onSpinoff={createSpinoff} />
+      <TextContextMenu
+        onSpinoff={createSpinoff}
+        onQuote={quoteSelection}
+        onCritique={critiqueSelection}
+      />
 
       {/* Spinoff windows */}
       {spinoffs.filter(s => !s.minimized).map(s => (

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -1,9 +1,21 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 
-export default function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert }) {
+const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert }, ref) {
   const [value, setValue] = useState('')
   const [images, setImages] = useState([]) // [{dataUrl, name, size}]
   const textareaRef = useRef(null)
+
+  // Imperative API for parents that want to inject text from outside the
+  // composer (e.g. the text-selection context menu's "Quote in reply" and
+  // "Critique this" actions). Prepends the snippet so an existing draft
+  // stays where the user left it, and re-focuses the textarea.
+  useImperativeHandle(ref, () => ({
+    insertText: (snippet) => {
+      if (!snippet) return
+      setValue(prev => prev ? `${snippet}\n\n${prev}` : snippet)
+      textareaRef.current?.focus()
+    },
+  }), [])
 
   useEffect(() => {
     if (!disabled && textareaRef.current) {
@@ -152,4 +164,6 @@ export default function ChatInput({ onSend, disabled, pendingInserts = [], onCle
       </form>
     </div>
   )
-}
+})
+
+export default ChatInput

--- a/dashboard/frontend/src/components/chat/TextContextMenu.jsx
+++ b/dashboard/frontend/src/components/chat/TextContextMenu.jsx
@@ -1,6 +1,27 @@
 import { useState, useEffect, useCallback } from 'react'
 
-export default function TextContextMenu({ onSpinoff }) {
+// Copies text to the clipboard. Falls back to a hidden textarea +
+// execCommand for insecure origins (HTTP through the tunnel) where
+// navigator.clipboard is unavailable. Mirrors the pattern in
+// CopyablePre.jsx.
+async function copyToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    try { await navigator.clipboard.writeText(text); return true } catch { /* fall through */ }
+  }
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.setAttribute('readonly', '')
+  ta.style.position = 'fixed'
+  ta.style.opacity = '0'
+  document.body.appendChild(ta)
+  ta.select()
+  let ok = false
+  try { ok = document.execCommand('copy') } catch { ok = false }
+  document.body.removeChild(ta)
+  return ok
+}
+
+export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
   const [menu, setMenu] = useState(null) // { x, y, text }
 
   const handleContextMenu = useCallback((e) => {
@@ -46,6 +67,36 @@ export default function TextContextMenu({ onSpinoff }) {
       >
         <i className="fa-solid fa-code-branch text-purple-400 text-xs"></i>
         Spin off...
+      </button>
+      <button
+        onClick={async () => {
+          await copyToClipboard(menu.text)
+          setMenu(null)
+        }}
+        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+      >
+        <i className="fa-solid fa-copy text-gray-400 text-xs"></i>
+        Copy
+      </button>
+      <button
+        onClick={() => {
+          onQuote?.(menu.text)
+          setMenu(null)
+        }}
+        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+      >
+        <i className="fa-solid fa-quote-right text-blue-400 text-xs"></i>
+        Quote in reply
+      </button>
+      <button
+        onClick={() => {
+          onCritique?.(menu.text)
+          setMenu(null)
+        }}
+        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+      >
+        <i className="fa-solid fa-magnifying-glass text-amber-400 text-xs"></i>
+        Critique this
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

The right-click menu on a text selection inside a chat message only offered \"Spin off...\". Adds three more items:

- **Copy** — clipboard write with an insecure-origin fallback (mirrors the pattern in \`CopyablePre.jsx\` for HTTP-over-tunnel access).
- **Quote in reply** — prepends a \`>\` markdown blockquote of the selection into the composer, leaving any existing draft in place.
- **Critique this** — prepends \`Please critique the following:\\n\\n> {quoted selection}\`. Uses the main model in the same conversation; a sidekick-style critique on arbitrary text would need a new endpoint since the existing \`critique()\` flow is keyed on a stored \`message_id\`.

## Mechanics

\`ChatInput\` gains an imperative \`insertText(snippet)\` API via \`forwardRef\` + \`useImperativeHandle\`. \`ChatArea\` holds a \`composerRef\` and the two new menu callbacks format the snippet and call into the ref. Prepending (rather than appending or replacing) preserves any draft.

## Files

- \`dashboard/frontend/src/components/chat/ChatInput.jsx\` — convert to \`forwardRef\`, expose \`insertText\`.
- \`dashboard/frontend/src/components/chat/ChatArea.jsx\` — wire \`composerRef\`, add \`quoteSelection\` and \`critiqueSelection\` callbacks.
- \`dashboard/frontend/src/components/chat/TextContextMenu.jsx\` — three new menu buttons + the local clipboard helper.

## Test plan

- [ ] Select text in any message, right-click → **Copy** → paste somewhere; matches the selection. Repeat with the dashboard reached over HTTP-only (insecure origin) — should still work via the fallback path.
- [ ] Select text, right-click → **Quote in reply** → composer textarea now contains the selection prefixed with \`> \` on each line and is focused. Type after — your reply lands below the quote.
- [ ] Same, but with text already in the composer — quote is prepended, your draft survives below it.
- [ ] Select multi-line text, → Quote — every line gets its own \`> \` prefix.
- [ ] **Critique this** → composer gets \`Please critique the following:\\n\\n> ...\`; sending fires a normal user turn at the main model.
- [ ] **Spin off...** still works exactly as before (regression check on the existing item).
- [ ] Right-click with no selection — browser default context menu still appears (no interception).