### PR TITLE
feat(chat): add Web Search MCP server (closes #13)

### DIFF
--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -5,6 +5,11 @@ import sys
 
 _SERVERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_servers")
 
+_WEBSEARCH_MCP_ROOT = os.environ.get(
+    "LLM_DOCK_WEBSEARCH_MCP_ROOT",
+    "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp",
+)
+
 MCP_SERVERS = {
     "sympy-math": {
         "name": "SymPy Math",
@@ -120,6 +125,18 @@ Important rules:
 - Prioritize clean, readable layout over compact layout. Spread components out.
 
 The diagram will be rendered automatically as an artifact.""",
+    },
+    "websearch": {
+        "name": "Web Search",
+        "description": "Search the web via the configured websearch MCP provider (SerpAPI / Exa)",
+        "command": [
+            os.path.join(_WEBSEARCH_MCP_ROOT, ".venv/bin/python"),
+            os.path.join(_WEBSEARCH_MCP_ROOT, "main.py"),
+            "--transport",
+            "stdio",
+        ],
+        "icon": "fa-magnifying-glass",
+        "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details.",
     },
 }
 

--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -137,17 +137,44 @@ The diagram will be rendered automatically as an artifact.""",
         ],
         "icon": "fa-magnifying-glass",
         "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details.",
+        # External — only enable when the configured executable exists.
+        # Without this gate the UI would advertise the toggle and the system
+        # prompt would tell the model it has web_search even when tool
+        # discovery fails silently (mcp_client returns []), risking
+        # fabricated "I searched the web" answers.
+        "external": True,
     },
 }
 
 
+def _server_available(server_id: str, server: dict) -> bool:
+    """Return False for external servers whose configured executable is missing.
+
+    Built-in servers (no `external` flag) are always treated as available;
+    they live inside this repo and run under the dashboard's own interpreter.
+    """
+    if not server.get("external"):
+        return True
+    command = server.get("command") or []
+    if not command:
+        return False
+    return os.path.exists(command[0])
+
+
 def get_tool_hints(server_ids: list) -> str:
-    """Build a system prompt suffix describing enabled tools."""
+    """Build a system prompt suffix describing enabled tools.
+
+    Skips servers whose executable isn't present — otherwise the model would
+    be told it has a tool that tool discovery can't actually surface.
+    """
     hints = []
     for sid in server_ids:
         server = MCP_SERVERS.get(sid)
-        if server and server.get("tool_hint"):
-            hints.append(server["tool_hint"])
+        if not server or not server.get("tool_hint"):
+            continue
+        if not _server_available(sid, server):
+            continue
+        hints.append(server["tool_hint"])
     return "\n\n".join(hints)
 
 
@@ -156,9 +183,15 @@ def list_available_servers() -> list:
     return [
         {"id": sid, "name": s["name"], "description": s["description"], "icon": s["icon"]}
         for sid, s in MCP_SERVERS.items()
+        if _server_available(sid, s)
     ]
 
 
 def get_server_config(server_id: str) -> dict:
-    """Get the config for a specific server."""
-    return MCP_SERVERS.get(server_id)
+    """Get the config for a specific server, or None if unavailable."""
+    server = MCP_SERVERS.get(server_id)
+    if server is None:
+        return None
+    if not _server_available(server_id, server):
+        return None
+    return server


### PR DESCRIPTION
## Summary

Registers `websearch-mcp` as an optional stdio MCP server in the chat tool registry. With the toggle enabled in a conversation, the model gets access to a `web_search(query, n_results=10)` tool routed through the existing OpenAI-style tool-calling bridge.

- New `websearch` entry in `dashboard/chat/mcp_registry.py` (name "Web Search", icon `fa-magnifying-glass`).
- Path resolves from `LLM_DOCK_WEBSEARCH_MCP_ROOT` env var (defaults to `/github/teo-mateo/ai-toolbox/mcp/websearch-mcp`), so the absolute path isn't baked in for other hosts.
- Uses the websearch package's own venv (`.venv/bin/python`) so llm-dock doesn't have to absorb `exa-py` / `httpx` / etc.
- Search-provider config (`SEARCH_ENGINE`, `SERPAPI_API_KEY`, `EXA_API_KEY`) stays in `websearch-mcp/.env` — llm-dock does not duplicate or own those keys.
- No frontend changes needed: the toggle list is built from `GET /api/chat/mcp-servers`, which the registry already feeds.

The websearch package's prior fix to route startup status to `sys.stderr` is already in place upstream, so stdout stays clean JSON-RPC.

## Test plan

- [x] Registry loads — `list_available_servers()` returns `websearch`.
- [x] Tool discovery via stdio works — `MCPClientManager.get_tools('websearch')` returns the `web_search` tool with the right JSON schema.
- [x] Stdout is clean JSON-RPC; startup status lines go to stderr.
- [ ] In the chat UI, enable Web Search on a conversation, ask "What's the current price of Bitcoin?" and confirm `tool_call` / `tool_result` events fire and the assistant uses the result.
- [ ] No MCP parse errors in dashboard logs after a real round-trip.