### PR TITLE
fix(chat): persist partial assistant response on client disconnect

### DIFF
--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -157,62 +157,142 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
 
     assistant_msg_id = str(uuid.uuid4())
     done = False
+    had_error = False              # gate _save_partial against the error path
+    saved_partial = False          # avoid double-save
+    accumulated_content = ""       # per-delta accumulators for partial-save
+    accumulated_reasoning = ""
     collected_tool_calls = []
     collected_artifacts = []
 
-    for event_type, data in stream:
-        if event_type == "delta":
-            yield f"data: {data['raw']}\n\n"
-        elif event_type == "tool_call":
-            collected_tool_calls.append({
-                "name": data["name"],
-                "arguments": data["arguments"],
-                "server_id": data["server_id"],
-            })
-            yield f"data: {json.dumps({'type': 'tool_call', 'name': data['name'], 'arguments': data['arguments'], 'server_id': data['server_id']})}\n\n"
-        elif event_type == "tool_result":
-            for tc in reversed(collected_tool_calls):
-                if tc["name"] == data["name"] and "result" not in tc:
-                    tc["result"] = data["result"]
-                    break
-            yield f"data: {json.dumps({'type': 'tool_result', 'name': data['name'], 'result': data['result'], 'server_id': data['server_id']})}\n\n"
-        elif event_type == "artifact":
-            collected_artifacts.append(data)
-            # Send artifact to frontend (without full content to keep SSE lean)
-            yield f"data: {json.dumps({'type': 'artifact', 'artifact_type': data['type'], 'title': data.get('title'), 'content': data['content']}, default=str)}\n\n"
-        elif event_type == "done":
-            next_seq = db.next_seq(conv.id)
-            assistant_msg = Message(
+    def _save_partial():
+        """Persist whatever we accumulated when the client disconnects mid-stream.
+
+        Called from the GeneratorExit handler and the finally clause. No-op
+        when the stream completed normally, errored, already saved, or never
+        produced any text. Includes stale-stream guards so an old
+        disconnected stream can't append a partial after newer state has
+        landed (a user edit or a fresh user turn).
+        """
+        nonlocal saved_partial
+        if saved_partial or done or had_error:
+            return
+        if not (accumulated_content or accumulated_reasoning):
+            return
+        # Stale-stream guard:
+        #   (1) user message deleted — edit_message at routes.py:340 calls
+        #       delete_messages_from_seq, dropping user_msg from the DB.
+        #   (2) newer messages have landed — next_seq advanced past
+        #       user_msg.seq, so a partial inserted now would attach after
+        #       unrelated history.
+        if db.get_message(user_msg.id) is None:
+            logger.info(
+                "Skipping partial-save for %s: user message %s no longer exists (edited?)",
+                assistant_msg_id, user_msg.id,
+            )
+            return
+        if db.next_seq(conv.id) - 1 != user_msg.seq:
+            logger.info(
+                "Skipping partial-save for %s: conversation advanced past user_msg.seq=%d",
+                assistant_msg_id, user_msg.seq,
+            )
+            return
+        try:
+            db.add_message(Message(
                 id=assistant_msg_id,
                 conversation_id=conv.id,
                 role="assistant",
-                content=data["content"],
-                reasoning_content=data["reasoning_content"],
+                content=accumulated_content,
+                reasoning_content=accumulated_reasoning or None,
                 model_service=conv.main_service,
-                tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
-                seq=next_seq,
-            )
-            db.add_message(assistant_msg)
-            # Save artifacts linked to this message
-            for art_data in collected_artifacts:
-                db.save_artifact(Artifact(
-                    id=str(uuid.uuid4()),
-                    message_id=assistant_msg_id,
-                    artifact_type=art_data["type"],
-                    content=art_data["content"],
-                    title=art_data.get("title"),
-                    language=art_data.get("language"),
-                ))
+                # Skip partial tool_calls: a tool_call without its result is
+                # misleading in the UI. Text content is the primary value.
+                seq=db.next_seq(conv.id),
+            ))
             db.touch_conversation(conv.id)
