### PR TITLE
feat(chat): add Render HTML MCP server (closes #15)

### DIFF
--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -10,6 +10,11 @@ _WEBSEARCH_MCP_ROOT = os.environ.get(
     "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp",
 )
 
+_RENDER_HTML_MCP_COMMAND = os.environ.get(
+    "LLM_DOCK_RENDER_HTML_MCP_COMMAND",
+    "/github/teo-mateo/ai-toolbox/mcp/render-html-mcp/.venv/bin/render-html-mcp",
+)
+
 MCP_SERVERS = {
     "sympy-math": {
         "name": "SymPy Math",
@@ -142,6 +147,14 @@ The diagram will be rendered automatically as an artifact.""",
         # prompt would tell the model it has web_search even when tool
         # discovery fails silently (mcp_client returns []), risking
         # fabricated "I searched the web" answers.
+        "external": True,
+    },
+    "render-html": {
+        "name": "Render HTML",
+        "description": "Render HTML or Markdown in a local desktop browser window (requires GUI session)",
+        "command": [_RENDER_HTML_MCP_COMMAND],
+        "icon": "fa-window-restore",
+        "tool_hint": "You can render HTML or Markdown in a local desktop browser window when the user asks for a preview of a document, report, table, chart, or any formatted output. Prefer render_html for generated HTML you've just produced and render_html_from_markdown for generated markdown. The *_from_file variants open arbitrary local paths — only use them when the user has explicitly named a file to open, never on a path you inferred or guessed. The tool requires a graphical session; if it returns a DISPLAY/WAYLAND error, tell the user the dashboard is running headless and stop trying.",
         "external": True,
     },
 }


### PR DESCRIPTION
## Summary

Registers `render-html-mcp` as an optional stdio MCP server. With the toggle on, the model can render generated HTML or Markdown in a local desktop browser window through any of four tools: `render_html`, `render_html_from_file`, `render_html_from_markdown`, `render_html_from_markdown_file`.

- New `render-html` entry in `dashboard/chat/mcp_registry.py`, icon `fa-window-restore`.
- Command path resolves from `LLM_DOCK_RENDER_HTML_MCP_COMMAND` env var (defaults to the local checkout), so the absolute path isn't baked in for other hosts.
- Marked `external: True` so it picks up the existing executable-presence gate from PR #14 — on a host without the path, the toggle simply doesn't appear in the UI and no false `you-have-render-html` hint leaks into the system prompt.
- Search-side scope: all four tools are exposed (the registry has no per-tool filtering today). The `tool_hint` nudges the model toward the generated-content tools (`render_html`, `render_html_from_markdown`) and explicitly warns that the `*_from_file` variants are only for paths the user has named — never inferred or guessed. It also tells the model what to do if it sees a DISPLAY/WAYLAND error (i.e., stop trying).
- No frontend changes needed.

## Test plan

- [x] Registry lists `render-html` after the change.
- [x] `MCPClientManager.get_tools('render-html')` discovered all 4 tools cleanly over stdio.
- [x] Stdout stays clean JSON-RPC (no startup prints to stdout in the package).
- [ ] In the chat UI on a GUI session, enable Render HTML and ask for a small HTML/Markdown preview; confirm `tool_call` / `tool_result` events and a browser window opens.
- [ ] On a headless setup, confirm the tool returns a clean DISPLAY/WAYLAND error and the model surfaces it to the user instead of retrying.