### PR TITLE
feat(mcp): declarative MCP registry + Tools dashboard page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ docker-compose.yml
 docker-compose.yml.backup
 docker-compose.lock
 
+# Machine-local MCP registry (declared external servers)
+dashboard/mcp_servers.json
+
 # Logs
 *.log
 dashboard/dashboard.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,53 @@ entries — but it also means a **typo** in the flag name (e.g. `--gpu-mem`)
 ships to the container as-is and fails at startup, not at config time.
 Verify with `mgr.preview_service(name)` before bringing the container up.
 
+## Adding an external MCP server
+
+Built-in MCP tools live in `dashboard/chat/mcp_registry.py` and ship with
+the repo. External MCP servers (machine-local — their venv, path, and
+config live outside this repo) are declared in a JSON file on disk,
+default `dashboard/mcp_servers.json` (gitignored). Override via
+`LLM_DOCK_MCP_SERVERS_FILE`.
+
+Shape — one entry per server id, top-level object keyed by id. See
+`dashboard/mcp_servers.example.json` for a working example.
+
+```json
+{
+  "my-tool": {
+    "enabled": true,
+    "name": "My Tool",
+    "description": "What the user sees in the chat toggle",
+    "command": "/abs/path/to/venv/bin/python",
+    "args": ["/abs/path/to/server.py", "--transport", "stdio"],
+    "icon": "fa-magnifying-glass",
+    "tool_hint": "System-prompt suffix telling the model when to use this tool."
+  }
+}
+```
+
+Rules enforced at load time:
+
+- `command` must be an **absolute path**. No `shell=True`, no PATH lookup.
+- `id` must not contain `__` (collides with `server_id__tool_name`
+  namespacing in `mcp_client.py`).
+- `id` must not collide with a built-in (`sympy-math`, `schemdraw-circuits`,
+  `render-html`). Built-ins always win.
+- All of `name`, `description`, `command`, `args`, `icon`, `tool_hint` are
+  required; `enabled` defaults to `true`.
+
+Editing the file:
+
+- **From the UI**: `/tools` page in the dashboard. Edit the JSON, hit Save
+  (server-side validation, atomic write, auto-reload), or fix on disk and
+  hit Reload from disk.
+- **From the CLI**: edit the file with your editor, then `curl -X POST
+  -H "Authorization: Bearer $TOKEN"
+  http://localhost:3399/api/chat/mcp-registry/reload`.
+
+Secrets stay in the external MCP server's own `.env`; the registry only
+holds paths.
+
 ## Reference: working embedding service
 
 `vllm-nomic-embed-text-v1.5` (port 3320) — see `services.json`. Smoke

--- a/dashboard/chat/mcp_admin_routes.py
+++ b/dashboard/chat/mcp_admin_routes.py
@@ -1,0 +1,179 @@
+"""Admin endpoints for the declarative MCP registry.
+
+Mounted on the same `chat_bp` blueprint as the rest of the chat API. All
+routes require the standard bearer auth. None of these handlers echo
+process environment or secrets back to the client — the only things
+returned are the configured `command` + `args` (which are paths the user
+already chose) and tool metadata produced by the MCP server itself.
+"""
+
+import json
+import logging
+import os
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+from flask import current_app, jsonify, request
+
+from auth import require_auth
+from . import mcp_config
+from .mcp_client import MCPClientManager
+from .mcp_registry import MCP_SERVERS as BUILTIN
+from .routes import chat_bp
+
+logger = logging.getLogger(__name__)
+
+DISCOVER_TIMEOUT = 5.0
+CALL_TIMEOUT = 10.0
+
+
+def _get_mcp() -> MCPClientManager:
+    return current_app.config["MCP_MANAGER"]
+
+
+def _registry_view(state: dict) -> dict:
+    """Build the public registry view.
+
+    Built-in entries don't include `command` — it's a Python path inside
+    the repo, uninteresting to the user and just noise in the UI. External
+    entries include their command + args (the configured executable path
+    is the whole point of the external registry).
+    """
+    servers = []
+    merged = state["merged"]
+    for sid, cfg in merged.items():
+        is_builtin = sid in BUILTIN and not cfg.get("external")
+        entry = {
+            "id": sid,
+            "name": cfg["name"],
+            "description": cfg["description"],
+            "icon": cfg["icon"],
+            "source": "built-in" if is_builtin else "external",
+            "enabled": bool(cfg.get("enabled", True)),
+        }
+        if not is_builtin:
+            cmd = cfg["command"]
+            entry["command"] = cmd[0]
+            entry["args"] = cmd[1:]
+        servers.append(entry)
+    return {
+        "servers": servers,
+        "external_errors": list(state.get("external_errors", [])),
+        "load_error": state.get("load_error"),
+        "config_file": mcp_config.config_file_path(),
+    }
+
+
+@chat_bp.route("/api/chat/mcp-registry", methods=["GET"])
+@require_auth
+def get_mcp_registry():
+    return jsonify(_registry_view(mcp_config.get_state()))
+
+
+@chat_bp.route("/api/chat/mcp-registry/json", methods=["GET"])
+@require_auth
+def get_mcp_registry_json():
+    path = mcp_config.config_file_path()
+    if not os.path.exists(path):
+        return jsonify({"content": "", "path": path})
+    try:
+        with open(path, "r") as f:
+            content = f.read()
+    except OSError as e:
+        return jsonify({"error": f"cannot read {path}: {e}"}), 500
+    return jsonify({"content": content, "path": path})
+
+
+@chat_bp.route("/api/chat/mcp-registry/json", methods=["PUT"])
+@require_auth
+def put_mcp_registry_json():
+    data = request.get_json(silent=True) or {}
+    content = data.get("content")
+    if not isinstance(content, str):
+        return jsonify({"error": "body must be {content: string}"}), 400
+
+    ok, errors, load_error = mcp_config.write_external_json(content)
+    if not ok:
+        body = {"error": "validation failed"}
+        if errors:
+            body["entry_errors"] = errors
+        if load_error:
+            body["load_error"] = load_error
+        return jsonify(body), 400
+
+    return jsonify(_registry_view(mcp_config.get_state()))
+
+
+@chat_bp.route("/api/chat/mcp-registry/reload", methods=["POST"])
+@require_auth
+def reload_mcp_registry():
+    state = mcp_config.reload()
+    return jsonify(_registry_view(state))
+
+
+@chat_bp.route("/api/chat/mcp-registry/test", methods=["POST"])
+@require_auth
+def test_mcp_registry():
+    data = request.get_json(silent=True) or {}
+    server_id = data.get("server_id")
+    tool_name = data.get("tool_name")
+    arguments = data.get("arguments") or {}
+
+    if not isinstance(server_id, str) or not server_id:
+        return jsonify({"error": "server_id is required"}), 400
+    if tool_name is not None and not isinstance(tool_name, str):
+        return jsonify({"error": "tool_name must be a string"}), 400
+    if not isinstance(arguments, dict):
+        return jsonify({"error": "arguments must be an object"}), 400
+
+    cfg = mcp_config.get_config(server_id)
+    if cfg is None:
+        return jsonify({"error": f"unknown or disabled server '{server_id}'"}), 404
+
+    mgr = _get_mcp()
+
+    if tool_name is None:
+        # Discovery — list_tools only.
+        try:
+            tools = mgr.run_with_timeout(mgr._discover_tools(cfg, server_id), DISCOVER_TIMEOUT)
+        except FuturesTimeoutError:
+            return jsonify({"ok": False, "error": f"timed out after {DISCOVER_TIMEOUT}s"}), 200
+        except Exception as e:
+            logger.exception("MCP test discover failed for %s", server_id)
+            return jsonify({"ok": False, "error": str(e)}), 200
+        return jsonify({
+            "ok": True,
+            "tools": [
+                {
+                    "name": t["function"]["name"].split("__", 1)[-1],
+                    "namespaced_name": t["function"]["name"],
+                    "description": t["function"].get("description", ""),
+                    "parameters": t["function"].get("parameters", {}),
+                }
+                for t in tools
+            ],
+        })
+
+    # Call.
+    try:
+        result_text, artifacts = mgr.run_with_timeout(
+            mgr._execute_tool(cfg, tool_name, arguments), CALL_TIMEOUT
+        )
+    except FuturesTimeoutError:
+        return jsonify({"ok": False, "error": f"timed out after {CALL_TIMEOUT}s"}), 200
+    except Exception as e:
+        logger.exception("MCP test call failed for %s.%s", server_id, tool_name)
+        return jsonify({"ok": False, "error": str(e)}), 200
+
+    return jsonify({
+        "ok": True,
+        "result_text": result_text,
+        "artifacts": [
+            {
+                "type": a.get("type"),
+                "title": a.get("title"),
+                "language": a.get("language"),
+                "content_size": len(a.get("content", "")) if isinstance(a.get("content"), str) else 0,
+            }
+            for a in artifacts
+        ],
+    })