-            done = True
-            yield "data: [DONE]\n\n"
-            yield f"data: {json.dumps({'type': 'message_saved', 'message_id': assistant_msg_id, 'seq': next_seq})}\n\n"
-        elif event_type == "error":
-            yield f"data: {json.dumps({'error': data['message']})}\n\n"
-            return
+            saved_partial = True
+            logger.info(
+                "Saved partial assistant message %s (%d content chars, %d reasoning chars)",
+                assistant_msg_id, len(accumulated_content), len(accumulated_reasoning),
+            )
+        except Exception:
+            logger.exception("Failed to save partial assistant message on disconnect")
 
-    if not done:
-        yield f"data: {json.dumps({'error': 'Stream ended unexpectedly'})}\n\n"
+    try:
+        for event_type, data in stream:
+            if event_type == "delta":
+                accumulated_content += data.get("content", "") or ""
+                accumulated_reasoning += data.get("reasoning_content", "") or ""
+                yield f"data: {data['raw']}\n\n"
+            elif event_type == "tool_call":
+                collected_tool_calls.append({
+                    "name": data["name"],
+                    "arguments": data["arguments"],
+                    "server_id": data["server_id"],
+                })
+                yield f"data: {json.dumps({'type': 'tool_call', 'name': data['name'], 'arguments': data['arguments'], 'server_id': data['server_id']})}\n\n"
+            elif event_type == "tool_result":
+                for tc in reversed(collected_tool_calls):
+                    if tc["name"] == data["name"] and "result" not in tc:
+                        tc["result"] = data["result"]
+                        break
+                yield f"data: {json.dumps({'type': 'tool_result', 'name': data['name'], 'result': data['result'], 'server_id': data['server_id']})}\n\n"
+            elif event_type == "artifact":
+                collected_artifacts.append(data)
+                # Send artifact to frontend (without full content to keep SSE lean)
+                yield f"data: {json.dumps({'type': 'artifact', 'artifact_type': data['type'], 'title': data.get('title'), 'content': data['content']}, default=str)}\n\n"
+            elif event_type == "done":
+                next_seq = db.next_seq(conv.id)
+                assistant_msg = Message(
+                    id=assistant_msg_id,
+                    conversation_id=conv.id,
+                    role="assistant",
+                    content=data["content"],
+                    reasoning_content=data["reasoning_content"],
+                    model_service=conv.main_service,
+                    tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
+                    seq=next_seq,
+                )
+                db.add_message(assistant_msg)
+                # Flip done IMMEDIATELY after the assistant row is in. If an
+                # artifact save throws below, the finally clause must NOT
+                # attempt a second insert with the same assistant_msg_id.
+                done = True
+                # Save artifacts linked to this message
+                for art_data in collected_artifacts:
+                    db.save_artifact(Artifact(
+                        id=str(uuid.uuid4()),
+                        message_id=assistant_msg_id,
+                        artifact_type=art_data["type"],
+                        content=art_data["content"],
+                        title=art_data.get("title"),
+                        language=art_data.get("language"),
+                    ))
+                db.touch_conversation(conv.id)
+                yield "data: [DONE]\n\n"
+                yield f"data: {json.dumps({'type': 'message_saved', 'message_id': assistant_msg_id, 'seq': next_seq})}\n\n"
+            elif event_type == "error":
+                # Set had_error BEFORE yielding — a client disconnect during
+                # the yield would otherwise fire GeneratorExit -> finally
+                # without the flag set, and a server-side model failure with
+                # accumulated deltas would still write a partial.
+                had_error = True
+                yield f"data: {json.dumps({'error': data['message']})}\n\n"
+                return
+
+        if not done:
+            yield f"data: {json.dumps({'error': 'Stream ended unexpectedly'})}\n\n"
+    except GeneratorExit:
+        # Client disconnected mid-stream (navigation, tab close, network
+        # drop). Flask raises this at the next yield after the WSGI layer
+        # notices the broken socket. Persist whatever we have so the user
+        # doesn't lose the in-progress reply when they return.
+        _save_partial()
+        raise                       # MUST re-raise so the generator closes
+    finally:
+        # Belt and suspenders: any non-GeneratorExit exit that didn't already
+        # save still tries to flush. No-op when done=True, had_error=True,
+        # or already saved.
+        _save_partial()
 
 
 def _auto_generate_title(db, conv_id: str, first_user_content: str, service_name: str) -> Optional[str]:

