### PR TITLE
feat(chat): replace external render-html-mcp with built-in artifact server

### DIFF
--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -10,11 +10,6 @@ _WEBSEARCH_MCP_ROOT = os.environ.get(
     "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp",
 )
 
-_RENDER_HTML_MCP_COMMAND = os.environ.get(
-    "LLM_DOCK_RENDER_HTML_MCP_COMMAND",
-    "/github/teo-mateo/ai-toolbox/mcp/render-html-mcp/.venv/bin/render-html-mcp",
-)
-
 MCP_SERVERS = {
     "sympy-math": {
         "name": "SymPy Math",
@@ -151,11 +146,10 @@ The diagram will be rendered automatically as an artifact.""",
     },
     "render-html": {
         "name": "Render HTML",
-        "description": "Render HTML or Markdown in a local desktop browser window (requires GUI session)",
-        "command": [_RENDER_HTML_MCP_COMMAND],
+        "description": "Render HTML or Markdown as an artifact in the chat",
+        "command": [sys.executable, os.path.join(_SERVERS_DIR, "render_html_server.py")],
         "icon": "fa-window-restore",
-        "tool_hint": "You can render HTML or Markdown in a local desktop browser window when the user asks for a preview of a document, report, table, chart, or any formatted output. Prefer render_html for generated HTML you've just produced and render_html_from_markdown for generated markdown. The *_from_file variants open arbitrary local paths — only use them when the user has explicitly named a file to open, never on a path you inferred or guessed. The tool requires a graphical session; if it returns a DISPLAY/WAYLAND error, tell the user the dashboard is running headless and stop trying.",
-        "external": True,
+        "tool_hint": "You can render HTML or Markdown directly in this chat window. Use render_html when you've produced an HTML document or fragment the user should see formatted (reports, tables, dashboards, mock UI, charts, etc.) — pass a complete <!doctype html> document if you want full control over styling, or just a fragment if you don't care. Use render_html_from_markdown when the content is markdown and you want it styled nicely without writing HTML yourself. The output appears as an artifact panel attached to your message, inside a sandboxed iframe — the user can also pop it out to a full-window tab. There is NO file-system access: you cannot pass paths, only literal content.",
     },
 }
 

--- a/dashboard/chat/mcp_servers/render_html_server.py
+++ b/dashboard/chat/mcp_servers/render_html_server.py
@@ -1,0 +1,116 @@
+"""Render HTML MCP Server — turn model-generated HTML or Markdown into
+chat artifacts that the dashboard renders in a sandboxed iframe.
+
+No native browser, no DISPLAY, no subprocess. Just emits the existing
+artifact convention (mcp_client.py:134-145) so the dashboard's
+ArtifactRenderer picks them up as `type: 'html'` artifacts.
+"""
+
+import json
+
+from markdown_it import MarkdownIt
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("render-html")
+
+_md = MarkdownIt("commonmark", {"html": True, "linkify": True, "typographer": True}).enable("table").enable("strikethrough")
+
+# Lean default stylesheet — readable defaults for markdown that wasn't
+# styled by the model. Kept small on purpose; the iframe lives inside
+# the chat UI and shouldn't compete visually with it.
+_DEFAULT_CSS = """
+body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       color: #1f2937; background: #fff; max-width: 760px; margin: 0 auto; padding: 1.25rem; }
+h1, h2, h3, h4 { line-height: 1.25; margin-top: 1.4em; margin-bottom: .5em; }
+h1 { font-size: 1.7em; border-bottom: 1px solid #e5e7eb; padding-bottom: .3em; }
+h2 { font-size: 1.35em; border-bottom: 1px solid #f1f5f9; padding-bottom: .25em; }
+h3 { font-size: 1.15em; }
+p, ul, ol, blockquote, table, pre { margin: .65em 0; }
+code { background: #f3f4f6; padding: .1em .35em; border-radius: 3px; font-size: .92em; }
+pre { background: #f3f4f6; padding: .75em 1em; border-radius: 6px; overflow-x: auto; }
+pre code { background: transparent; padding: 0; }
+blockquote { border-left: 3px solid #d1d5db; color: #4b5563; padding: 0 .9em; }
+table { border-collapse: collapse; }
+th, td { border: 1px solid #e5e7eb; padding: .35em .6em; text-align: left; }
+th { background: #f9fafb; }
+a { color: #2563eb; }
+img { max-width: 100%; }
+hr { border: 0; border-top: 1px solid #e5e7eb; margin: 1.5em 0; }
+"""
+
+
+def _wrap_document(body: str, title: str | None, *, inject_css: bool) -> str:
+    """Wrap a body fragment in a minimal HTML5 document.
+
+    `inject_css` is True for markdown (we own the styling) and False for
+    raw HTML the model produced (it likely brought its own styles).
+    """
+    css_block = f"<style>{_DEFAULT_CSS}</style>" if inject_css else ""
+    safe_title = (title or "Rendered").replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        "<!doctype html>\n"
+        '<html lang="en"><head>'
+        '<meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{safe_title}</title>"
+        f"{css_block}"
+        "</head><body>"
+        f"{body}"
+        "</body></html>"
+    )
+
+
+def _looks_like_document(html: str) -> bool:
+    head = html.lstrip()[:200].lower()
+    return head.startswith("<!doctype") or head.startswith("<html")
+
+
+@mcp.tool()
+def render_html(html: str, title: str = "Rendered HTML") -> str:
+    """Render HTML in a sandboxed iframe inside the chat window.
+
+    Pass a complete HTML document (starting with <!doctype html> or <html>)
+    OR a fragment — fragments are wrapped in a minimal HTML5 shell
+    automatically. Scripts run, but inside a sandbox that has no access
+    to the parent dashboard. The result appears as an artifact panel
+    attached to your message.
+    """
+    if _looks_like_document(html):
+        document = html
+    else:
+        # Don't inject the default CSS for raw HTML — the model probably
+        # styled it deliberately. Just supply a doctype + viewport shell.
+        document = _wrap_document(html, title, inject_css=False)
+
+    return json.dumps({
+        "artifact": True,
+        "type": "html",
+        "title": title,
+        "content": document,
+        "description": f"Rendered HTML artifact '{title}'.",
+    })
+
+
+@mcp.tool()
+def render_html_from_markdown(markdown: str, title: str = "Rendered Markdown") -> str:
+    """Render Markdown as HTML in a sandboxed iframe inside the chat window.
+
+    Accepts CommonMark plus tables and strikethrough. The output is
+    wrapped in a minimal stylesheet so headings, code blocks, and tables
+    look reasonable without further work. The result appears as an
+    artifact panel attached to your message.
+    """
+    body = _md.render(markdown)
+    document = _wrap_document(body, title, inject_css=True)
+
+    return json.dumps({
+        "artifact": True,
+        "type": "html",
+        "title": title,
+        "content": document,
+        "description": f"Rendered Markdown artifact '{title}'.",
+    })
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
+++ b/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
@@ -13,6 +13,15 @@ function downloadArtifact(artifact) {
   URL.revokeObjectURL(url)
 }
 
+function popoutArtifact(artifact) {
+  // Open the HTML in a new tab via a blob URL. Don't revoke immediately —
+  // the new window needs the URL alive until it has finished loading.
+  // The blob is small and short-lived in practice.
+  const blob = new Blob([artifact.content], { type: 'text/html' })
+  const url = URL.createObjectURL(blob)
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
 export default function ArtifactRenderer({ artifact }) {
   const [expanded, setExpanded] = useState(true)
   // Normalize: SSE sends artifact_type, DB sends type
@@ -33,6 +42,15 @@ export default function ArtifactRenderer({ artifact }) {
           <span className="text-gray-500 text-[10px]">{artType.toUpperCase()}</span>
         </div>
         <div className="flex items-center gap-1">
+          {artType === 'html' && (
+            <button
+              onClick={() => popoutArtifact(artifact)}
+              className="text-gray-500 hover:text-blue-400 px-1.5 py-0.5 rounded hover:bg-blue-500/10"
+              title="Pop out to new tab"
+            >
+              <i className="fa-solid fa-up-right-from-square text-[10px]"></i>
+            </button>
+          )}
           <button
             onClick={() => downloadArtifact(artifact)}
             className="text-gray-500 hover:text-blue-400 px-1.5 py-0.5 rounded hover:bg-blue-500/10"

--- a/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
+++ b/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
@@ -14,10 +14,29 @@ function downloadArtifact(artifact) {
 }
 
 function popoutArtifact(artifact) {
-  // Open the HTML in a new tab via a blob URL. Don't revoke immediately —
-  // the new window needs the URL alive until it has finished loading.
-  // The blob is small and short-lived in practice.
-  const blob = new Blob([artifact.content], { type: 'text/html' })
+  // A blob: URL inherits the dashboard's origin, so anything we open at
+  // the top level shares localStorage with the dashboard — and the
+  // bearer token lives there (api.js). Opening model-authored HTML as a
+  // top-level page would give it script access to the token. Instead,
+  // wrap the artifact in a tiny script-free shell whose only job is to
+  // host a sandboxed iframe; the model HTML runs inside the iframe with
+  // an opaque origin and cannot reach the dashboard's storage.
+  const escaped = artifact.content
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+  const title = (artifact.title || 'Artifact')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  const wrapper = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>${title}</title>
+<style>html,body{margin:0;height:100%;background:#fff}iframe{border:0;width:100%;height:100%}</style>
+</head><body>
+<iframe srcdoc="${escaped}" sandbox="allow-scripts"></iframe>
+</body></html>`
+  const blob = new Blob([wrapper], { type: 'text/html' })
   const url = URL.createObjectURL(blob)
   window.open(url, '_blank', 'noopener,noreferrer')
 }

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -9,6 +9,7 @@ import ThinkingBlock from './ThinkingBlock'
 import CritiqueButton from './CritiqueButton'
 import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
+import { formatArgValue } from './toolCallUtils'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -63,7 +64,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 {tc.arguments && Object.keys(tc.arguments).length > 0 && (
                   <div className="text-gray-400 font-mono pl-5">
                     {Object.entries(tc.arguments).map(([k, v]) => (
-                      <div key={k}><span className="text-gray-500">{k}:</span> {String(v)}</div>
+                      <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
                     ))}
                   </div>
                 )}

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -8,6 +8,7 @@ import MessageBubble from './MessageBubble'
 import ThinkingBlock from './ThinkingBlock'
 import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
+import { formatArgValue } from './toolCallUtils'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -87,7 +88,7 @@ export default function MessageList({
                         {evt.arguments && Object.keys(evt.arguments).length > 0 && (
                           <div className="text-gray-400 font-mono pl-5">
                             {Object.entries(evt.arguments).map(([k, v]) => (
-                              <div key={k}><span className="text-gray-500">{k}:</span> {String(v)}</div>
+                              <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
                             ))}
                           </div>
                         )}

--- a/dashboard/frontend/src/components/chat/toolCallUtils.js
+++ b/dashboard/frontend/src/components/chat/toolCallUtils.js
@@ -1,0 +1,14 @@
+const ARG_VALUE_MAX = 120
+
+export function formatArgValue(v) {
+  if (v == null) return String(v)
+  if (typeof v === 'string') {
+    const flat = v.replace(/\s+/g, ' ').trim()
+    return flat.length > ARG_VALUE_MAX ? flat.slice(0, ARG_VALUE_MAX) + '…' : flat
+  }
+  if (typeof v === 'object') {
+    const s = JSON.stringify(v)
+    return s.length > ARG_VALUE_MAX ? s.slice(0, ARG_VALUE_MAX) + '…' : s
+  }
+  return String(v)
+}

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -10,4 +10,5 @@ requests>=2.31.0
 mcp[cli]>=1.0.0
 sympy>=1.13.0
 schemdraw>=0.19
+markdown-it-py>=3.0.0
 prometheus-client>=0.20.0


### PR DESCRIPTION
## Summary

PR #17's external render-html-mcp opens a **native desktop browser** via `webbrowser.open()`. That doesn't work when the dashboard runs as a systemd service (no `DISPLAY` / `WAYLAND_DISPLAY` / `XAUTHORITY` in the process env), and even if it did, the `mcp` SDK's `get_default_environment()` only forwards `HOME, LOGNAME, PATH, SHELL, TERM, USER` to child processes — graphical-env vars get stripped before they reach the subprocess.

The user is already looking at a browser tab. So instead of opening *another* browser via subprocess, return the rendered HTML as a chat artifact and let `ArtifactRenderer.jsx` (which already supports `type: 'html'` with a sandboxed iframe) display it inline.

## Changes

- **New** `dashboard/chat/mcp_servers/render_html_server.py` — FastMCP server exposing:
  - `render_html(html, title)` — passes through full documents; wraps fragments in a minimal HTML5 shell.
  - `render_html_from_markdown(markdown, title)` — CommonMark + tables + strikethrough via the already-installed `markdown-it-py`, wrapped in a small default stylesheet so headings/code/tables look reasonable.
  - Both return the standard `{artifact: true, type: 'html', content, title, description}` JSON the existing pipeline recognizes (`mcp_client.py:134-145`).
- **Modified** `dashboard/chat/mcp_registry.py`:
  - Drops `_RENDER_HTML_MCP_COMMAND` / `LLM_DOCK_RENDER_HTML_MCP_COMMAND` indirection — server is in-tree now, under `sys.executable` like sympy/schemdraw.
  - Drops `external: True` from the entry. The `_server_available()` mechanism stays in place for the websearch entry.
  - Rewrites the tool hint around in-browser rendering. Drops the headless-error guidance and any mention of `*_from_file` (those tools are gone on purpose — local-file reads on the dashboard host had no value when rendering happens in the user's browser).
- **Modified** `dashboard/frontend/src/components/chat/ArtifactRenderer.jsx`:
  - Adds a "Pop out" button (only on `type: 'html'`) that opens the html in a new tab via `URL.createObjectURL` for users who want a full-window view. Trade-off: the popped-out tab is at a `blob:` origin and runs scripts with full privileges there; the inline iframe stays sandboxed. User has to click; same trust model as Download.

The external `ai-toolbox/mcp/render-html-mcp` package is untouched — anyone who wants the native-popup behavior outside llm-dock can still use it standalone.

## Test plan

- [x] Backend smoke: `MCPClientManager.get_tools('render-html')` returns 2 tools; `call_tool` for both returns an `html` artifact with content starting with `<!doctype html>`; markdown tool produces `<li>` and `<strong>` from list + bold input.
- [x] Frontend builds cleanly.
- [x] Restart dashboard, enable Render HTML on a conversation, ask the model for a small HTML report; expect an inline sandboxed iframe in the chat with Pop out + Download buttons.
- [x] Ask the model to render a markdown document; expect formatted output (headings, lists, code blocks) styled by the default CSS.
- [x] Reload the conversation; expect the artifact to re-render from the `artifacts` table.
- [x] Confirm "Pop out" opens a new tab with the same content full-width.