--- a/dashboard/chat/mcp_admin_routes.py
+++ b/dashboard/chat/mcp_admin_routes.py
@@ -54,6 +54,9 @@ def _registry_view(state: dict) -> dict:
             cmd = cfg["command"]
             entry["command"] = cmd[0]
             entry["args"] = cmd[1:]
+            entry["command_exists"] = bool(cmd) and os.path.exists(cmd[0])
+        else:
+            entry["command_exists"] = True
         servers.append(entry)
     return {
         "servers": servers,

--- a/dashboard/chat/mcp_client.py
+++ b/dashboard/chat/mcp_client.py
@@ -61,10 +61,16 @@ class MCPClientManager:
 
         Exposed for one-shot admin operations (the Tools page test endpoint)
         that want a tighter deadline than the 30s default and don't want to
-        touch the cached chat path.
+        touch the cached chat path. On timeout, cancel the future so the
+        running coroutine (and its `stdio_client` subprocess) gets a chance
+        to clean up instead of leaking past the HTTP response.
         """
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout=timeout)
+        try:
+            return future.result(timeout=timeout)
+        except Exception:
+            future.cancel()
+            raise
 
     def get_tools(self, server_id: str) -> list:
         """Get tools for a server in OpenAI format. Uses cache."""

--- a/dashboard/chat/mcp_client.py
+++ b/dashboard/chat/mcp_client.py
@@ -56,6 +56,16 @@ class MCPClientManager:
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         return future.result(timeout=30)
 
+    def run_with_timeout(self, coro, timeout: float):
+        """Run a coroutine on the manager's event loop with a custom timeout.
+
+        Exposed for one-shot admin operations (the Tools page test endpoint)
+        that want a tighter deadline than the 30s default and don't want to
+        touch the cached chat path.
+        """
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
     def get_tools(self, server_id: str) -> list:
         """Get tools for a server in OpenAI format. Uses cache."""
         if server_id in self._tools_cache:

--- a/dashboard/chat/mcp_config.py
+++ b/dashboard/chat/mcp_config.py
@@ -1,0 +1,252 @@
+"""Declarative MCP server registry.
+
+Merges built-in MCP servers (defined in `mcp_registry.MCP_SERVERS`) with
+external servers declared in a JSON file on disk. The chat side of the app
+keeps talking to `mcp_registry`'s public API; this module is what backs it.
+
+External servers cover the case where the server lives outside this repo
+(its own venv, its own path, machine-local). They're declared in
+`LLM_DOCK_MCP_SERVERS_FILE` (default `dashboard/mcp_servers.json`) instead
+of in Python, so adding one is a config edit, not a code change + restart.
+"""
+
+import json
+import logging
+import os
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "mcp_servers.json",
+)
+
+REQUIRED_FIELDS = ("name", "description", "command", "args", "icon", "tool_hint")
+
+_lock = threading.Lock()
+_state = {
+    "merged": {},          # id -> normalized config dict
+    "external_errors": [], # [{"entry_id": str|None, "message": str}]
+    "load_error": None,    # top-level parse error string, if any
+}
+
+# Reference to the chat app's MCPClientManager. Set by `bind_manager` at
+# startup so reload() can invalidate the tool cache.
+_manager = None
+
+
+def config_file_path() -> str:
+    return os.environ.get("LLM_DOCK_MCP_SERVERS_FILE", DEFAULT_CONFIG_FILE)
+
+
+def bind_manager(manager) -> None:
+    """Wire the MCPClientManager so reload() can drop its tool cache."""
+    global _manager
+    _manager = manager
+
+
+def _validate_entry(server_id: str, entry: dict, builtin_ids: set) -> Optional[str]:
+    """Return None if valid, otherwise an error message."""
+    if not isinstance(server_id, str) or not server_id:
+        return "id must be a non-empty string"
+    if "__" in server_id:
+        return "id must not contain '__' (collides with tool-name namespacing)"
+    if server_id in builtin_ids:
+        return f"id '{server_id}' collides with a built-in server"
+    if not isinstance(entry, dict):
+        return "entry must be a JSON object"
+    for field in REQUIRED_FIELDS:
+        if field not in entry:
+            return f"missing required field '{field}'"
+    for field in ("name", "description", "icon", "tool_hint"):
+        if not isinstance(entry[field], str) or not entry[field]:
+            return f"field '{field}' must be a non-empty string"
+    if not isinstance(entry["command"], str) or not entry["command"]:
+        return "field 'command' must be a non-empty string"
+    if not os.path.isabs(entry["command"]):
+        return "field 'command' must be an absolute path"
+    if not isinstance(entry["args"], list) or not all(isinstance(a, str) for a in entry["args"]):
+        return "field 'args' must be a list of strings"
+    if "enabled" in entry and not isinstance(entry["enabled"], bool):
+        return "field 'enabled' must be a boolean"
+    return None
+
+
+def _normalize_external(server_id: str, entry: dict) -> dict:
+    return {
+        "name": entry["name"],
+        "description": entry["description"],
+        "command": [entry["command"], *entry["args"]],
+        "icon": entry["icon"],
+        "tool_hint": entry["tool_hint"],
+        "external": True,
+        "enabled": entry.get("enabled", True),
+    }
+
+
+def _load_external(builtin_ids: set):
+    """Read and validate the external file. Returns (entries, errors, load_error)."""
+    path = config_file_path()
+    if not os.path.exists(path):
+        return {}, [], None
+
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return {}, [], f"{path}: invalid JSON: {e}"
+    except OSError as e:
+        return {}, [], f"{path}: cannot read: {e}"
+
+    if not isinstance(data, dict):
+        return {}, [], f"{path}: top-level must be a JSON object keyed by server id"
+
+    entries = {}
+    errors = []
+    for server_id, entry in data.items():
+        err = _validate_entry(server_id, entry, builtin_ids)
+        if err is not None:
+            errors.append({"entry_id": server_id, "message": err})
+            continue
+        entries[server_id] = _normalize_external(server_id, entry)
+    return entries, errors, None
+
+
+def _merge(builtin: dict, external: dict) -> dict:
+    merged = {sid: {**cfg, "external": False, "enabled": True} for sid, cfg in builtin.items()}
+    for sid, cfg in external.items():
+        merged[sid] = cfg
+    return merged
+
+
+def reload() -> dict:
+    """Re-read the external file, refresh the merged registry, drop tool cache.
+
+    Returns the new state dict (merged + external_errors + load_error).
+    Safe to call from any thread.
+    """
+    from .mcp_registry import MCP_SERVERS as BUILTIN
+
+    with _lock:
+        builtin_ids = set(BUILTIN.keys())
+        external, errors, load_error = _load_external(builtin_ids)
+
+        # Don't drop the in-memory merged view on a top-level parse error —
+        # the user's editing the file and the dashboard should keep serving
+        # the last known-good config.
+        if load_error is not None:
+            _state["load_error"] = load_error
+            _state["external_errors"] = []
+            logger.warning("MCP registry external file failed to load: %s", load_error)
+            return _snapshot_locked()
+
+        _state["merged"] = _merge(BUILTIN, external)
+        _state["external_errors"] = errors
+        _state["load_error"] = None
+        for err in errors:
+            logger.warning("MCP registry external entry '%s' invalid: %s", err["entry_id"], err["message"])
+
+        if _manager is not None:
+            _manager.invalidate_cache()
+        return _snapshot_locked()
+
+
+def _snapshot_locked() -> dict:
+    return {
+        "merged": dict(_state["merged"]),
+        "external_errors": list(_state["external_errors"]),
+        "load_error": _state["load_error"],
+    }
+
+
+def get_registry() -> dict:
+    """Return the full merged registry (built-in + external, enabled and not)."""
+    with _lock:
+        if not _state["merged"]:
+            # Lazy init on first read so callers don't have to remember to
+            # invoke reload() at startup. After this the explicit reload()
+            # is what refreshes state.
+            pass
+    if not _state["merged"] and _state["load_error"] is None:
+        reload()
+    with _lock:
+        return dict(_state["merged"])
+
+
+def get_state() -> dict:
+    """Return a snapshot of the merged registry + any validation errors."""
+    if not _state["merged"] and _state["load_error"] is None:
+        reload()
+    with _lock:
+        return _snapshot_locked()
+
+
+def get_config(server_id: str) -> Optional[dict]:
+    """Return config for an enabled server, or None."""
+    reg = get_registry()
+    cfg = reg.get(server_id)
+    if cfg is None or not cfg.get("enabled", True):
+        return None
+    return cfg
+
+
+def list_enabled() -> list:
+    """Return [{id, name, description, icon}] for enabled servers."""
+    reg = get_registry()
+    return [
+        {"id": sid, "name": cfg["name"], "description": cfg["description"], "icon": cfg["icon"]}
+        for sid, cfg in reg.items()
+        if cfg.get("enabled", True)
+    ]
+
+
+def write_external_json(content: str) -> tuple:
+    """Validate and atomically write the external JSON file.
+
+    Returns (ok: bool, errors: list[dict], load_error: str|None).
+    On success, the file is replaced and the registry is reloaded.
+    On failure, the file is left untouched.
+    """
+    from .mcp_registry import MCP_SERVERS as BUILTIN
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        return False, [], f"invalid JSON: {e}"
+
+    if not isinstance(data, dict):
+        return False, [], "top-level must be a JSON object keyed by server id"
+
+    builtin_ids = set(BUILTIN.keys())
+    errors = []
+    for server_id, entry in data.items():
+        err = _validate_entry(server_id, entry, builtin_ids)
+        if err is not None:
+            errors.append({"entry_id": server_id, "message": err})
+    if errors:
+        return False, errors, None
+
+    path = config_file_path()
+    # Atomic write: tempfile in same dir, then os.replace. Same-dir is
+    # required so rename stays on one filesystem.
+    dir_path = os.path.dirname(path) or "."
+    os.makedirs(dir_path, exist_ok=True)
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except OSError as e:
+        # Best-effort cleanup of the tempfile.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return False, [], f"failed to write {path}: {e}"
+
+    reload()
+    return True, [], None

--- a/dashboard/chat/mcp_config.py
+++ b/dashboard/chat/mcp_config.py
@@ -133,10 +133,14 @@ def reload() -> dict:
         builtin_ids = set(BUILTIN.keys())
         external, errors, load_error = _load_external(builtin_ids)
 
-        # Don't drop the in-memory merged view on a top-level parse error —
-        # the user's editing the file and the dashboard should keep serving
-        # the last known-good config.
+        # On a top-level parse error: keep the previous external entries
+        # (the user is editing the file), but always re-merge built-ins so
+        # they survive even on a first-time load against a broken file.
         if load_error is not None:
+            previous_external = {
+                sid: cfg for sid, cfg in _state["merged"].items() if cfg.get("external")
+            }
+            _state["merged"] = _merge(BUILTIN, previous_external)
             _state["load_error"] = load_error
             _state["external_errors"] = []
             logger.warning("MCP registry external file failed to load: %s", load_error)
@@ -183,22 +187,40 @@ def get_state() -> dict:
         return _snapshot_locked()
 
 
+def _chat_available(cfg: dict) -> bool:
+    """Is this entry usable from the chat path?
+
+    Built-in entries are always available. External entries must be enabled
+    AND have an existing command on disk — otherwise the model would be
+    told it has a tool that tool discovery can't actually surface, risking
+    fabricated "I used the tool" answers. The Tools page reads the raw
+    state and still shows unavailable external entries so the user can
+    debug them.
+    """
+    if not cfg.get("enabled", True):
+        return False
+    if not cfg.get("external"):
+        return True
+    command = cfg.get("command") or []
+    return bool(command) and os.path.exists(command[0])
+
+
 def get_config(server_id: str) -> Optional[dict]:
-    """Return config for an enabled server, or None."""
+    """Return config for a chat-available server, or None."""
     reg = get_registry()
     cfg = reg.get(server_id)
-    if cfg is None or not cfg.get("enabled", True):
+    if cfg is None or not _chat_available(cfg):
         return None
     return cfg
 
 
 def list_enabled() -> list:
-    """Return [{id, name, description, icon}] for enabled servers."""
+    """Return [{id, name, description, icon}] for chat-available servers."""
     reg = get_registry()
     return [
         {"id": sid, "name": cfg["name"], "description": cfg["description"], "icon": cfg["icon"]}
         for sid, cfg in reg.items()
-        if cfg.get("enabled", True)
+        if _chat_available(cfg)
     ]
 
 

--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -1,14 +1,14 @@
-"""Registry of available MCP servers."""
+"""Built-in MCP servers.
+
+External servers (machine-local, declared in JSON) are layered on top of
+these by `mcp_config.py`. This file holds only the in-tree servers that
+ship with the repo and run under the dashboard's own interpreter.
+"""
 
 import os
 import sys
 
 _SERVERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_servers")
-
-_WEBSEARCH_MCP_ROOT = os.environ.get(
-    "LLM_DOCK_WEBSEARCH_MCP_ROOT",
-    "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp",
-)
 
 MCP_SERVERS = {
     "sympy-math": {
@@ -126,24 +126,6 @@ Important rules:
 
 The diagram will be rendered automatically as an artifact.""",
     },