--- a/dashboard/tests/test_partial_save.py
+++ b/dashboard/tests/test_partial_save.py
@@ -1,0 +1,195 @@
+"""Tests for save-on-disconnect in chat._stream_response.
+
+When the client aborts mid-stream (navigation, tab close, network drop),
+the assistant message we'd have eventually written should still land in
+the DB with whatever was generated so far — so the user doesn't lose
+visible work when they come back. The guard logic also has to prevent
+stale streams from overwriting newer state.
+"""
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-partial-save")
+
+from chat import routes
+from chat.db import ChatDB
+from chat.models import Conversation, Message
+
+
+def _seed_conversation(db):
+    """Create a conversation in the DB and return (Conversation, user_msg)."""
+    conv = Conversation(
+        id=str(uuid.uuid4()),
+        title="t",
+        main_service="test-service",
+    )
+    db.create_conversation(conv)
+    user_msg = Message(
+        id=str(uuid.uuid4()),
+        conversation_id=conv.id,
+        role="user",
+        content="hello",
+        seq=db.next_seq(conv.id),
+    )
+    return conv, user_msg
+
+
+def _delta(content, raw=None):
+    """Build a delta tuple matching what stream_chat_completion yields."""
+    return ("delta", {"content": content, "reasoning_content": "", "raw": raw or json.dumps({"choices": [{"delta": {"content": content}}]})})
+
+
+def _patch_stream(monkeypatch, stream_factory):
+    """Replace both stream_chat_completion and stream_with_tools with the same stub.
+
+    stream_factory() returns a fresh generator each time so the test can
+    re-invoke _stream_response in the same process without exhausting a
+    one-shot iterator.
+    """
+    def _wrapper(*args, **kwargs):
+        return stream_factory()
+    monkeypatch.setattr(routes, "stream_chat_completion", _wrapper)
+    monkeypatch.setattr(routes, "stream_with_tools", _wrapper)
+
+
+def test_partial_save_persists_accumulated_deltas_on_disconnect(monkeypatch, tmp_path):
+    """A close() after consuming some deltas should leave the partial in DB."""
+    db = ChatDB(":memory:")
+    conv, user_msg = _seed_conversation(db)
+
+    def stub():
+        yield _delta("hello ")
+        yield _delta("world")
+        # block forever — simulates a still-generating model
+        while True:
+            yield _delta("")  # never reached after close() but keeps the generator alive
+
+    _patch_stream(monkeypatch, stub)
+
+    gen = routes._stream_response(db, conv, user_msg)
+    # Consume two deltas + the upstream "yields" forwarded to SSE.
+    next(gen)
+    next(gen)
+    gen.close()
+
+    msgs = db.get_messages(conv.id)
+    assert len(msgs) == 2, f"expected user + partial assistant, got {len(msgs)}"
+    assistant = msgs[1]
+    assert assistant.role == "assistant"
+    assert assistant.content == "hello world"
+    assert assistant.model_service == "test-service"
+
+
+def test_close_before_any_delta_writes_nothing(monkeypatch, tmp_path):
+    """Disconnect with no deltas accumulated must NOT write a partial.
+
+    Drives the generator to its first yield via a tool_call (which doesn't
+    accumulate content), then closes. The user message gets persisted
+    inside _stream_response, but no assistant row should appear.
+    """
+    db = ChatDB(":memory:")
+    conv, user_msg = _seed_conversation(db)
+
+    def stub():
+        yield ("tool_call", {"name": "noop", "arguments": {}, "server_id": "x"})
+        while True:
+            yield ("tool_call", {"name": "noop", "arguments": {}, "server_id": "x"})
+
+    _patch_stream(monkeypatch, stub)
+
+    gen = routes._stream_response(db, conv, user_msg)
+    next(gen)  # advances past user-msg insert and the first tool_call yield
+    gen.close()
+
+    msgs = db.get_messages(conv.id)
+    assert len(msgs) == 1, f"expected only user message, got {len(msgs)}: {[m.role for m in msgs]}"
+    assert msgs[0].role == "user"
+
+
+def test_error_event_does_not_save_partial(monkeypatch, tmp_path):
+    """A model-side error after some deltas must NOT write a partial assistant row."""
+    db = ChatDB(":memory:")
+    conv, user_msg = _seed_conversation(db)
+
+    def stub():
+        yield _delta("partial answer")
+        yield ("error", {"message": "model exploded"})
+
+    _patch_stream(monkeypatch, stub)
+
+    gen = routes._stream_response(db, conv, user_msg)
+    # Drain to completion — the error branch will yield then return.
+    sse_events = list(gen)
+
+    # Sanity: the error event was delivered to the client.
+    assert any('"error"' in e for e in sse_events), sse_events
+
+    msgs = db.get_messages(conv.id)
+    assert len(msgs) == 1, f"error path must not save a partial, got {len(msgs)}"
+    assert msgs[0].role == "user"
+
+
+def test_stale_stream_skips_save_when_user_msg_deleted(monkeypatch, tmp_path, caplog):
+    """If the user message was deleted mid-stream (e.g. edit), drop the partial."""
+    db = ChatDB(":memory:")
+    conv, user_msg = _seed_conversation(db)
+
+    deleted = {"flag": False}
+
+    def stub():
+        yield _delta("hello")
+        # Between this and the next yield the test will delete the user msg
+        # and close the generator. The partial-save check sees user_msg
+        # missing and skips.
+        deleted["flag"] = True
+        while True:
+            yield _delta("")
+
+    _patch_stream(monkeypatch, stub)
+
+    gen = routes._stream_response(db, conv, user_msg)
+    next(gen)  # forwards "hello"
+    next(gen)  # triggers the deletion flag inside stub; "" is forwarded as a delta
+
+    # Now simulate the edit: drop the user message (and any descendants).
+    db.delete_messages_from_seq(conv.id, user_msg.seq)
+    assert deleted["flag"]
+    assert db.get_message(user_msg.id) is None
+
+    import logging
+    with caplog.at_level(logging.INFO, logger="chat.routes"):
+        gen.close()
+
+    msgs = db.get_messages(conv.id)
+    assert len(msgs) == 0, f"stale partial must not be written; got {len(msgs)} rows"
+
+    # The skip log line should mention this assistant_msg_id was dropped.
+    assert any("no longer exists" in r.message for r in caplog.records), (
+        "expected a 'no longer exists' info log, got " + repr([r.message for r in caplog.records])
+    )
+
+
+def test_normal_completion_does_not_double_save(monkeypatch, tmp_path):
+    """The done branch already inserts; the finally must not write a second row."""
+    db = ChatDB(":memory:")
+    conv, user_msg = _seed_conversation(db)
+
+    def stub():
+        yield _delta("complete answer")
+        yield ("done", {"content": "complete answer", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+
+    gen = routes._stream_response(db, conv, user_msg)
+    list(gen)  # drain to completion (no close)
+
+    msgs = db.get_messages(conv.id)
+    assert len(msgs) == 2, f"expected user + one assistant, got {len(msgs)}"
+    assert msgs[1].role == "assistant"
+    assert msgs[1].content == "complete answer"


### PR DESCRIPTION
## Summary

When the model is still generating an assistant reply and the user navigates away — to another conversation, to a different route, or by closing the tab — Flask raises \`GeneratorExit\` at the next yield in \`_stream_response\` (\`dashboard/chat/routes.py:133\`). Previously the function exited without writing anything; the assistant message was only persisted inside the \`event_type == \"done\"\` branch, so any disconnect before \"done\" arrived left the DB with only the user message. Coming back to the conversation, the user saw an empty response slot.

This PR is the **safety-net layer** (Option A): accumulate deltas, save whatever was generated on disconnect. A separate follow-up could keep the SSE stream alive across in-app navigations (Option B), but the floor needs to be \"no data loss even if the laptop closes.\"

## Approach

Wrap the streaming \`for\` loop in \`try / except GeneratorExit / finally\`. Inside, two new accumulators (\`accumulated_content\`, \`accumulated_reasoning\`) gather what the upstream deltas already expose (\`stream_chat_completion\` yields content/reasoning per-delta — see \`llm_proxy.py:131-135\`). \`_save_partial()\` writes the assistant message to DB on disconnect, gated by:

- \`saved_partial\` — single-save invariant.
- \`done\` — normal-completion path owns the save, don't double-write.
- \`had_error\` — server-side model error path explicitly opts out.
- Non-empty accumulators — don't write a zero-byte row.
- **Stale-stream guards** — \`db.get_message(user_msg.id) is None\` (user message edited away) or \`db.next_seq(conv.id) - 1 != user_msg.seq\` (newer messages landed). Either drops the partial silently so an old disconnected stream can't append after fresh state.

## Subtle correctness fixes in the same function

- **\`done = True\` is flipped IMMEDIATELY after \`db.add_message(assistant_msg)\`** in the done branch — before artifact saves and \`touch_conversation\`. If an artifact save throws after the assistant row is inserted, the finally clause's \`_save_partial\` would otherwise attempt a second insert with the same \`assistant_msg_id\`, hit a PK collision, and log a misleading \"Failed to save partial\".

- **\`had_error = True\` is set BEFORE yielding the error SSE.** \`finally\` always runs after the error branch's \`return\`. If the client disconnects DURING the error yield, \`GeneratorExit\` fires and \`finally\` runs — without setting the flag first, a server-side model failure with accumulated deltas would still write a misleading partial.

## What this doesn't do (deliberate)

- Frontend keep-alive across conversation switches (Option B). With this PR landed, that becomes optional — the partial is in DB regardless of the frontend's abort behavior.
- Truncation marker on partial messages. Partial sentences self-identify; we can add an indicator later if confusing.
- Resume from a saved partial (would need model-specific state).
- Tool-result reattachment. Partial tool_calls (no result) are excluded from the saved row to avoid showing half a transaction.

## Tests

\`dashboard/tests/test_partial_save.py\` — 5 cases, all passing locally:

1. \`test_partial_save_persists_accumulated_deltas_on_disconnect\` — drives the generator, consumes two deltas, calls \`gen.close()\` (Python's equivalent of GeneratorExit). DB ends up with user + partial assistant carrying the accumulated content.
2. \`test_close_before_any_delta_writes_nothing\` — generator advances to a tool_call yield (no content), then close. No assistant row.
3. \`test_error_event_does_not_save_partial\` — stub yields some deltas then an error. \`had_error\` gate fires; no assistant row.
4. \`test_stale_stream_skips_save_when_user_msg_deleted\` — user message deleted mid-stream (simulating an edit racing the disconnect). Save is skipped with a \"no longer exists\" info log.
5. \`test_normal_completion_does_not_double_save\` — happy path; the finally clause is a no-op when done=True.

The 100 other backend tests still pass.

## Manual smoke (post-merge, requires running dashboard)

- [ ] Start a long generation, click another conversation mid-stream, wait, click back — partial assistant present.
- [ ] Same, but navigate to \`/v2/services\` and back — partial present.
- [ ] Same, but close the tab mid-stream — partial present after reopen.
- [ ] Normal completion produces exactly one assistant row (no double-save).
- [ ] Point the conversation at a stopped service and send — error flows through, no partial row.
- [ ] Edit the user message in tab B while tab A's stream is mid-flight — backend log shows \"Skipping partial-save for ... user message no longer exists\"; the original conv's history reflects the edit, not a phantom partial.