-    "websearch": {
-        "name": "Web Search",
-        "description": "Search the web via the configured websearch MCP provider (SerpAPI / Exa)",
-        "command": [
-            os.path.join(_WEBSEARCH_MCP_ROOT, ".venv/bin/python"),
-            os.path.join(_WEBSEARCH_MCP_ROOT, "main.py"),
-            "--transport",
-            "stdio",
-        ],
-        "icon": "fa-magnifying-glass",
-        "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details.",
-        # External — only enable when the configured executable exists.
-        # Without this gate the UI would advertise the toggle and the system
-        # prompt would tell the model it has web_search even when tool
-        # discovery fails silently (mcp_client returns []), risking
-        # fabricated "I searched the web" answers.
-        "external": True,
-    },
     "render-html": {
         "name": "Render HTML",
         "description": "Render HTML or Markdown as an artifact in the chat",
@@ -154,51 +136,27 @@ The diagram will be rendered automatically as an artifact.""",
 }
 
 
-def _server_available(server_id: str, server: dict) -> bool:
-    """Return False for external servers whose configured executable is missing.
-
-    Built-in servers (no `external` flag) are always treated as available;
-    they live inside this repo and run under the dashboard's own interpreter.
-    """
-    if not server.get("external"):
-        return True
-    command = server.get("command") or []
-    if not command:
-        return False
-    return os.path.exists(command[0])
-
-
 def get_tool_hints(server_ids: list) -> str:
-    """Build a system prompt suffix describing enabled tools.
+    """Build a system prompt suffix describing enabled tools."""
+    from . import mcp_config
 
-    Skips servers whose executable isn't present — otherwise the model would
-    be told it has a tool that tool discovery can't actually surface.
-    """
     hints = []
     for sid in server_ids:
-        server = MCP_SERVERS.get(sid)
-        if not server or not server.get("tool_hint"):
-            continue
-        if not _server_available(sid, server):
-            continue
-        hints.append(server["tool_hint"])
+        cfg = mcp_config.get_config(sid)
+        if cfg and cfg.get("tool_hint"):
+            hints.append(cfg["tool_hint"])
     return "\n\n".join(hints)
 
 
 def list_available_servers() -> list:
-    """Return list of available MCP servers for the API."""
-    return [
-        {"id": sid, "name": s["name"], "description": s["description"], "icon": s["icon"]}
-        for sid, s in MCP_SERVERS.items()
-        if _server_available(sid, s)
-    ]
+    """Return list of enabled MCP servers for the API."""
+    from . import mcp_config
+
+    return mcp_config.list_enabled()
 
 
-def get_server_config(server_id: str) -> dict:
-    """Get the config for a specific server, or None if unavailable."""
-    server = MCP_SERVERS.get(server_id)
-    if server is None:
-        return None
-    if not _server_available(server_id, server):
-        return None
-    return server
+def get_server_config(server_id: str):
+    """Return the config for an enabled server, or None."""
+    from . import mcp_config
+
+    return mcp_config.get_config(server_id)

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -27,7 +27,7 @@ def init_chat(app, db_path: str = None):
     app.config["CHAT_DB"] = db
 
     from .mcp_client import MCPClientManager
-    from . import mcp_config, mcp_admin_routes  # noqa: F401  (admin routes register on chat_bp)
+    from . import mcp_config
     mgr = MCPClientManager()
     app.config["MCP_MANAGER"] = mgr
     mcp_config.bind_manager(mgr)
@@ -527,3 +527,11 @@ def spinoff():
 
     return Response(stream_with_context(generate()), mimetype="text/event-stream",
                     headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+
+
+# Register admin routes onto chat_bp at module-load time. Importing this
+# from inside init_chat() runs after app.register_blueprint(chat_bp), which
+# Flask 3 rejects with "The setup method 'route' can no longer be called on
+# the blueprint 'chat'". This bottom-of-file import runs while chat.routes
+# is being imported by app.py — before the blueprint is registered.
+from . import mcp_admin_routes  # noqa: E402,F401

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -27,7 +27,11 @@ def init_chat(app, db_path: str = None):
     app.config["CHAT_DB"] = db
 
     from .mcp_client import MCPClientManager
-    app.config["MCP_MANAGER"] = MCPClientManager()
+    from . import mcp_config, mcp_admin_routes  # noqa: F401  (admin routes register on chat_bp)
+    mgr = MCPClientManager()
+    app.config["MCP_MANAGER"] = mgr
+    mcp_config.bind_manager(mgr)
+    mcp_config.reload()
 
     logger.info("Chat subsystem initialized")
 

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import GpuMonitor from './components/GpuMonitor'
 import ServicesTable from './components/ServicesTable'
 import ServiceDetailsPage from './components/ServiceDetailsPage'
 import ChatPage from './components/chat/ChatPage'
+import ToolsPage from './components/tools/ToolsPage'
 
 function DefaultLayout({ children }) {
   return (
@@ -25,6 +26,7 @@ function App() {
         <Routes>
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/chat/:conversationId" element={<ChatPage />} />
+          <Route path="/tools" element={<DefaultLayout><ToolsPage /></DefaultLayout>} />
           <Route path="/" element={<DefaultLayout><GpuMonitor /><ServicesTable /></DefaultLayout>} />
           <Route path="/services/:serviceName/*" element={<DefaultLayout><ServiceDetailsPage /></DefaultLayout>} />
         </Routes>

--- a/dashboard/frontend/src/components/Sidebar.jsx
+++ b/dashboard/frontend/src/components/Sidebar.jsx
@@ -45,6 +45,19 @@ function Sidebar() {
           <i className="fa-solid fa-comments w-5 text-center"></i>
           <span>Chat</span>
         </NavLink>
+        <NavLink
+          to="/tools"
+          className={({ isActive }) =>
+            `flex items-center gap-3 px-4 py-2.5 ${
+              isActive
+                ? 'text-white bg-gray-800/70'
+                : 'text-gray-400 hover:bg-gray-800/50'
+            }`
+          }
+        >
+          <i className="fa-solid fa-toolbox w-5 text-center"></i>
+          <span>Tools</span>
+        </NavLink>
       </nav>
 
       {/* User section */}

--- a/dashboard/frontend/src/components/tools/RegistryEditor.jsx
+++ b/dashboard/frontend/src/components/tools/RegistryEditor.jsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react'
+
+const EXAMPLE = `{
+  "websearch": {
+    "enabled": true,
+    "name": "Web Search",
+    "description": "Search the web via the configured websearch MCP provider",
+    "command": "/abs/path/to/websearch-mcp/.venv/bin/python",
+    "args": ["/abs/path/to/websearch-mcp/main.py", "--transport", "stdio"],
+    "icon": "fa-magnifying-glass",
+    "tool_hint": "Use web_search for current/external information."
+  }
+}`
+
+export default function RegistryEditor({ initialContent, configPath, externalErrors, loadError, onSave, onReload }) {
+  const [content, setContent] = useState(initialContent || '')
+  const [dirty, setDirty] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [saveError, setSaveError] = useState(null)
+  const [saveEntryErrors, setSaveEntryErrors] = useState([])
+  const [savedNote, setSavedNote] = useState(null)
+
+  useEffect(() => {
+    if (!dirty) setContent(initialContent || '')
+  }, [initialContent, dirty])
+
+  function onChange(v) {
+    setContent(v)
+    setDirty(true)
+    setSaveError(null)
+    setSaveEntryErrors([])
+    setSavedNote(null)
+  }
+
+  async function handleSave() {
+    setBusy(true)
+    setSaveError(null)
+    setSaveEntryErrors([])
+    setSavedNote(null)
+    try {
+      await onSave(content)
+      setDirty(false)
+      setSavedNote('Saved')
+    } catch (e) {
+      setSaveError(e.message || 'Save failed')
+      setSaveEntryErrors(e.body?.entry_errors || [])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleReload() {
+    setBusy(true)
+    setSaveError(null)
+    setSaveEntryErrors([])
+    setSavedNote(null)
+    try {
+      await onReload()
+      setDirty(false)
+    } catch (e) {
+      setSaveError(e.message || 'Reload failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function handleDiscard() {
+    setContent(initialContent || '')
+    setDirty(false)
+    setSaveError(null)
+    setSaveEntryErrors([])
+    setSavedNote(null)
+  }
+
+  function handleInsertExample() {
+    setContent(content.trim() ? content : EXAMPLE)
+    setDirty(true)
+  }
+
+  return (
+    <div className="border border-gray-700 rounded bg-gray-900">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-700">
+        <div className="text-sm text-gray-300">
+          <i className="fa-solid fa-file-code mr-2 text-gray-500"></i>
+          External registry JSON
+          {configPath && (
+            <span className="ml-2 text-xs text-gray-500 font-mono">{configPath}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {savedNote && <span className="text-xs text-green-400">{savedNote}</span>}
+          {dirty && <span className="text-xs text-yellow-400">Unsaved</span>}
+          <button
+            onClick={handleInsertExample}
+            disabled={busy}
+            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+          >
+            Insert example
+          </button>
+          <button
+            onClick={handleDiscard}
+            disabled={busy || !dirty}
+            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+          >
+            Discard
+          </button>
+          <button
+            onClick={handleReload}
+            disabled={busy}
+            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+          >
+            Reload from disk
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={busy || !dirty}
+            className="text-xs px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+
+      <textarea
+        value={content}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        className="w-full h-72 bg-gray-950 text-gray-200 font-mono text-xs p-3 focus:outline-none resize-y"
+        placeholder='{ "my-tool": { "enabled": true, "name": "...", "command": "/abs/path", "args": [], ... } }'
+      />
+
+      {(loadError || saveError || (externalErrors && externalErrors.length > 0) || saveEntryErrors.length > 0) && (
+        <div className="px-3 py-2 border-t border-gray-700 text-xs space-y-1">
+          {loadError && (
+            <div className="text-red-400"><i className="fa-solid fa-triangle-exclamation mr-1"></i>Load: {loadError}</div>
+          )}
+          {saveError && (
+            <div className="text-red-400"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{saveError}</div>
+          )}
+          {saveEntryErrors.map((err, i) => (
+            <div key={`save-${i}`} className="text-red-300">
+              <span className="font-mono text-gray-500">{err.entry_id || '(top-level)'}:</span> {err.message}
+            </div>
+          ))}
+          {externalErrors && externalErrors.map((err, i) => (
+            <div key={`ext-${i}`} className="text-yellow-300">
+              <span className="font-mono text-gray-500">{err.entry_id || '(top-level)'}:</span> {err.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/tools/ServerTestPanel.jsx
+++ b/dashboard/frontend/src/components/tools/ServerTestPanel.jsx
@@ -1,0 +1,149 @@
+import { useState } from 'react'
+import { testServer } from '../../services/mcpRegistry'
+
+function ToolRow({ serverId, tool }) {
+  const [args, setArgs] = useState('{}')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState(null)
+  const [error, setError] = useState(null)
+
+  async function run() {
+    setBusy(true)
+    setError(null)
+    setResult(null)
+    let parsed
+    try {
+      parsed = JSON.parse(args || '{}')
+    } catch (e) {
+      setError(`Invalid JSON: ${e.message}`)
+      setBusy(false)
+      return
+    }
+    try {
+      const res = await testServer(serverId, tool.name, parsed)
+      if (!res.ok) {
+        setError(res.error || 'Tool call failed')
+      } else {
+        setResult(res)
+      }
+    } catch (e) {
+      setError(e.message || 'Request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="border border-gray-700 rounded bg-gray-900 p-3 space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <div>
+          <span className="font-mono text-sm text-yellow-300">{tool.name}</span>
+          {tool.description && (
+            <span className="ml-2 text-xs text-gray-400">{tool.description}</span>
+          )}
+        </div>
+        <button
+          onClick={run}
+          disabled={busy}
+          className="text-xs px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white"
+        >
+          {busy ? 'Running…' : 'Run'}
+        </button>
+      </div>
+      <textarea
+        value={args}
+        onChange={(e) => setArgs(e.target.value)}
+        spellCheck={false}
+        rows={3}
+        className="w-full bg-gray-950 text-gray-200 font-mono text-xs p-2 rounded border border-gray-700 focus:outline-none focus:border-gray-500"
+        placeholder='{"query": "example"}'
+      />
+      {error && (
+        <div className="text-xs text-red-400">
+          <i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}
+        </div>
+      )}
+      {result && (
+        <div className="text-xs space-y-1">
+          <div className="text-green-400">
+            <i className="fa-solid fa-check mr-1"></i>Result
+          </div>
+          {result.artifacts && result.artifacts.length > 0 && (
+            <div className="text-gray-400">
+              Artifacts: {result.artifacts.map((a, i) => (
+                <span key={i} className="ml-1 font-mono">[{a.type}{a.content_size ? ` ${a.content_size}b` : ''}]</span>
+              ))}
+            </div>
+          )}
+          <pre className="bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 max-h-72 overflow-auto whitespace-pre-wrap">{result.result_text}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function ServerTestPanel({ server }) {
+  const [busy, setBusy] = useState(false)
+  const [tools, setTools] = useState(null)
+  const [error, setError] = useState(null)
+
+  async function discover() {
+    setBusy(true)
+    setError(null)
+    setTools(null)
+    try {
+      const res = await testServer(server.id)
+      if (!res.ok) {
+        setError(res.error || 'list_tools failed')
+      } else {
+        setTools(res.tools)
+      }
+    } catch (e) {
+      setError(e.message || 'Request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!server.enabled) {
+    return (
+      <div className="text-xs text-gray-500 italic">
+        Server is disabled in config. Enable it to test.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <button
+          onClick={discover}
+          disabled={busy}
+          className="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+        >
+          {busy ? 'Discovering…' : 'List tools'}
+        </button>
+        {tools && (
+          <span className="text-xs text-gray-400">
+            {tools.length} tool{tools.length === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+      {error && (
+        <div className="text-xs text-red-400">
+          <i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}
+        </div>
+      )}
+      {tools && tools.length > 0 && (
+        <div className="space-y-2">
+          {tools.map((t) => (
+            <ToolRow key={t.namespaced_name} serverId={server.id} tool={t} />
+          ))}
+        </div>
+      )}
+      {tools && tools.length === 0 && (
+        <div className="text-xs text-gray-500 italic">Server advertises no tools.</div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -22,6 +22,9 @@ function ServerRow({ server, selected, onSelect }) {
         {!server.enabled && (
           <span className="text-[10px] uppercase tracking-wide text-gray-500 border border-gray-700 px-1.5 py-0.5 rounded">disabled</span>
         )}
+        {server.command_exists === false && (
+          <span className="text-[10px] uppercase tracking-wide text-red-300 border border-red-800 px-1.5 py-0.5 rounded">no command</span>
+        )}
       </div>
     </button>
   )
@@ -56,11 +59,20 @@ function ServerDetails({ server, registryErrors }) {
           <div>
             <span className="text-gray-500">command:</span>{' '}
             <span className="font-mono text-gray-200">{server.command}</span>
+            {server.command_exists === false && (
+              <span className="ml-2 text-red-300">(not found on disk)</span>
+            )}
           </div>
           {server.args && server.args.length > 0 && (
             <div>
               <span className="text-gray-500">args:</span>{' '}
               <span className="font-mono text-gray-200">{server.args.join(' ')}</span>
+            </div>
+          )}
+          {server.command_exists === false && (
+            <div className="text-red-300 mt-1">
+              <i className="fa-solid fa-triangle-exclamation mr-1"></i>
+              Hidden from chat until the command exists.
             </div>
           )}
         </div>

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react'
+import useRegistry from '../../hooks/useRegistry'
+import RegistryEditor from './RegistryEditor'
+import ServerTestPanel from './ServerTestPanel'
+
+function ServerRow({ server, selected, onSelect }) {
+  return (
+    <button
+      onClick={() => onSelect(server.id)}
+      className={`w-full text-left px-3 py-2 rounded border ${
+        selected
+          ? 'bg-gray-800 border-gray-600'
+          : 'bg-gray-900 border-transparent hover:bg-gray-800/70'
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <i className={`fa-solid ${server.icon} text-gray-400 w-4 text-center`}></i>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-gray-200 truncate">{server.name}</div>
+          <div className="text-[11px] text-gray-500 truncate">{server.description}</div>
+        </div>
+        {!server.enabled && (
+          <span className="text-[10px] uppercase tracking-wide text-gray-500 border border-gray-700 px-1.5 py-0.5 rounded">disabled</span>
+        )}
+      </div>
+    </button>
+  )
+}
+
+function ServerDetails({ server, registryErrors }) {
+  const entryError = registryErrors?.find(e => e.entry_id === server.id)
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="flex items-center gap-3">
+          <i className={`fa-solid ${server.icon} text-gray-400`}></i>
+          <h2 className="text-lg text-gray-100">{server.name}</h2>
+          <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${
+            server.source === 'built-in'
+              ? 'border-blue-700 text-blue-300'
+              : 'border-purple-700 text-purple-300'
+          }`}>{server.source}</span>
+          {!server.enabled && (
+            <span className="text-[10px] uppercase tracking-wide text-gray-500 border border-gray-700 px-1.5 py-0.5 rounded">disabled</span>
+          )}
+        </div>
+        <p className="text-sm text-gray-400 mt-1">{server.description}</p>
+      </div>
+
+      {server.source === 'built-in' ? (
+        <div className="text-xs text-gray-500 bg-gray-900 border border-gray-800 rounded px-3 py-2">
+          Built-in server. Defined in <span className="font-mono">dashboard/chat/mcp_registry.py</span>. Edit via code.
+        </div>
+      ) : (
+        <div className="bg-gray-900 border border-gray-800 rounded px-3 py-2 space-y-1 text-xs">
+          <div>
+            <span className="text-gray-500">command:</span>{' '}
+            <span className="font-mono text-gray-200">{server.command}</span>
+          </div>
+          {server.args && server.args.length > 0 && (
+            <div>
+              <span className="text-gray-500">args:</span>{' '}
+              <span className="font-mono text-gray-200">{server.args.join(' ')}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {entryError && (
+        <div className="text-xs text-red-400 bg-red-950/30 border border-red-900 rounded px-3 py-2">
+          <i className="fa-solid fa-triangle-exclamation mr-1"></i>
+          {entryError.message}
+        </div>
+      )}
+
+      <div className="pt-2 border-t border-gray-800">
+        <h3 className="text-xs uppercase tracking-wide text-gray-500 mb-2">Test</h3>
+        <ServerTestPanel server={server} />
+      </div>
+    </div>
+  )
+}
+
+export default function ToolsPage() {
+  const { data, json, loading, error, save, reload } = useRegistry()
+  const [selectedId, setSelectedId] = useState(null)
+
+  const servers = data?.servers || []
+  const grouped = useMemo(() => {
+    const builtin = servers.filter(s => s.source === 'built-in')
+    const external = servers.filter(s => s.source === 'external')
+    return { builtin, external }
+  }, [servers])
+
+  const selected = useMemo(() => {
+    if (!servers.length) return null
+    return servers.find(s => s.id === selectedId) || servers[0]
+  }, [servers, selectedId])
+
+  if (loading) {
+    return (
+      <div className="p-6 text-gray-400">
+        <i className="fa-solid fa-spinner fa-spin mr-2"></i>Loading registry…
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="p-6 text-red-400">
+        <i className="fa-solid fa-triangle-exclamation mr-2"></i>{error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 max-w-6xl">
+      <div>
+        <h1 className="text-xl text-gray-100">Tools</h1>
+        <p className="text-sm text-gray-400">
+          MCP servers available to the chat. Built-in servers ship with the dashboard; external servers are
+          declared in a JSON file on disk.
+        </p>
+      </div>
+
+      <RegistryEditor
+        initialContent={json?.content}
+        configPath={data?.config_file}
+        externalErrors={data?.external_errors}
+        loadError={data?.load_error}
+        onSave={save}
+        onReload={reload}
+      />
+
+      <div className="grid grid-cols-[280px_1fr] gap-4">
+        <div className="space-y-3">
+          <div>
+            <div className="text-[11px] uppercase tracking-wide text-gray-500 mb-1 px-1">Built-in</div>
+            <div className="space-y-1">
+              {grouped.builtin.map((s) => (
+                <ServerRow key={s.id} server={s} selected={selected?.id === s.id} onSelect={setSelectedId} />
+              ))}
+            </div>
+          </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-wide text-gray-500 mb-1 px-1">External</div>
+            <div className="space-y-1">
+              {grouped.external.length === 0 && (
+                <div className="text-xs text-gray-500 italic px-1">None configured. Add some in the editor above.</div>
+              )}
+              {grouped.external.map((s) => (
+                <ServerRow key={s.id} server={s} selected={selected?.id === s.id} onSelect={setSelectedId} />
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-900/50 border border-gray-800 rounded p-4">
+          {selected ? (
+            <ServerDetails server={selected} registryErrors={data?.external_errors} />
+          ) : (
+            <div className="text-sm text-gray-500">No servers registered.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/hooks/useRegistry.js
+++ b/dashboard/frontend/src/hooks/useRegistry.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getRegistry, getRegistryJson, putRegistryJson, reloadRegistry } from '../services/mcpRegistry'
+
+export default function useRegistry() {
+  const [data, setData] = useState(null)
+  const [json, setJson] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const mountedRef = useRef(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [reg, j] = await Promise.all([getRegistry(), getRegistryJson()])
+      if (!mountedRef.current) return
+      setData(reg)
+      setJson(j)
+      setError(null)
+    } catch (e) {
+      if (mountedRef.current) setError(e.message || 'Failed to load registry')
+    } finally {
+      if (mountedRef.current) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    refresh()
+    return () => { mountedRef.current = false }
+  }, [refresh])
+
+  const save = useCallback(async (content) => {
+    // Throws on validation failure; caller handles err.body.entry_errors etc.
+    const reg = await putRegistryJson(content)
+    setData(reg)
+    setJson({ content, path: reg.config_file })
+    return reg
+  }, [])
+
+  const reload = useCallback(async () => {
+    const reg = await reloadRegistry()
+    const j = await getRegistryJson()
+    setData(reg)
+    setJson(j)
+    return reg
+  }, [])
+
+  return { data, json, loading, error, refresh, save, reload }
+}

--- a/dashboard/frontend/src/services/mcpRegistry.js
+++ b/dashboard/frontend/src/services/mcpRegistry.js
@@ -1,0 +1,42 @@
+import { API_BASE, getToken } from '../api'
+
+async function request(path, options = {}) {
+  const token = getToken()
+  if (!token) throw new Error('Not authenticated')
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  })
+  const text = await res.text()
+  let body = null
+  try { body = text ? JSON.parse(text) : null } catch { body = { error: text } }
+  if (!res.ok) {
+    // Surface structured validation errors from PUT /json so the editor
+    // can render per-entry messages. Generic Error.message keeps the
+    // existing throw-and-catch ergonomics elsewhere.
+    const err = new Error(body?.error || `HTTP ${res.status}`)
+    err.status = res.status
+    err.body = body
+    throw err
+  }
+  return body
+}
+
+export const getRegistry = () => request('/chat/mcp-registry')
+export const getRegistryJson = () => request('/chat/mcp-registry/json')
+export const putRegistryJson = (content) =>
+  request('/chat/mcp-registry/json', { method: 'PUT', body: JSON.stringify({ content }) })
+export const reloadRegistry = () =>
+  request('/chat/mcp-registry/reload', { method: 'POST' })
+export const testServer = (server_id, tool_name = null, args = {}) => {
+  const body = { server_id }
+  if (tool_name) {
+    body.tool_name = tool_name
+    body.arguments = args
+  }
+  return request('/chat/mcp-registry/test', { method: 'POST', body: JSON.stringify(body) })
+}

--- a/dashboard/mcp_servers.example.json
+++ b/dashboard/mcp_servers.example.json
@@ -1,0 +1,15 @@
+{
+  "websearch": {
+    "enabled": true,
+    "name": "Web Search",
+    "description": "Search the web via the configured websearch MCP provider (SerpAPI / Exa)",
+    "command": "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp/.venv/bin/python",
+    "args": [
+      "/github/teo-mateo/ai-toolbox/mcp/websearch-mcp/main.py",
+      "--transport",
+      "stdio"
+    ],
+    "icon": "fa-magnifying-glass",
+    "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details."
+  }
+}


### PR DESCRIPTION
## Summary

Closes #16.

Splits the MCP server registry into a built-in half (Python, in-repo) and an external half declared in JSON on disk. Adds a `/tools` dashboard page for viewing the merged registry, editing the external JSON, reloading it, and smoke-testing configured servers.

- **`dashboard/chat/mcp_config.py`** — loader/validator/normalizer with atomic write, in-memory merged view, and reload hook that drops the `MCPClientManager` tool cache. Rejects `__` in ids, built-in collisions, relative `command` paths, and missing required fields.
- **`dashboard/chat/mcp_registry.py`** — thin wrappers (`list_available_servers` / `get_server_config` / `get_tool_hints`) delegating to `mcp_config`. `websearch` entry removed; it moves to the external JSON (`dashboard/mcp_servers.example.json` ships the canonical shape).
- **`dashboard/chat/mcp_admin_routes.py`** — `GET/PUT /api/chat/mcp-registry{,/json}`, `POST /reload`, `POST /test` (list_tools or call_tool with 5s/10s timeouts). All `@require_auth`; no env echoed back.
- **Frontend** — `ToolsPage` with raw-JSON editor (server-side validation, inline per-entry errors) and per-server test panel.
- **Config** — `dashboard/mcp_servers.json` added to `.gitignore`; `LLM_DOCK_MCP_SERVERS_FILE` overrides the default path.

## Test plan

- [ ] Built-in toggles (sympy / schemdraw / render-html) still appear in chat
- [ ] Drop `mcp_servers.example.json` → `mcp_servers.json`, reload from Tools page, see `websearch` in chat MCP toggle
- [ ] `/tools` page → select websearch → List tools → run `web_search` with sample args
- [ ] Paste invalid JSON in editor → save → 400 with structured errors, file untouched (`stat` before/after)
- [ ] Flip `enabled: false` in JSON, reload → entry still in `/tools` (disabled badge) but gone from chat toggle
- [ ] Existing conversation that had `websearch` selected still loads/runs
- [ ] Try id `sympy-math` in JSON → validation error, no merge collision
- [ ] Try id `bad__id` → validation error
- [ ] `curl /api/chat/mcp-registry` returns no env vars