### PR TITLE
Chat: streaming heartbeat + tool_call_pending events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ htmlcov/
 .codex/
 .codex
 opencode.json
+
+# test harness output
+tools/traces/

--- a/dashboard/chat/constants.py
+++ b/dashboard/chat/constants.py
@@ -33,7 +33,11 @@ Tool use
   reasoning. If you have nothing to add, write a brief direct answer rather than
   emitting empty output.
 - Hard cap: at most 5 tool calls per question. If you hit the cap without a confident
-  answer, answer with what you have and flag the uncertainty."""
+  answer, answer with what you have and flag the uncertainty.
+- When constructing web search queries about current state of anything (prices, products,
+  events, rankings, "best X in Y"), use the year from the `Current date:` line below —
+  not years from your training data. Do not append "2024" or "2025" to a query unless
+  the user specifically asked about that year."""
 
 DEFAULT_SIDEKICK_SYSTEM_PROMPT = (
     "You are a critical technical reviewer. When asked to critique a response, "

--- a/dashboard/chat/constants.py
+++ b/dashboard/chat/constants.py
@@ -6,8 +6,8 @@ of it.
 
 Style
 - Match length to the task. Short questions get short answers. No preamble ("Great question!",
-  "Sure, here's…"), no trailing summaries of what you just said.
-- Use markdown: fenced code blocks with a language tag, inline `code` for symbols and paths,
+  "Sure, here's…"), no trailing summary of what you just said.
+- Use markdown: fenced code blocks with a language tag, inline backticks for symbols and paths,
   tables when comparing, lists when enumerating. Plain prose otherwise.
 - For code, show the minimum that answers the question. Don't pad with imports, boilerplate,
   or "here's how to run it" unless that's the question.
@@ -19,11 +19,21 @@ Accuracy
 - When the user shows you code or output, read it carefully before answering. Quote the
   specific line you're reacting to.
 
-Tools
-- When tools are available (their usage is described below), prefer calling them over
-  describing what they would do. Always invoke tools by their full namespaced name
-  (`<server_id>__<tool_name>`).
-- Don't narrate tool calls before making them ("Let me search…"). Just call."""
+Tool use
+- Tools shown below are real and connected. When the task asks for current data
+  (web pages, prices, recent events, exact specs) and a relevant tool is available,
+  use it. Do not fabricate results from memory under the guise of "simulating" a search.
+- Call exactly ONE tool per turn. Wait for the result before deciding the next call.
+  Do not pre-plan a batch of calls — let each result guide what to do next.
+- Issue every tool call through the structured tool-calling interface. Never write
+  tool invocations as text, code blocks, or angle-bracket tags; never echo a tool's
+  raw schema back to the user.
+- When you have enough information to answer, stop calling tools and write the answer
+  as plain text. The user only sees that final text — not your tool calls, not your
+  reasoning. If you have nothing to add, write a brief direct answer rather than
+  emitting empty output.
+- Hard cap: at most 5 tool calls per question. If you hit the cap without a confident
+  answer, answer with what you have and flag the uncertainty."""
 
 DEFAULT_SIDEKICK_SYSTEM_PROMPT = (
     "You are a critical technical reviewer. When asked to critique a response, "

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -99,6 +99,7 @@ class ChatDB:
             ("conversations", "selected_text", "ALTER TABLE conversations ADD COLUMN selected_text TEXT"),
             ("conversations", "mcp_servers_json", "ALTER TABLE conversations ADD COLUMN mcp_servers_json TEXT"),
             ("messages", "tool_calls_json", "ALTER TABLE messages ADD COLUMN tool_calls_json TEXT"),
+            ("messages", "parse_warning_json", "ALTER TABLE messages ADD COLUMN parse_warning_json TEXT"),
         ]
         for table, column, sql in migrations:
             try:
@@ -266,6 +267,7 @@ class ChatDB:
             model_service=row["model_service"],
             images_json=row["images_json"],
             tool_calls_json=row["tool_calls_json"],
+            parse_warning_json=row["parse_warning_json"] if "parse_warning_json" in row.keys() else None,
             seq=row["seq"],
             created_at=row["created_at"],
         )
@@ -313,10 +315,11 @@ class ChatDB:
         try:
             conn.execute(
                 """INSERT INTO messages
-                   (id, conversation_id, role, content, reasoning_content, model_service, images_json, tool_calls_json, seq)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   (id, conversation_id, role, content, reasoning_content, model_service, images_json, tool_calls_json, parse_warning_json, seq)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (msg.id, msg.conversation_id, msg.role, msg.content,
-                 msg.reasoning_content, msg.model_service, msg.images_json, msg.tool_calls_json, msg.seq),
+                 msg.reasoning_content, msg.model_service, msg.images_json, msg.tool_calls_json,
+                 msg.parse_warning_json, msg.seq),
             )
             conn.commit()
             return self.get_message(msg.id)

--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -1,9 +1,61 @@
 import json
 import logging
+import re
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+# Known wrong-format markers Qwen3.6 (and similar) emit when the structured
+# tool-call format drifts. The qwen3_coder parser strips the canonical
+# `<tool_call>…</tool_call>` block, but if the model writes any of these
+# instead, the garbage leaks into `content` (or content ends up empty after
+# the parser tries to consume a malformed call). Detecting these gives the
+# UI a chip to surface the failure ad-hoc rather than rendering an empty
+# bubble. Kinds line up 1:1 with the `format drift modes` we've observed.
+FORMAT_DRIFT_PATTERNS = [
+    ("arg_key_tags", re.compile(r"<arg_key>"),
+     "Model emitted `<arg_key>` XML tags in content — Qwen3.6 family format drift."),
+    ("arg_value_tags", re.compile(r"<arg_value>"),
+     "Model emitted `<arg_value>` XML tags in content — Qwen3.6 family format drift."),
+    ("function_text_tag", re.compile(r"<function="),
+     "Model emitted `<function=…>` text instead of a structured tool_call."),
+    ("json_codeblock_call", re.compile(r"```(?:json|tool_code)\s*\{[\s\S]{0,40}\"(?:name|tool|function)\"\s*:"),
+     "Model emitted a JSON tool call in a markdown codeblock instead of structured tool_calls."),
+    ("orphan_tool_call_tag", re.compile(r"<tool_call>"),
+     "Model emitted a `<tool_call>` tag in content — parser likely failed to consume it."),
+    ("orphan_close_function", re.compile(r"</function>"),
+     "Model emitted a stray `</function>` close tag — partial/malformed tool call."),
+]
+
+
+def detect_format_drift(content: str, reasoning: str = "", had_tool_calls: bool = False):
+    """Return a {kind, snippet, description} dict if content shows known drift, else None.
+
+    Also flags the silent-drop case: reasoning produced but no content and no
+    tool calls. That usually means the parser swallowed a malformed call and
+    left nothing behind, which is the most confusing failure mode to debug.
+    """
+    if content:
+        for kind, pat, description in FORMAT_DRIFT_PATTERNS:
+            m = pat.search(content)
+            if m:
+                start = max(0, m.start() - 40)
+                end = min(len(content), m.end() + 160)
+                snippet = content[start:end]
+                if start > 0:
+                    snippet = "…" + snippet
+                if end < len(content):
+                    snippet = snippet + "…"
+                return {"kind": kind, "snippet": snippet, "description": description}
+    if not (content and content.strip()) and not had_tool_calls and reasoning and reasoning.strip():
+        return {
+            "kind": "silent_drop",
+            "snippet": "",
+            "description": "Model emitted reasoning but no content and no tool calls. Parser may have silently dropped a malformed tool call.",
+        }
+    return None
 
 
 def resolve_service(service_name: str) -> dict:
@@ -69,6 +121,12 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
     if tools:
         payload["tools"] = tools
         payload["tool_choice"] = "auto"
+        # Tool-using turns are sensitive to sampling variance: at vLLM's
+        # default temperature=1.0, the model occasionally drifts from the
+        # structured tool-call format into XML-in-content (`<arg_key>...`
+        # `</function>` ghost calls, etc.). 0.3 keeps the format on-rails
+        # without making the answer prose feel robotic.
+        payload["temperature"] = 0.3
 
     collected_content = ""
     collected_reasoning = ""
@@ -148,6 +206,16 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
         if finish_reason == "tool_calls" or (collected_tool_calls and not collected_content):
             yield ("tool_calls", {"tool_calls": collected_tool_calls})
         else:
+            # Format-drift detection — surface known wrong-format failure
+            # modes before the `done` event so the UI can render a chip on
+            # the assistant bubble even when content is empty/garbage.
+            drift = detect_format_drift(
+                collected_content,
+                reasoning=collected_reasoning,
+                had_tool_calls=bool(collected_tool_calls),
+            )
+            if drift is not None:
+                yield ("parse_warning", drift)
             yield ("done", {
                 "content": collected_content,
                 "reasoning_content": collected_reasoning or None,

--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -73,6 +73,7 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
     collected_content = ""
     collected_reasoning = ""
     collected_tool_calls = []  # accumulated from streaming chunks
+    pending_emitted = set()    # tool-call indices we've already announced via tool_call_pending
     finish_reason = None
 
     try:
@@ -125,6 +126,15 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
                             collected_tool_calls[idx]["function"]["name"] += fn["name"]
                         if "arguments" in fn and fn["arguments"]:
                             collected_tool_calls[idx]["function"]["arguments"] += fn["arguments"]
+                    # Surface a "pending" event the first time this index has any
+                    # name fragment — the full tool_calls event only fires at
+                    # finish_reason, which can leave the UI silent for seconds
+                    # while the model assembles the call.
+                    if idx not in pending_emitted:
+                        current_name = collected_tool_calls[idx]["function"]["name"]
+                        if current_name:
+                            pending_emitted.add(idx)
+                            yield ("tool_call_pending", {"index": idx, "name": current_name})
 
             # Forward content deltas to frontend
             if content_piece or reasoning_piece:

--- a/dashboard/chat/models.py
+++ b/dashboard/chat/models.py
@@ -14,11 +14,13 @@ class Message:
     model_service: Optional[str] = None
     images_json: Optional[str] = None
     tool_calls_json: Optional[str] = None
+    parse_warning_json: Optional[str] = None
     created_at: Optional[str] = None
 
     def to_dict(self):
         images = json.loads(self.images_json) if self.images_json else []
         tool_calls = json.loads(self.tool_calls_json) if self.tool_calls_json else []
+        parse_warning = json.loads(self.parse_warning_json) if self.parse_warning_json else None
         d = {
             "id": self.id,
             "conversation_id": self.conversation_id,
@@ -32,6 +34,8 @@ class Message:
         }
         if tool_calls:
             d["tool_calls"] = tool_calls
+        if parse_warning:
+            d["parse_warning"] = parse_warning
         return d
 
 

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -286,6 +286,7 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
     accumulated_reasoning = ""
     collected_tool_calls = []
     collected_artifacts = []
+    last_parse_warning = None      # most recent parse_warning event, persisted on done
 
     def _save_partial():
         """Persist whatever we accumulated when the client disconnects mid-stream.
@@ -351,6 +352,12 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
                 yield f"data: {data['raw']}\n\n"
             elif event_type == "tool_call_pending":
                 yield f"data: {json.dumps({'type': 'tool_call_pending', 'index': data['index'], 'name': data['name']})}\n\n"
+            elif event_type == "parse_warning":
+                # Format-drift signal from llm_proxy. Stash so we can persist
+                # alongside the message on `done`; also forward live so the UI
+                # shows the chip before the response finishes streaming.
+                last_parse_warning = data
+                yield f"data: {json.dumps({'type': 'parse_warning', **data})}\n\n"
             elif event_type == "tool_call":
                 collected_tool_calls.append({
                     "name": data["name"],
@@ -378,6 +385,7 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
                     reasoning_content=data["reasoning_content"],
                     model_service=conv.main_service,
                     tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
+                    parse_warning_json=json.dumps(last_parse_warning) if last_parse_warning else None,
                     seq=next_seq,
                 )
                 db.add_message(assistant_msg)

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -251,7 +252,10 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
     db.add_message(user_msg)
     db.touch_conversation(conv.id)
 
-    # Build messages array, augmenting system prompt with tool hints
+    # Build messages array, augmenting system prompt with tool hints and
+    # an explicit "today's date" line. Models keep training on data with a
+    # past cutoff, so without this they'll write 2024/2025 in queries even
+    # when the user is asking about now.
     messages = db.get_messages(conv.id)
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
     system_prompt = conv.main_system_prompt
@@ -259,6 +263,9 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
         hints = get_tool_hints(enabled_servers)
         if hints:
             system_prompt = f"{system_prompt}\n\n{hints}" if system_prompt else hints
+    today = datetime.date.today()
+    date_line = f"Current date: {today.isoformat()} ({today.strftime('%A')}). Use this as \"today\" when interpreting time-sensitive questions."
+    system_prompt = f"{system_prompt}\n\n{date_line}" if system_prompt else date_line
     messages_array = build_messages_array(system_prompt, messages)
 
     # Get MCP tools

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -333,27 +333,18 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
         except Exception:
             logger.exception("Failed to save partial assistant message on disconnect")
 
-    stream_start = time.monotonic()
-
-    def _log_evt(label, extra=""):
-        logger.info("[stream %s] +%.2fs %s %s", conv.id[:8], time.monotonic() - stream_start, label, extra)
-
     try:
         for event_type, data in stream:
             if event_type == "__heartbeat__":
-                _log_evt("heartbeat", f"elapsed={data['elapsed_s']}")
                 yield f"data: {json.dumps({'type': 'heartbeat', 'elapsed_s': data['elapsed_s']})}\n\n"
                 continue
             if event_type == "delta":
-                _log_evt("delta", f"content_len={len(data.get('content') or '')} reasoning_len={len(data.get('reasoning_content') or '')}")
                 accumulated_content += data.get("content", "") or ""
                 accumulated_reasoning += data.get("reasoning_content", "") or ""
                 yield f"data: {data['raw']}\n\n"
             elif event_type == "tool_call_pending":
-                _log_evt("tool_call_pending", f"name={data['name']}")
                 yield f"data: {json.dumps({'type': 'tool_call_pending', 'index': data['index'], 'name': data['name']})}\n\n"
             elif event_type == "tool_call":
-                _log_evt("tool_call", f"name={data['name']} server={data['server_id']}")
                 collected_tool_calls.append({
                     "name": data["name"],
                     "arguments": data["arguments"],

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -399,7 +399,16 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
                     conversation_id=conv.id,
                     role="assistant",
                     content=data["content"],
-                    reasoning_content=data["reasoning_content"],
+                    # `data["reasoning_content"]` is only the FINAL model
+                    # round's reasoning. In a multi-round tool flow the
+                    # reasoning emitted before each `finish_reason=tool_calls`
+                    # is streamed to the UI (continuous reasoning display) but
+                    # would be dropped on the post-save refetch if we persisted
+                    # only the last round. `accumulated_reasoning` is the full
+                    # cross-round trace the user actually saw; persist that.
+                    # Falls back to the done payload for the single-round case
+                    # where they are identical.
+                    reasoning_content=(accumulated_reasoning or data["reasoning_content"]) or None,
                     model_service=conv.main_service,
                     tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
                     parse_warning_json=json.dumps(last_parse_warning) if last_parse_warning else None,

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -138,6 +138,13 @@ def delete_conversations_batch():
 # -- Messages --
 
 HEARTBEAT_INTERVAL_S = 3.0
+# Bounded queue size between producer and consumer. Large enough to absorb a
+# burst of token deltas without blocking the producer in normal operation;
+# small enough that an abandoned producer can't grow unbounded memory.
+HEARTBEAT_QUEUE_MAX = 64
+# Polling interval on the producer side. Caps how long after the consumer
+# sets `stop` the producer waits before noticing on a full-queue path.
+HEARTBEAT_PRODUCER_POLL_S = 0.5
 
 
 def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
@@ -145,42 +152,97 @@ def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
 
     The inner stream blocks on upstream HTTP (`requests.iter_lines`), so a
     naive `for ev in it:` can sit for seconds without emitting anything. We
-    drive the inner iterator on a worker thread feeding a queue, and the
-    outer loop pops with a timeout — on every timeout we yield a heartbeat
-    event so the SSE pipe stays visibly alive.
+    drive the inner iterator on a worker thread feeding a bounded queue, and
+    the outer loop pops with a timeout — on every timeout we yield a
+    heartbeat event so the SSE pipe stays visibly alive.
 
-    The thread is a daemon. If the client disconnects we cannot reach into
-    `requests.iter_lines` to interrupt it, but the upstream connection will
-    finish the model turn and drain naturally (same as the pre-heartbeat
-    behavior that backs partial-save).
+    Cancellation contract (client disconnect / Stop button / navigation):
+
+    - The consumer's `finally` sets `stop` and drains the queue, which both
+      caps memory and unblocks the producer if it's parked on a full queue.
+    - The producer checks `stop` between events and on every full-queue
+      retry. Once it notices, it closes the inner generator and exits.
+    - Closing the inner generator (`it.close()`) propagates `GeneratorExit`
+      into `stream_with_tools` / `stream_chat_completion` at their next
+      yield, which short-circuits any further tool execution in
+      `tool_loop.py` and prevents new MCP side-effects after disconnect.
+
+    Caveat: this is cooperative. If the producer is currently inside
+    `requests.iter_lines` waiting on a socket read, it won't notice `stop`
+    until the next chunk arrives (or the upstream times out). Likewise, a
+    tool call already in progress in `mcp_manager.call_tool()` runs to
+    completion — those subprocess calls aren't interruptible from here.
+    True interruption would need a cancel token threaded through to
+    `stream_chat_completion`/`stream_with_tools`; tracked as a follow-up.
     """
-    q = queue.Queue()
+    q = queue.Queue(maxsize=HEARTBEAT_QUEUE_MAX)
     sentinel = object()
+    stop = threading.Event()
 
     def producer():
         try:
             for ev in it:
-                q.put(("ev", ev))
+                if stop.is_set():
+                    break
+                # Bounded put with periodic stop checks so a dead consumer
+                # can't permanently park us here.
+                while True:
+                    try:
+                        q.put(("ev", ev), timeout=HEARTBEAT_PRODUCER_POLL_S)
+                        break
+                    except queue.Full:
+                        if stop.is_set():
+                            break
+                if stop.is_set():
+                    break
         except BaseException as e:
-            q.put(("exc", e))
+            try:
+                q.put(("exc", e), timeout=HEARTBEAT_PRODUCER_POLL_S)
+            except queue.Full:
+                logger.warning("_with_heartbeat: dropped exception on full queue", exc_info=e)
         finally:
-            q.put(sentinel)
+            # Close the inner generator FROM THIS THREAD. The generator
+            # protocol forbids closing a generator that's running on another
+            # thread, so the consumer-side `finally` only sets `stop` and
+            # leaves the actual close to us.
+            try:
+                it.close()
+            except Exception:
+                logger.exception("_with_heartbeat: error closing inner stream")
+            try:
+                q.put(sentinel, timeout=HEARTBEAT_PRODUCER_POLL_S)
+            except queue.Full:
+                pass
 
     threading.Thread(target=producer, daemon=True).start()
     idle_since = time.monotonic()
-    while True:
+    try:
+        while True:
+            try:
+                item = q.get(timeout=interval)
+            except queue.Empty:
+                yield ("__heartbeat__", {"elapsed_s": round(time.monotonic() - idle_since, 1)})
+                continue
+            if item is sentinel:
+                return
+            kind, payload = item
+            if kind == "exc":
+                raise payload
+            idle_since = time.monotonic()
+            yield payload
+    finally:
+        # Consumer is exiting (normal completion, GeneratorExit from client
+        # disconnect, or an exception thrown into us). Signal the producer
+        # to stop and drain anything pending so it isn't blocked on a full
+        # queue put. The drain is required: without it, a producer parked
+        # in q.put() at maxsize won't notice the stop event until its 0.5s
+        # timeout fires, and meanwhile would still process its next event.
+        stop.set()
         try:
-            item = q.get(timeout=interval)
+            while True:
+                q.get_nowait()
         except queue.Empty:
-            yield ("__heartbeat__", {"elapsed_s": round(time.monotonic() - idle_since, 1)})
-            continue
-        if item is sentinel:
-            return
-        kind, payload = item
-        if kind == "exc":
-            raise payload
-        idle_since = time.monotonic()
-        yield payload
+            pass
 
 
 def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_manager=None):
@@ -271,18 +333,27 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
         except Exception:
             logger.exception("Failed to save partial assistant message on disconnect")
 
+    stream_start = time.monotonic()
+
+    def _log_evt(label, extra=""):
+        logger.info("[stream %s] +%.2fs %s %s", conv.id[:8], time.monotonic() - stream_start, label, extra)
+
     try:
         for event_type, data in stream:
             if event_type == "__heartbeat__":
+                _log_evt("heartbeat", f"elapsed={data['elapsed_s']}")
                 yield f"data: {json.dumps({'type': 'heartbeat', 'elapsed_s': data['elapsed_s']})}\n\n"
                 continue
             if event_type == "delta":
+                _log_evt("delta", f"content_len={len(data.get('content') or '')} reasoning_len={len(data.get('reasoning_content') or '')}")
                 accumulated_content += data.get("content", "") or ""
                 accumulated_reasoning += data.get("reasoning_content", "") or ""
                 yield f"data: {data['raw']}\n\n"
             elif event_type == "tool_call_pending":
+                _log_evt("tool_call_pending", f"name={data['name']}")
                 yield f"data: {json.dumps({'type': 'tool_call_pending', 'index': data['index'], 'name': data['name']})}\n\n"
             elif event_type == "tool_call":
+                _log_evt("tool_call", f"name={data['name']} server={data['server_id']}")
                 collected_tool_calls.append({
                     "name": data["name"],
                     "arguments": data["arguments"],

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -179,6 +179,13 @@ def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
     q = queue.Queue(maxsize=HEARTBEAT_QUEUE_MAX)
     sentinel = object()
     stop = threading.Event()
+    # Out-of-band termination flag. The queued `sentinel` is a fast-path
+    # optimization for prompt shutdown, but it can be dropped if the queue
+    # is full for the whole producer-put timeout (slow/stalled consumer).
+    # `finished` is set unconditionally in the producer's finally, so the
+    # consumer can always detect end-of-stream even when the sentinel never
+    # makes it into the queue.
+    finished = threading.Event()
 
     def producer():
         try:
@@ -210,6 +217,10 @@ def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
                 it.close()
             except Exception:
                 logger.exception("_with_heartbeat: error closing inner stream")
+            # Mark completion BEFORE the (droppable) sentinel put so the
+            # consumer can terminate via `finished` even if the queue stays
+            # full and the sentinel never lands.
+            finished.set()
             try:
                 q.put(sentinel, timeout=HEARTBEAT_PRODUCER_POLL_S)
             except queue.Full:
@@ -222,6 +233,12 @@ def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
             try:
                 item = q.get(timeout=interval)
             except queue.Empty:
+                # Queue is empty. If the producer already finished, the
+                # sentinel was either consumed or dropped on a full queue —
+                # either way there is nothing more coming, so terminate
+                # instead of emitting heartbeats forever.
+                if finished.is_set():
+                    return
                 yield ("__heartbeat__", {"elapsed_s": round(time.monotonic() - idle_since, 1)})
                 continue
             if item is sentinel:

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import os
+import queue
+import threading
+import time
 import uuid
 from typing import Optional
 
@@ -134,6 +137,52 @@ def delete_conversations_batch():
 
 # -- Messages --
 
+HEARTBEAT_INTERVAL_S = 3.0
+
+
+def _with_heartbeat(it, interval: float = HEARTBEAT_INTERVAL_S):
+    """Yield items from `it` and inject ("__heartbeat__", {elapsed_s}) on idle.
+
+    The inner stream blocks on upstream HTTP (`requests.iter_lines`), so a
+    naive `for ev in it:` can sit for seconds without emitting anything. We
+    drive the inner iterator on a worker thread feeding a queue, and the
+    outer loop pops with a timeout — on every timeout we yield a heartbeat
+    event so the SSE pipe stays visibly alive.
+
+    The thread is a daemon. If the client disconnects we cannot reach into
+    `requests.iter_lines` to interrupt it, but the upstream connection will
+    finish the model turn and drain naturally (same as the pre-heartbeat
+    behavior that backs partial-save).
+    """
+    q = queue.Queue()
+    sentinel = object()
+
+    def producer():
+        try:
+            for ev in it:
+                q.put(("ev", ev))
+        except BaseException as e:
+            q.put(("exc", e))
+        finally:
+            q.put(sentinel)
+
+    threading.Thread(target=producer, daemon=True).start()
+    idle_since = time.monotonic()
+    while True:
+        try:
+            item = q.get(timeout=interval)
+        except queue.Empty:
+            yield ("__heartbeat__", {"elapsed_s": round(time.monotonic() - idle_since, 1)})
+            continue
+        if item is sentinel:
+            return
+        kind, payload = item
+        if kind == "exc":
+            raise payload
+        idle_since = time.monotonic()
+        yield payload
+
+
 def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_manager=None):
     """Generator that streams SSE events for a chat completion."""
     # Save user message
@@ -158,6 +207,7 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
         stream = stream_with_tools(conv.main_service, messages_array, tools, mcp_manager)
     else:
         stream = stream_chat_completion(conv.main_service, messages_array)
+    stream = _with_heartbeat(stream)
 
     assistant_msg_id = str(uuid.uuid4())
     done = False
@@ -223,10 +273,15 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
 
     try:
         for event_type, data in stream:
+            if event_type == "__heartbeat__":
+                yield f"data: {json.dumps({'type': 'heartbeat', 'elapsed_s': data['elapsed_s']})}\n\n"
+                continue
             if event_type == "delta":
                 accumulated_content += data.get("content", "") or ""
                 accumulated_reasoning += data.get("reasoning_content", "") or ""
                 yield f"data: {data['raw']}\n\n"
+            elif event_type == "tool_call_pending":
+                yield f"data: {json.dumps({'type': 'tool_call_pending', 'index': data['index'], 'name': data['name']})}\n\n"
             elif event_type == "tool_call":
                 collected_tool_calls.append({
                     "name": data["name"],

--- a/dashboard/chat/tool_loop.py
+++ b/dashboard/chat/tool_loop.py
@@ -31,6 +31,9 @@ def stream_with_tools(service_name: str, messages_array: list, tools: list, mcp_
             elif event_type == "tool_call_pending":
                 yield ("tool_call_pending", data)
 
+            elif event_type == "parse_warning":
+                yield ("parse_warning", data)
+
             elif event_type == "tool_calls":
                 tool_calls_received = True
                 tool_calls = data["tool_calls"]
@@ -121,6 +124,8 @@ def stream_with_tools(service_name: str, messages_array: list, tools: list, mcp_
             yield ("delta", data)
         elif event_type == "tool_call_pending":
             yield ("tool_call_pending", data)
+        elif event_type == "parse_warning":
+            yield ("parse_warning", data)
         elif event_type == "done":
             yield ("done", data)
             return

--- a/dashboard/chat/tool_loop.py
+++ b/dashboard/chat/tool_loop.py
@@ -28,6 +28,9 @@ def stream_with_tools(service_name: str, messages_array: list, tools: list, mcp_
             if event_type == "delta":
                 yield ("delta", data)
 
+            elif event_type == "tool_call_pending":
+                yield ("tool_call_pending", data)
+
             elif event_type == "tool_calls":
                 tool_calls_received = True
                 tool_calls = data["tool_calls"]
@@ -116,6 +119,8 @@ def stream_with_tools(service_name: str, messages_array: list, tools: list, mcp_
     for event_type, data in stream_chat_completion(service_name, messages_array, tools=None):
         if event_type == "delta":
             yield ("delta", data)
+        elif event_type == "tool_call_pending":
+            yield ("tool_call_pending", data)
         elif event_type == "done":
             yield ("done", data)
             return

--- a/dashboard/frontend/src/components/MetricsPanel.jsx
+++ b/dashboard/frontend/src/components/MetricsPanel.jsx
@@ -4,7 +4,12 @@ import TokenSparkline from './TokenSparkline'
 import RequestStrip from './RequestStrip'
 import GaugesRow from './GaugesRow'
 import SpecDecodeBar from './SpecDecodeBar'
-import { getValue, timeAgo } from '../utils'
+import { getValue, totalValue, timeAgo } from '../utils'
+
+function fmt(n) {
+  if (n == null) return '—'
+  return n.toLocaleString()
+}
 
 export default function MetricsPanel({ serviceName, enabled }) {
   const { metrics, history, loading, error, lastScraped } = useServiceMetrics({ serviceName, enabled })
@@ -18,6 +23,10 @@ export default function MetricsPanel({ serviceName, enabled }) {
     if (entries.length === 0) return null
     return raw
   }, [metrics])
+
+  const promptTotal = totalValue(metrics, 'vllm:prompt_tokens_total')
+  const genTotal = totalValue(metrics, 'vllm:generation_tokens_total')
+  const showCumulative = promptTotal != null || genTotal != null
 
   if (!enabled) {
     return (
@@ -44,6 +53,25 @@ export default function MetricsPanel({ serviceName, enabled }) {
         <span className="text-gray-500 text-xs">{loading ? 'Initial fetch...' : timeAgo(lastScraped)}</span>
         {error && <span className="text-red-400 text-xs ml-auto">{error}</span>}
       </div>
+
+      {showCumulative && (
+        <div className="flex items-center gap-6 mb-4 px-1 text-xs font-mono">
+          <div className="flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-full bg-blue-500" />
+            <span className="text-gray-400">Prompt:</span>
+            <span className="text-gray-200 font-semibold">{fmt(promptTotal)}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-full bg-green-500" />
+            <span className="text-gray-400">Gen:</span>
+            <span className="text-gray-200 font-semibold">{fmt(genTotal)}</span>
+          </div>
+          <div className="flex items-center gap-1.5 ml-auto">
+            <span className="text-gray-500">Total:</span>
+            <span className="text-gray-100 font-semibold">{fmt((promptTotal || 0) + (genTotal || 0))}</span>
+          </div>
+        </div>
+      )}
 
       {!hasHistory && !loading && !error ? (
         <div className="flex flex-col items-center justify-center py-12">

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -22,6 +22,8 @@ export default function ChatArea({
   streamingContent,
   streamingReasoning,
   toolEvents,
+  pendingToolCalls,
+  heartbeat,
   artifacts,
   streamingArtifacts,
   error,
@@ -179,6 +181,8 @@ export default function ChatArea({
           streamingContent={streamingContent}
           streamingReasoning={streamingReasoning}
           toolEvents={toolEvents}
+          pendingToolCalls={pendingToolCalls}
+          heartbeat={heartbeat}
           artifacts={artifacts}
           streamingArtifacts={streamingArtifacts}
           activeCritiqueId={critiqueTarget}

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -26,6 +26,7 @@ export default function ChatArea({
   heartbeat,
   artifacts,
   streamingArtifacts,
+  streamingParseWarning,
   error,
   onSend,
   onEdit,
@@ -185,6 +186,7 @@ export default function ChatArea({
           heartbeat={heartbeat}
           artifacts={artifacts}
           streamingArtifacts={streamingArtifacts}
+          streamingParseWarning={streamingParseWarning}
           activeCritiqueId={critiqueTarget}
         />
 

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -20,6 +20,8 @@ export default function ChatPage() {
     streamingContent,
     streamingReasoning,
     toolEvents,
+    pendingToolCalls,
+    heartbeat,
     artifacts,
     streamingArtifacts,
     error,
@@ -107,6 +109,8 @@ export default function ChatPage() {
         streamingContent={streamingContent}
         streamingReasoning={streamingReasoning}
         toolEvents={toolEvents}
+        pendingToolCalls={pendingToolCalls}
+        heartbeat={heartbeat}
         artifacts={artifacts}
         streamingArtifacts={streamingArtifacts}
         error={error}

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -24,6 +24,7 @@ export default function ChatPage() {
     heartbeat,
     artifacts,
     streamingArtifacts,
+    streamingParseWarning,
     error,
     loadConversation,
     sendMessage,
@@ -113,6 +114,7 @@ export default function ChatPage() {
         heartbeat={heartbeat}
         artifacts={artifacts}
         streamingArtifacts={streamingArtifacts}
+        streamingParseWarning={streamingParseWarning}
         error={error}
         onSend={sendMessage}
         onEdit={editMessage}

--- a/dashboard/frontend/src/components/chat/FormatDriftChip.jsx
+++ b/dashboard/frontend/src/components/chat/FormatDriftChip.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { DRIFT_KIND_LABEL } from './formatDrift'
+
+export default function FormatDriftChip({ warning, rawContent }) {
+  const [open, setOpen] = useState(false)
+  if (!warning) return null
+  const label = DRIFT_KIND_LABEL[warning.kind] || warning.kind || 'format drift'
+  const hasRaw = typeof rawContent === 'string' && rawContent.length > 0
+  return (
+    <div className="mt-1 mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="inline-flex items-center gap-1.5 rounded border border-yellow-600/40 bg-yellow-900/20 px-2 py-0.5 text-[11px] text-yellow-300 hover:bg-yellow-900/40"
+        title="Click to inspect"
+      >
+        <i className={`fa-solid fa-triangle-exclamation`}></i>
+        <span>{label}</span>
+        <i className={`fa-solid ${open ? 'fa-chevron-up' : 'fa-chevron-down'} text-[9px] opacity-70`}></i>
+      </button>
+      {open && (
+        <div className="mt-1 rounded border border-yellow-600/30 bg-gray-900/60 p-2 text-[11px] text-gray-300 space-y-2 font-mono">
+          {warning.description && (
+            <div className="text-yellow-300/90 font-sans">{warning.description}</div>
+          )}
+          {warning.snippet && (
+            <div>
+              <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-0.5 font-sans">snippet</div>
+              <pre className="whitespace-pre-wrap break-words text-yellow-100/90">{warning.snippet}</pre>
+            </div>
+          )}
+          {hasRaw && (
+            <div>
+              <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-0.5 font-sans">raw content ({rawContent.length} chars)</div>
+              <pre className="whitespace-pre-wrap break-words max-h-64 overflow-auto text-gray-200">{rawContent}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -10,6 +10,7 @@ import CritiqueButton from './CritiqueButton'
 import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
 import { formatArgValue } from './toolCallUtils'
+import ToolResultBlock from './ToolResultBlock'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -69,9 +70,8 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                   </div>
                 )}
                 {tc.result && (
-                  <div className="text-green-400 pl-5">
-                    <i className="fa-solid fa-arrow-right mr-1"></i>
-                    <span className="font-mono">{tc.result}</span>
+                  <div className="pl-5">
+                    <ToolResultBlock text={tc.result} />
                   </div>
                 )}
               </div>

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -11,6 +11,8 @@ import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
 import { formatArgValue } from './toolCallUtils'
 import ToolResultBlock from './ToolResultBlock'
+import FormatDriftChip from './FormatDriftChip'
+import { detectFormatDrift } from './formatDrift'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -20,6 +22,9 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
   const isUser = message.role === 'user'
   const isTemp = message.id?.startsWith('temp-')
   const messageImages = message.images || []
+  // Prefer the server-persisted warning. Fall back to a client-side scan for
+  // backfill of pre-existing messages whose row doesn't have parse_warning_json.
+  const parseWarning = !isUser ? (message.parse_warning || detectFormatDrift(message)) : null
 
   function handleEditSubmit() {
     const trimmed = editValue.trim()
@@ -51,6 +56,13 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
         {/* Thinking block for assistant */}
         {!isUser && message.reasoning_content && (
           <ThinkingBlock content={message.reasoning_content} />
+        )}
+
+        {/* Format-drift chip — flags Qwen3.6-style failure modes. Prefers
+            persisted warning, falls back to client-side detection so older
+            messages without parse_warning_json still surface a chip. */}
+        {parseWarning && (
+          <FormatDriftChip warning={parseWarning} rawContent={message.content} />
         )}
 
         {/* Tool calls (persisted) */}

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -9,6 +9,7 @@ import ThinkingBlock from './ThinkingBlock'
 import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
 import { formatArgValue } from './toolCallUtils'
+import ToolResultBlock from './ToolResultBlock'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -68,38 +69,45 @@ export default function MessageList({
           />
         ))}
 
+        {/* Assistant header + continuous thinking trace — renders ABOVE the
+            tool events so the visual order matches the saved view (one
+            Thinking block at top, then tool calls). streamingReasoning is
+            never cleared on tool_call now; it grows across all rounds. */}
+        {streaming && (toolEvents.length > 0 || streamingReasoning) && (
+          <div className="flex justify-start">
+            <div className="max-w-[90%]">
+              <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
+              {streamingReasoning && (
+                <ThinkingBlock content={streamingReasoning} />
+              )}
+            </div>
+          </div>
+        )}
+
         {/* Tool events during streaming */}
         {streaming && toolEvents.length > 0 && (
           <div className="space-y-1.5">
             {toolEvents.map((evt, i) => (
               <div key={i} className="flex justify-start">
                 <div className="max-w-[90%]">
-                  {/* Reasoning before this tool call */}
-                  {evt.type === 'call' && evt.reasoning && (
-                    <div className="mb-1">
-                      <ThinkingBlock content={evt.reasoning} />
-                    </div>
-                  )}
                   <div className="rounded px-3 py-2 text-xs border bg-gray-800/50 border-gray-700/50 space-y-1">
-                    {evt.type === 'call' ? (
-                      <>
-                        <div className="text-yellow-400">
-                          <i className="fa-solid fa-wrench mr-1.5"></i>
-                          <span className="font-mono">{evt.name}</span>
-                        </div>
-                        {evt.arguments && Object.keys(evt.arguments).length > 0 && (
-                          <div className="text-gray-400 font-mono pl-5">
-                            {Object.entries(evt.arguments).map(([k, v]) => (
-                              <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
-                            ))}
-                          </div>
-                        )}
-                      </>
-                    ) : (
-                      <div className="text-green-400">
-                        <i className="fa-solid fa-check mr-1.5"></i>
-                        <span className="font-mono">{evt.name}</span>
-                        <span className="text-gray-300 ml-1">→ <span className="font-mono">{evt.result}</span></span>
+                    <div className={'result' in evt ? 'text-green-400' : 'text-yellow-400'}>
+                      <i className={`fa-solid ${'result' in evt ? 'fa-check' : 'fa-wrench fa-fade'} mr-1.5`}></i>
+                      <span className="font-mono">{evt.name}</span>
+                      {!('result' in evt) && (
+                        <span className="ml-2 text-[10px] uppercase tracking-wide text-gray-500">running…</span>
+                      )}
+                    </div>
+                    {evt.arguments && Object.keys(evt.arguments).length > 0 && (
+                      <div className="text-gray-400 font-mono pl-5">
+                        {Object.entries(evt.arguments).map(([k, v]) => (
+                          <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
+                        ))}
+                      </div>
+                    )}
+                    {'result' in evt && (
+                      <div className="pl-5">
+                        <ToolResultBlock text={evt.result} />
                       </div>
                     )}
                   </div>
@@ -137,13 +145,13 @@ export default function MessageList({
           </div>
         )}
 
-        {/* Streaming response */}
+        {/* Streaming response — only the content/fallback. The Assistant
+            header + reasoning render above (alongside tool events). */}
         {streaming && (
           <div className="flex justify-start">
             <div className="max-w-[90%]">
-              <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
-              {streamingReasoning && (
-                <ThinkingBlock content={streamingReasoning} />
+              {!toolEvents.length && !streamingReasoning && (
+                <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
               )}
               {streamingContent ? (
                 <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700 text-gray-200">

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -23,6 +23,8 @@ export default function MessageList({
   streamingContent,
   streamingReasoning,
   toolEvents = [],
+  pendingToolCalls = [],
+  heartbeat = null,
   artifacts = {},
   streamingArtifacts = [],
   activeCritiqueId,
@@ -116,6 +118,25 @@ export default function MessageList({
           </div>
         )}
 
+        {/* Pending tool call pills — model has started naming a tool but
+            hasn't finished assembling the call yet. Replaced by the full
+            panel in toolEvents once finish_reason==tool_calls lands. */}
+        {streaming && pendingToolCalls.length > 0 && (
+          <div className="space-y-1.5">
+            {pendingToolCalls.map((p) => (
+              <div key={p.index} className="flex justify-start">
+                <div className="max-w-[90%]">
+                  <div className="rounded px-3 py-2 text-xs border bg-gray-800/30 border-gray-700/50 border-dashed flex items-center gap-2 text-yellow-400/80">
+                    <i className="fa-solid fa-wrench fa-fade"></i>
+                    <span className="font-mono">{p.name || 'tool'}</span>
+                    <span className="text-gray-500">assembling call…</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* Streaming response */}
         {streaming && (
           <div className="flex justify-start">
@@ -132,14 +153,37 @@ export default function MessageList({
                     </ReactMarkdown>
                   </div>
                 </div>
-              ) : !streamingReasoning && toolEvents.length === 0 ? (
+              ) : !streamingReasoning && toolEvents.length === 0 && pendingToolCalls.length === 0 ? (
                 <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700">
                   <div className="flex items-center gap-2 text-sm text-gray-400">
-                    <i className="fa-solid fa-spinner fa-spin"></i>
-                    <span>Thinking...</span>
+                    <span className="relative flex h-2 w-2">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60"></span>
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+                    </span>
+                    <span>
+                      {heartbeat
+                        ? `Waiting for model… ${heartbeat.elapsed_s.toFixed(1)}s`
+                        : 'Thinking…'}
+                    </span>
                   </div>
                 </div>
               ) : null}
+            </div>
+          </div>
+        )}
+
+        {/* Live heartbeat ribbon — shown whenever the SSE pipe has been idle
+            and the "Thinking…" panel above isn't already displayed (because
+            partial content / reasoning / tool events are already on screen).
+            Covers between-tool-round gaps and reasoning-without-content phases. */}
+        {streaming && heartbeat && (streamingContent || streamingReasoning || toolEvents.length > 0 || pendingToolCalls.length > 0) && (
+          <div className="flex justify-start">
+            <div className="text-[11px] text-gray-500 flex items-center gap-2 pl-1">
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60"></span>
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500"></span>
+              </span>
+              <span>Waiting for model… {heartbeat.elapsed_s.toFixed(1)}s</span>
             </div>
           </div>
         )}

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -10,6 +10,7 @@ import ArtifactRenderer from './ArtifactRenderer'
 import CopyablePre from './CopyablePre'
 import { formatArgValue } from './toolCallUtils'
 import ToolResultBlock from './ToolResultBlock'
+import FormatDriftChip from './FormatDriftChip'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -28,6 +29,7 @@ export default function MessageList({
   heartbeat = null,
   artifacts = {},
   streamingArtifacts = [],
+  streamingParseWarning = null,
   activeCritiqueId,
 }) {
   const bottomRef = useRef(null)
@@ -152,6 +154,9 @@ export default function MessageList({
             <div className="max-w-[90%]">
               {!toolEvents.length && !streamingReasoning && (
                 <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
+              )}
+              {streamingParseWarning && (
+                <FormatDriftChip warning={streamingParseWarning} rawContent={streamingContent} />
               )}
               {streamingContent ? (
                 <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700 text-gray-200">

--- a/dashboard/frontend/src/components/chat/ToolResultBlock.jsx
+++ b/dashboard/frontend/src/components/chat/ToolResultBlock.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+const PREVIEW_CHARS = 160
+
+export default function ToolResultBlock({ text }) {
+  const [open, setOpen] = useState(false)
+  const s = typeof text === 'string' ? text : String(text ?? '')
+  const long = s.length > PREVIEW_CHARS
+  const preview = long ? s.slice(0, PREVIEW_CHARS).replace(/\s+$/, '') + '…' : s
+  return (
+    <div className="text-gray-300 inline">
+      <span className="text-green-400 mr-1">→</span>
+      {open || !long ? (
+        <pre className="font-mono whitespace-pre-wrap break-words bg-gray-950/60 border border-gray-800 rounded px-2 py-1 mt-1 max-h-80 overflow-auto text-[11px] text-gray-300">{s}</pre>
+      ) : (
+        <span className="font-mono text-gray-400">{preview}</span>
+      )}
+      {long && (
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          className="ml-2 text-[10px] uppercase tracking-wide text-gray-500 hover:text-gray-300"
+        >
+          {open ? 'collapse' : `show all (${s.length.toLocaleString()} chars)`}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/formatDrift.js
+++ b/dashboard/frontend/src/components/chat/formatDrift.js
@@ -1,0 +1,76 @@
+// Mirrors FORMAT_DRIFT_PATTERNS in dashboard/chat/llm_proxy.py — same kinds,
+// same priorities. Detection runs server-side at stream end (persisted via
+// parse_warning_json) and client-side on saved messages so old conversations
+// without the column populated still surface the chip.
+
+const PATTERNS = [
+  {
+    kind: 'arg_key_tags',
+    regex: /<arg_key>/,
+    description: 'Model emitted `<arg_key>` XML tags in content — Qwen3.6 family format drift.',
+  },
+  {
+    kind: 'arg_value_tags',
+    regex: /<arg_value>/,
+    description: 'Model emitted `<arg_value>` XML tags in content — Qwen3.6 family format drift.',
+  },
+  {
+    kind: 'function_text_tag',
+    regex: /<function=/,
+    description: 'Model emitted `<function=…>` text instead of a structured tool_call.',
+  },
+  {
+    kind: 'json_codeblock_call',
+    regex: /```(?:json|tool_code)\s*\{[\s\S]{0,40}"(?:name|tool|function)"\s*:/,
+    description: 'Model emitted a JSON tool call in a markdown codeblock instead of structured tool_calls.',
+  },
+  {
+    kind: 'orphan_tool_call_tag',
+    regex: /<tool_call>/,
+    description: 'Model emitted a `<tool_call>` tag in content — parser likely failed to consume it.',
+  },
+  {
+    kind: 'orphan_close_function',
+    regex: /<\/function>/,
+    description: 'Model emitted a stray `</function>` close tag — partial/malformed tool call.',
+  },
+]
+
+export function detectFormatDrift(message) {
+  if (!message) return null
+  const content = message.content || ''
+  for (const p of PATTERNS) {
+    const m = p.regex.exec(content)
+    if (m) {
+      const start = Math.max(0, m.index - 40)
+      const end = Math.min(content.length, m.index + m[0].length + 160)
+      let snippet = content.slice(start, end)
+      if (start > 0) snippet = '…' + snippet
+      if (end < content.length) snippet = snippet + '…'
+      return { kind: p.kind, snippet, description: p.description }
+    }
+  }
+  // Silent-drop heuristic: parser ate everything, leaving reasoning but no
+  // visible content and no tool_calls. Most confusing failure mode in the UI.
+  const trimmed = content.trim()
+  const reasoning = (message.reasoning_content || '').trim()
+  const toolCalls = message.tool_calls || []
+  if (!trimmed && reasoning && toolCalls.length === 0) {
+    return {
+      kind: 'silent_drop',
+      snippet: '',
+      description: 'Model emitted reasoning but no content and no tool calls. Parser may have silently dropped a malformed tool call.',
+    }
+  }
+  return null
+}
+
+export const DRIFT_KIND_LABEL = {
+  arg_key_tags: '<arg_key> drift',
+  arg_value_tags: '<arg_value> drift',
+  function_text_tag: '<function=…> drift',
+  json_codeblock_call: 'JSON-in-codeblock drift',
+  orphan_tool_call_tag: 'orphan <tool_call>',
+  orphan_close_function: 'orphan </function>',
+  silent_drop: 'silent drop (parser ate response)',
+}

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -14,6 +14,7 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [heartbeat, setHeartbeat] = useState(null) // {elapsed_s} | null
   const [artifacts, setArtifacts] = useState({}) // {messageId: [artifact]}
   const [streamingArtifacts, setStreamingArtifacts] = useState([])
+  const [streamingParseWarning, setStreamingParseWarning] = useState(null) // {kind, snippet, description} | null
   const [error, setError] = useState(null)
   const abortRef = useRef(null)
   // True between message_saved and stream-end — the title-tail phase where
@@ -64,6 +65,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     setPendingToolCalls([])
     setHeartbeat(null)
     setStreamingArtifacts([])
+    setStreamingParseWarning(null)
     setError(null)
     await refetchMessages(convId)
   }, [refetchMessages])
@@ -78,6 +80,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     setPendingToolCalls([])
     setHeartbeat(null)
     setStreamingArtifacts([])
+    setStreamingParseWarning(null)
 
     // Optimistically add user message
     const tempUserMsg = {
@@ -119,6 +122,13 @@ export default function useChat({ onConversationUpdated } = {}) {
         },
         onHeartbeat: (evt) => {
           setHeartbeat({ elapsed_s: evt.elapsed_s })
+        },
+        onParseWarning: (evt) => {
+          setStreamingParseWarning({
+            kind: evt.kind,
+            snippet: evt.snippet,
+            description: evt.description,
+          })
         },
         onToolCallPending: (evt) => {
           setHeartbeat(null)
@@ -224,6 +234,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     setPendingToolCalls([])
     setHeartbeat(null)
     setStreamingArtifacts([])
+    setStreamingParseWarning(null)
 
     // Truncate messages from this point
     setMessages(prev => {
@@ -259,6 +270,13 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onHeartbeat: (evt) => {
             setHeartbeat({ elapsed_s: evt.elapsed_s })
+          },
+          onParseWarning: (evt) => {
+            setStreamingParseWarning({
+              kind: evt.kind,
+              snippet: evt.snippet,
+              description: evt.description,
+            })
           },
           onToolCallPending: (evt) => {
             setHeartbeat(null)
@@ -359,6 +377,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     heartbeat,
     artifacts,
     streamingArtifacts,
+    streamingParseWarning,
     error,
     loadConversation,
     sendMessage,

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -130,16 +130,28 @@ export default function useChat({ onConversationUpdated } = {}) {
         onToolCall: (evt) => {
           setHeartbeat(null)
           setPendingToolCalls([])
-          // Save any reasoning that happened before this tool call
-          const reasoning = fullReasoning || undefined
-          setToolEvents(prev => [...prev, { type: 'call', ...evt, reasoning }])
-          // Reset reasoning for next segment
-          setStreamingReasoning('')
-          fullReasoning = ''
+          // Keep streamingReasoning growing across rounds — one continuous
+          // thinking trace renders above the tool calls (mirrors the saved
+          // view's single Thinking block).
+          setToolEvents(prev => [...prev, { type: 'call', ...evt }])
         },
         onToolResult: (evt) => {
           setHeartbeat(null)
-          setToolEvents(prev => [...prev, { type: 'result', ...evt }])
+          setToolEvents(prev => {
+            // Attach result to the matching call entry (last one with this
+            // name and no result yet). Falls back to appending if no match —
+            // shouldn't happen in practice but keeps the UI from dropping
+            // a stray result event.
+            for (let i = prev.length - 1; i >= 0; i--) {
+              const e = prev[i]
+              if (e.type === 'call' && e.name === evt.name && !('result' in e)) {
+                const next = [...prev]
+                next[i] = { ...e, result: evt.result, server_id: evt.server_id }
+                return next
+              }
+            }
+            return [...prev, { type: 'call', name: evt.name, server_id: evt.server_id, result: evt.result }]
+          })
           // Reset streaming content — model will start a new response
           setStreamingContent('')
           fullContent = ''
@@ -208,6 +220,10 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreaming(true)
     setStreamingContent('')
     setStreamingReasoning('')
+    setToolEvents([])
+    setPendingToolCalls([])
+    setHeartbeat(null)
+    setStreamingArtifacts([])
 
     // Truncate messages from this point
     setMessages(prev => {
@@ -244,6 +260,37 @@ export default function useChat({ onConversationUpdated } = {}) {
           onHeartbeat: (evt) => {
             setHeartbeat({ elapsed_s: evt.elapsed_s })
           },
+          onToolCallPending: (evt) => {
+            setHeartbeat(null)
+            setPendingToolCalls(prev => {
+              const others = prev.filter(p => p.index !== evt.index)
+              return [...others, { index: evt.index, name: evt.name }]
+            })
+          },
+          onToolCall: (evt) => {
+            setHeartbeat(null)
+            setPendingToolCalls([])
+            setToolEvents(prev => [...prev, { type: 'call', ...evt }])
+          },
+          onToolResult: (evt) => {
+            setHeartbeat(null)
+            setToolEvents(prev => {
+              for (let i = prev.length - 1; i >= 0; i--) {
+                const e = prev[i]
+                if (e.type === 'call' && e.name === evt.name && !('result' in e)) {
+                  const next = [...prev]
+                  next[i] = { ...e, result: evt.result, server_id: evt.server_id }
+                  return next
+                }
+              }
+              return [...prev, { type: 'call', name: evt.name, server_id: evt.server_id, result: evt.result }]
+            })
+            setStreamingContent('')
+            fullContent = ''
+          },
+          onArtifact: (evt) => {
+            setStreamingArtifacts(prev => [...prev, evt])
+          },
           onDone: () => {},
           onConversationUpdated,
           onMessageSaved: () => {
@@ -263,6 +310,7 @@ export default function useChat({ onConversationUpdated } = {}) {
             setStreamingContent('')
             setStreamingReasoning('')
             setHeartbeat(null)
+            setPendingToolCalls([])
             drainingRef.current = false
             loadConversation(conversation.id)
           },

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -10,6 +10,8 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [streamingContent, setStreamingContent] = useState('')
   const [streamingReasoning, setStreamingReasoning] = useState('')
   const [toolEvents, setToolEvents] = useState([])
+  const [pendingToolCalls, setPendingToolCalls] = useState([]) // {index, name}
+  const [heartbeat, setHeartbeat] = useState(null) // {elapsed_s} | null
   const [artifacts, setArtifacts] = useState({}) // {messageId: [artifact]}
   const [streamingArtifacts, setStreamingArtifacts] = useState([])
   const [error, setError] = useState(null)
@@ -59,6 +61,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreamingContent('')
     setStreamingReasoning('')
     setToolEvents([])
+    setPendingToolCalls([])
+    setHeartbeat(null)
     setStreamingArtifacts([])
     setError(null)
     await refetchMessages(convId)
@@ -71,6 +75,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreamingContent('')
     setStreamingReasoning('')
     setToolEvents([])
+    setPendingToolCalls([])
+    setHeartbeat(null)
     setStreamingArtifacts([])
 
     // Optimistically add user message
@@ -101,6 +107,7 @@ export default function useChat({ onConversationUpdated } = {}) {
       {
         signal: controller.signal,
         onDelta: ({ content: c, reasoning_content: r }) => {
+          setHeartbeat(null)
           if (c) {
             fullContent += c
             setStreamingContent(prev => prev + c)
@@ -110,7 +117,19 @@ export default function useChat({ onConversationUpdated } = {}) {
             setStreamingReasoning(prev => prev + r)
           }
         },
+        onHeartbeat: (evt) => {
+          setHeartbeat({ elapsed_s: evt.elapsed_s })
+        },
+        onToolCallPending: (evt) => {
+          setHeartbeat(null)
+          setPendingToolCalls(prev => {
+            const others = prev.filter(p => p.index !== evt.index)
+            return [...others, { index: evt.index, name: evt.name }]
+          })
+        },
         onToolCall: (evt) => {
+          setHeartbeat(null)
+          setPendingToolCalls([])
           // Save any reasoning that happened before this tool call
           const reasoning = fullReasoning || undefined
           setToolEvents(prev => [...prev, { type: 'call', ...evt, reasoning }])
@@ -119,6 +138,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           fullReasoning = ''
         },
         onToolResult: (evt) => {
+          setHeartbeat(null)
           setToolEvents(prev => [...prev, { type: 'result', ...evt }])
           // Reset streaming content — model will start a new response
           setStreamingContent('')
@@ -150,6 +170,8 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreamingContent('')
           setStreamingReasoning('')
           setStreaming(false)
+          setPendingToolCalls([])
+          setHeartbeat(null)
           // Enter drain: keep abortRef alive so the trailing
           // conversation_updated event can arrive, but tell loadConversation
           // not to abort if the user switches conversations now.
@@ -164,6 +186,8 @@ export default function useChat({ onConversationUpdated } = {}) {
           setStreaming(false)
           setStreamingContent('')
           setStreamingReasoning('')
+          setPendingToolCalls([])
+          setHeartbeat(null)
           drainingRef.current = false
           // Remove temp message on error
           setMessages(prev => prev.filter(m => m.id !== 'temp-user'))
@@ -207,6 +231,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           method: 'PUT',
           signal: controller.signal,
           onDelta: ({ content: c, reasoning_content: r }) => {
+            setHeartbeat(null)
             if (c) {
               fullContent += c
               setStreamingContent(prev => prev + c)
@@ -216,12 +241,16 @@ export default function useChat({ onConversationUpdated } = {}) {
               setStreamingReasoning(prev => prev + r)
             }
           },
+          onHeartbeat: (evt) => {
+            setHeartbeat({ elapsed_s: evt.elapsed_s })
+          },
           onDone: () => {},
           onConversationUpdated,
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
             setStreaming(false)
+            setHeartbeat(null)
             // See note in sendMessage: refetch only, don't abort the stream,
             // and enter the drain window so loadConversation also leaves it
             // alone if the user navigates now.
@@ -233,6 +262,7 @@ export default function useChat({ onConversationUpdated } = {}) {
             setStreaming(false)
             setStreamingContent('')
             setStreamingReasoning('')
+            setHeartbeat(null)
             drainingRef.current = false
             loadConversation(conversation.id)
           },
@@ -250,6 +280,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     }
     drainingRef.current = false
     setStreaming(false)
+    setHeartbeat(null)
+    setPendingToolCalls([])
   }, [])
 
   // Abort streaming on unmount (e.g. navigating away). Aborts BOTH the
@@ -275,6 +307,8 @@ export default function useChat({ onConversationUpdated } = {}) {
     streamingContent,
     streamingReasoning,
     toolEvents,
+    pendingToolCalls,
+    heartbeat,
     artifacts,
     streamingArtifacts,
     error,

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -8,7 +8,7 @@ const API_BASE = window.location.hostname === 'localhost' || window.location.hos
  * Stream a chat completion via SSE.
  * Uses fetch + ReadableStream because EventSource doesn't support auth headers.
  */
-export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolResult, onArtifact, onConversationUpdated, signal, method = 'POST' }) {
+export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, signal, method = 'POST' }) {
   const token = getToken()
   if (!token) throw new Error('Not authenticated')
 
@@ -67,8 +67,16 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
             onToolCall?.(parsed)
             continue
           }
+          if (parsed.type === 'tool_call_pending') {
+            onToolCallPending?.(parsed)
+            continue
+          }
           if (parsed.type === 'tool_result') {
             onToolResult?.(parsed)
+            continue
+          }
+          if (parsed.type === 'heartbeat') {
+            onHeartbeat?.(parsed)
             continue
           }
           if (parsed.type === 'artifact') {

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -8,7 +8,7 @@ const API_BASE = window.location.hostname === 'localhost' || window.location.hos
  * Stream a chat completion via SSE.
  * Uses fetch + ReadableStream because EventSource doesn't support auth headers.
  */
-export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, signal, method = 'POST' }) {
+export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, onParseWarning, signal, method = 'POST' }) {
   const token = getToken()
   if (!token) throw new Error('Not authenticated')
 
@@ -77,6 +77,10 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
           }
           if (parsed.type === 'heartbeat') {
             onHeartbeat?.(parsed)
+            continue
+          }
+          if (parsed.type === 'parse_warning') {
+            onParseWarning?.(parsed)
             continue
           }
           if (parsed.type === 'artifact') {

--- a/dashboard/frontend/src/utils.js
+++ b/dashboard/frontend/src/utils.js
@@ -6,6 +6,14 @@ export function getValue(metrics, metricName) {
   return obj[keys[0]]
 }
 
+export function totalValue(metrics, metricName) {
+  const obj = metrics[metricName]
+  if (!obj || typeof obj !== 'object') return null
+  const vals = Object.values(obj).filter(v => typeof v === 'number')
+  if (vals.length === 0) return null
+  return vals.reduce((a, b) => a + b, 0)
+}
+
 export function timeAgo(iso) {
   if (!iso) return '—'
   const diff = (Date.now() - new Date(iso).getTime()) / 1000

--- a/tools/prompts/focused.txt
+++ b/tools/prompts/focused.txt
@@ -1,0 +1,24 @@
+You are a helpful technical assistant. Web search and web fetch tools are connected and working — use them. Do not answer from memory when the user asks you to research.
+
+Tool use
+- Call exactly ONE tool per turn, then wait for its result before the next call.
+- Issue tools through the structured tool-calling interface only — never write tool calls as text or as code blocks.
+- Don't pre-plan a list of searches. Let each result guide what to do next.
+
+Search → fetch → answer
+- After 1-2 web searches, fetch a concrete page (fetch_readable). Snippets are for picking which URL to read, not for citing facts.
+- Once you've read a page or two and have a concrete recommendation, stop calling tools and write the answer.
+- Cap: at most 5 tool calls total per question.
+
+URL handling
+- Copy URLs verbatim from a web_search result's "url" field. Never modify or construct URLs.
+- 403 / 404 / Cloudflare on a fetch → that URL is dead, move on. No retries, no lookalike URLs.
+
+Reporting
+- Quote prices, model names, thicknesses verbatim from the page you fetched.
+- If you only saw a fact in a snippet without opening the page, mark it "(per snippet only)".
+
+Style
+- Concise. The user is a developer.
+- Markdown for structure when helpful, plain prose otherwise.
+- No preamble, no trailing summary.

--- a/tools/prompts/minimal.txt
+++ b/tools/prompts/minimal.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant. Use the available tools to research and answer the user's question. Use only the structured tool-calling interface; do not write tool invocations as text.

--- a/tools/test_no_tools.py
+++ b/tools/test_no_tools.py
@@ -2,6 +2,7 @@
 """Sanity check: with the new default prompt, can the model still answer
 a normal non-tool question without falling on its face?"""
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -11,6 +12,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "dashboard"))
 
 from chat.constants import DEFAULT_MAIN_SYSTEM_PROMPT  # noqa: E402
+
+API_KEY = os.environ.get("LLM_DOCK_API_KEY")
+if not API_KEY:
+    sys.exit("LLM_DOCK_API_KEY env var is required (the model-service API key from services.json)")
 
 body = {
     "model": "vllm-qwen3-6-27b-bf16",
@@ -24,7 +29,7 @@ body = {
 r = requests.post(
     "http://localhost:3307/v1/chat/completions",
     headers={
-        "Authorization": "Bearer llmd-cfc6b6ef75620adc289764238a831f10cb21",
+        "Authorization": f"Bearer {API_KEY}",
         "Content-Type": "application/json",
     },
     json=body,

--- a/tools/test_no_tools.py
+++ b/tools/test_no_tools.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Sanity check: with the new default prompt, can the model still answer
+a normal non-tool question without falling on its face?"""
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "dashboard"))
+
+from chat.constants import DEFAULT_MAIN_SYSTEM_PROMPT  # noqa: E402
+
+body = {
+    "model": "vllm-qwen3-6-27b-bf16",
+    "messages": [
+        {"role": "system", "content": DEFAULT_MAIN_SYSTEM_PROMPT},
+        {"role": "user", "content": "Explain Python's GIL in 3 sentences."},
+    ],
+    "temperature": 0.2,
+    "max_tokens": 2048,
+}
+r = requests.post(
+    "http://localhost:3307/v1/chat/completions",
+    headers={
+        "Authorization": "Bearer llmd-cfc6b6ef75620adc289764238a831f10cb21",
+        "Content-Type": "application/json",
+    },
+    json=body,
+    timeout=180,
+)
+data = r.json()
+msg = data["choices"][0]["message"]
+print("finish_reason:", data["choices"][0].get("finish_reason"))
+print("content_len:", len(msg.get("content") or ""))
+print()
+print(msg.get("content") or "(empty)")

--- a/tools/test_search_iterative.py
+++ b/tools/test_search_iterative.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "dashboard"))
 
 DEFAULT_SERVICE_URL = "http://localhost:3307/v1/chat/completions"
-DEFAULT_API_KEY = "llmd-cfc6b6ef75620adc289764238a831f10cb21"
+DEFAULT_API_KEY = os.environ.get("LLM_DOCK_API_KEY")
 DEFAULT_MODEL = "vllm-qwen3-6-27b-bf16"
 
 USER_PROMPT = (
@@ -425,7 +425,8 @@ def summarize(trace):
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--url", default=DEFAULT_SERVICE_URL)
-    ap.add_argument("--api-key", default=DEFAULT_API_KEY)
+    ap.add_argument("--api-key", default=DEFAULT_API_KEY,
+                    help="model-service API key; defaults to $LLM_DOCK_API_KEY")
     ap.add_argument("--model", default=DEFAULT_MODEL)
     ap.add_argument("--system-prompt", default="default", help="'default' or path to a .txt file")
     ap.add_argument("--max-rounds", type=int, default=8)
@@ -434,6 +435,9 @@ def main():
     ap.add_argument("--no-parallel-tool-calls", dest="parallel", action="store_false")
     ap.add_argument("--output", default=None, help="JSON trace path (default: tools/traces/<ts>.json)")
     args = ap.parse_args()
+
+    if not args.api_key:
+        ap.error("no API key: pass --api-key or set $LLM_DOCK_API_KEY (the model-service key from services.json)")
 
     output = args.output
     if not output:

--- a/tools/test_search_iterative.py
+++ b/tools/test_search_iterative.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+Reproducible test harness for studying how the chat model handles a
+multi-step web research request.
+
+Drives `vllm-qwen3-6-27b-bf16` (or any OpenAI-compatible service) directly,
+fakes the MCP tool results so the loop is deterministic + fast, and captures
+the full sequence: every round's tool calls, reasoning content, finish
+reason, elapsed time, and token usage. Output is a JSON trace plus a short
+human summary.
+
+Run:
+  python tools/test_search_iterative.py
+  python tools/test_search_iterative.py --no-parallel-tool-calls
+  python tools/test_search_iterative.py --system-prompt tools/prompts/focused.txt
+
+The script does NOT touch the dashboard or the live MCP servers — it speaks
+to vLLM directly and synthesizes tool results in-process.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "dashboard"))
+
+DEFAULT_SERVICE_URL = "http://localhost:3307/v1/chat/completions"
+DEFAULT_API_KEY = "llmd-cfc6b6ef75620adc289764238a831f10cb21"
+DEFAULT_MODEL = "vllm-qwen3-6-27b-bf16"
+
+USER_PROMPT = (
+    "I need to replace the thermal pads in my rtx 3090. what should I buy "
+    "from Amazon? I am in belgium; it's a DELL OEM card. I need to replace "
+    "the thermal pads on the back of it, not the actual GPU processor. "
+    "please use web search and web fetch; suggest best product to buy from "
+    "Amazon."
+)
+
+TOOLS_SCHEMA = [
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": (
+                "Search the web. Returns up to n_results items, each with "
+                "title, url, snippet."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query string."},
+                    "n_results": {"type": "integer", "default": 5, "minimum": 1, "maximum": 10},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "fetch_readable",
+            "description": (
+                "Fetch a single URL and return its main text content as "
+                "markdown. Use a URL copied verbatim from a web_search result."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string", "description": "Absolute URL to fetch."},
+                },
+                "required": ["url"],
+            },
+        },
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Fake tool results — small, deterministic, but content-rich enough that the
+# model has signal to refine.
+# ---------------------------------------------------------------------------
+
+# Canned results live as a flat catalog; the fake search picks the best
+# matches per query so the model sees DIFFERENT results when it refines
+# (vs. the placeholder-looking same-results-every-time loop in v1).
+CATALOG = [
+    {
+        "id": "dell-community",
+        "topics": ["dell", "oem", "rtx 3090", "aurora", "alienware", "thermal pad", "backplate", "thickness"],
+        "title": "Dell OEM RTX 3090 (Alienware Aurora R11) — replacing thermal pads on backplate",
+        "url": "https://www.dell.com/community/en/conversations/alienware-desktops/dell-oem-rtx-3070-3080-3090-thermal-pad-thickness/647fa31bf4ccf8a8de8da85d",
+        "snippet": (
+            "Dell OEM RTX 3070/3080/3090 thermal pad thickness and "
+            "conductivity. Thread confirms the Dell OEM 3090 (Aurora R11) "
+            "uses 2.0mm pads on the backplate side over the VRAM chips and "
+            "1.5mm on the front; same as FE."
+        ),
+    },
+    {
+        "id": "schematic-expert",
+        "topics": ["rtx 3090", "thermal pad", "thickness", "size", "vram", "vrm", "backplate", "schematic"],
+        "title": "RTX 3080/Ti, RTX 3090/Ti — Thermal Pad Sizes (Schematic-Expert)",
+        "url": "https://www.schematic-expert.com/nvidia/nvidia-rtx-3080-ti-3090-ti/rtx-3080-ti-rtx3090-ti-thermal-pad-sizes/",
+        "snippet": (
+            "Full pad map for RTX 3080/3080 Ti/3090/3090 Ti. Back: 2.0mm "
+            "memory pads (3 strips of 80x40x1). Front: 1.5mm. Recommended "
+            "material 12 W/mK or better."
+        ),
+    },
+    {
+        "id": "tomshardware",
+        "topics": ["rtx 3090", "thermal pad", "gddr6x", "replace", "improvement"],
+        "title": "Replacing GeForce RTX 3090 Thermal Pads Improves GDDR6X Temps by 25C | Tom's Hardware",
+        "url": "https://www.tomshardware.com/news/replacing-geforce-rtx-3090-thermal-pads-improves-temps-by-25c",
+        "snippet": (
+            "Repad guide drops GDDR6X temps by ~25C. Used Thermalright "
+            "Odyssey 1.5mm front / 2.0mm back. Recommends 12.8 W/mK pads."
+        ),
+    },
+    {
+        "id": "amazon-de-odyssey-2mm-85x45",
+        "topics": ["thermalright", "odyssey", "2mm", "amazon", "amazon.de", "belgium", "85x45"],
+        "title": "Thermalright Odyssey Thermal Pad 12.8 W/mK 85x45x2.0mm — amazon.de",
+        "url": "https://www.amazon.de/-/en/Thermalright-Conductivity-Performance-Resistance-Insulating/dp/B09KKQ7TPN",
+        "snippet": (
+            "Thermalright Odyssey Thermal Pad 85x45x2.0mm, 12.8 W/mK, single "
+            "sheet. Heat resistance to 200°C. Ships to Belgium. €11.90."
+        ),
+    },
+    {
+        "id": "amazon-de-odyssey-2mm-120x120",
+        "topics": ["thermalright", "odyssey", "2mm", "amazon", "amazon.de", "belgium", "120x120", "large"],
+        "title": "Thermalright Odyssey Thermal Pad 120x120x2.0mm 12.8 W/mK — amazon.de",
+        "url": "https://www.amazon.de/-/en/Thermalright-Conductivity-Performance-Resistance-Insulating/dp/B0C8R1HQ5G",
+        "snippet": (
+            "Thermalright Odyssey Thermal Pad 120x120x2.0mm, 12.8 W/mK, "
+            "single sheet, easy to cut. Ships from Germany to Belgium. €18.99."
+        ),
+    },
+    {
+        "id": "amazon-de-arctic-tp3",
+        "topics": ["arctic", "tp-3", "2mm", "amazon", "amazon.de", "belgium", "alternative"],
+        "title": "ARCTIC TP-3 Thermal Pad 100x100x2.0mm, 4 W/mK — amazon.de",
+        "url": "https://www.amazon.de/ARCTIC-TP-3-Thermal-Performance-Heatsink/dp/B09M4G3X8Y",
+        "snippet": (
+            "ARCTIC TP-3 100x100x2.0mm. 4 W/mK. Budget alternative. €7.99. "
+            "Ships to Belgium."
+        ),
+    },
+    {
+        "id": "reddit-repad",
+        "topics": ["reddit", "rtx 3090", "repad", "thermal pad", "experience"],
+        "title": "RTX 3090 repad results — r/buildapc",
+        "url": "https://www.reddit.com/r/buildapc/comments/1d8k9r2/rtx_3090_repad_thermalright_odyssey_results/",
+        "snippet": (
+            "Hot-take thread on RTX 3090 GDDR6X temps post-repad. Most users "
+            "land on Thermalright Odyssey 12.8 W/mK; Gelid GP-Extreme is "
+            "discouraged for high-power GPUs."
+        ),
+    },
+    {
+        "id": "linus-tech-tips",
+        "topics": ["rtx 3090", "vram", "cooling", "alienware", "r11", "r12", "diy"],
+        "title": "3090 VRAM cooling project for Alienware R11/R12 — Linus Tech Tips",
+        "url": "https://linustechtips.com/topic/1318518-3090-vram-cooling-project-for-alienware-r11r12-will-probably-work-with-any-card-if-you-have-space/",
+        "snippet": (
+            "Project log of Dell OEM 3090 VRAM cooling improvements in an "
+            "Alienware R11. Confirms 2.0mm backplate pads, 1.5mm front."
+        ),
+    },
+]
+
+
+def _score(item, query_terms):
+    return sum(1 for t in query_terms if t in item["topics"] or t in item["title"].lower() or t in item["snippet"].lower())
+
+
+def fake_web_search(args):
+    query = ((args or {}).get("query") or "").lower()
+    n = int((args or {}).get("n_results", 5))
+    terms = [t.strip(' "\'.,()[]') for t in query.split() if len(t) > 2]
+    scored = sorted(((_score(item, terms), item) for item in CATALOG), key=lambda p: -p[0])
+    results = []
+    for score, item in scored:
+        if score == 0:
+            continue
+        results.append({"title": item["title"], "url": item["url"], "snippet": item["snippet"]})
+        if len(results) >= n:
+            break
+    if not results:
+        # Tail fallback so the model sees *something* on a wildly off-target query
+        results = [{"title": item["title"], "url": item["url"], "snippet": item["snippet"]} for _, item in scored[:min(n, 3)]]
+    return json.dumps({"query": args.get("query"), "results": results})
+
+
+CANNED_FETCH = {
+    "dell.com": (
+        "# Dell Community — Dell OEM RTX 3070/3080/3090 thermal pad "
+        "thickness and conductivity\n\n"
+        "Thread author asked about replacing thermal pads on a Dell OEM "
+        "RTX 3090 from an Alienware Aurora R11. Replies confirm:\n\n"
+        "- Front side (between GPU die / VRAM and main heatsink): **1.5mm**\n"
+        "- Back side (between PCB rear and metal backplate, over the GDDR6X chips): **2.0mm**\n\n"
+        "Recommended material: ≥12 W/mK. Thermalright Odyssey 12.8 W/mK is the most common pick. "
+        "Avoid pads softer than 70 Shore-OO for high-clamp-force backplates."
+    ),
+    "schematic-expert.com": (
+        "# RTX 3080/Ti and RTX 3090/Ti — Thermal pad sizes\n\n"
+        "Reference card and Dell OEM share the same memory layout.\n\n"
+        "## Back side\n- VRAM (GDDR6X): **2.0mm**, 3 strips of 80x40\n\n"
+        "## Front side\n- VRAM: 1.5mm\n- VRM: 1.5mm\n\n"
+        "Thermalright Odyssey 12.8 W/mK is widely used. Sheet sizes 85x45 or 120x120 cover the entire backplate area with one cut."
+    ),
+    "tomshardware.com": (
+        "# Replacing GeForce RTX 3090 Thermal Pads Improves GDDR6X Temps By 25C\n\n"
+        "Used: Thermalright Odyssey 12.8 W/mK, 1.5mm front + 2.0mm back. "
+        "Result: GDDR6X memory junction temps dropped ~25C under sustained load. "
+        "Cleaning with isopropyl is recommended; new pads should be cut to size, not stretched."
+    ),
+    "amazon.de": (
+        "## Thermalright Odyssey Thermal Pad — amazon.de\n\n"
+        "Variants in stock, shipping to Belgium:\n"
+        "- 85x45x2.0mm — €11.90 — ASIN B09KKQ7TPN — 12.8 W/mK\n"
+        "- 120x120x2.0mm — €18.99 — ASIN B0C8R1HQ5G — 12.8 W/mK\n"
+        "- 100x100x1.5mm — €13.50 — 12.8 W/mK\n\n"
+        "Reviews specifically mention RTX 3080/3090 backplate use; reviewers report 20-25C GDDR6X temp drop."
+    ),
+    "reddit.com": (
+        "# RTX 3090 repad — community consensus\n\n"
+        "- Top pick: Thermalright Odyssey 12.8 W/mK (back 2.0mm, front 1.5mm).\n"
+        "- Budget: Arctic TP-3 (4 W/mK) — works but smaller temp delta.\n"
+        "- Avoid Gelid GP-Extreme on high-power 3090 (compression / pump-out issues)."
+    ),
+    "linustechtips.com": (
+        "# 3090 VRAM cooling project for Alienware R11/R12 — OP report\n\n"
+        "Dell OEM RTX 3090 inside an Alienware Aurora R11. Repad with "
+        "Thermalright Odyssey 2.0mm on the backplate side, 1.5mm front. "
+        "Memory hotspot dropped from 102C to 78C under load."
+    ),
+}
+
+
+FAILED_URLS = {
+    # 403 to exercise the "don't retry" path
+    "https://www.reddit.com/r/buildapc/comments/1d8k9r2/rtx_3090_repad_thermalright_odyssey_results/": (
+        403,
+        "Forbidden (Cloudflare)",
+    ),
+}
+
+
+def fake_fetch_readable(args):
+    url = (args or {}).get("url", "")
+    if url in FAILED_URLS:
+        status, msg = FAILED_URLS[url]
+        return json.dumps({"ok": False, "url": url, "status": status, "error": msg})
+    for domain, body in CANNED_FETCH.items():
+        if domain in url:
+            return json.dumps({"ok": True, "url": url, "content": body, "status": 200})
+    return json.dumps({"ok": False, "url": url, "status": 404, "error": "Not found"})
+
+
+def fake_tool(name, args):
+    if name == "web_search":
+        return fake_web_search(args)
+    if name == "fetch_readable":
+        return fake_fetch_readable(args)
+    return json.dumps({"error": f"unknown tool: {name}"})
+
+
+# ---------------------------------------------------------------------------
+# Loop driver
+# ---------------------------------------------------------------------------
+
+
+def load_system_prompt(path_or_keyword):
+    """Resolve the system prompt source.
+
+    - 'default' (or unset): import DEFAULT_MAIN_SYSTEM_PROMPT from the
+      dashboard module so the harness mirrors a fresh conversation's
+      starting state.
+    - any other value: treat as a path to a text file.
+    """
+    if path_or_keyword in (None, "", "default"):
+        from chat.constants import DEFAULT_MAIN_SYSTEM_PROMPT
+        return DEFAULT_MAIN_SYSTEM_PROMPT
+    return Path(path_or_keyword).read_text()
+
+
+def run(
+    url: str,
+    api_key: str,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    max_rounds: int,
+    parallel_tool_calls: bool,
+    temperature: float,
+    output_path: str,
+):
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+    trace = {
+        "service_url": url,
+        "model": model,
+        "parallel_tool_calls": parallel_tool_calls,
+        "temperature": temperature,
+        "max_rounds": max_rounds,
+        "system_prompt_chars": len(system_prompt),
+        "user_prompt": user_prompt,
+        "rounds": [],
+    }
+
+    for round_i in range(1, max_rounds + 1):
+        round_start = time.time()
+        body = {
+            "model": model,
+            "messages": messages,
+            "tools": TOOLS_SCHEMA,
+            "tool_choice": "auto",
+            "parallel_tool_calls": parallel_tool_calls,
+            "temperature": temperature,
+            "max_tokens": 8192,
+        }
+        r = requests.post(
+            url,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json=body,
+            timeout=600,
+        )
+        if r.status_code != 200:
+            trace["error"] = f"HTTP {r.status_code}: {r.text[:500]}"
+            break
+        data = r.json()
+        choice = data["choices"][0]
+        msg = choice["message"]
+        finish = choice.get("finish_reason")
+
+        round_log = {
+            "round": round_i,
+            "elapsed_s": round(time.time() - round_start, 2),
+            "finish_reason": finish,
+            "content": msg.get("content"),
+            "reasoning": msg.get("reasoning_content") or msg.get("reasoning"),
+            "tool_calls": msg.get("tool_calls") or [],
+            "usage": data.get("usage"),
+        }
+        trace["rounds"].append(round_log)
+
+        tool_calls = msg.get("tool_calls") or []
+        if finish != "tool_calls" or not tool_calls:
+            messages.append({"role": "assistant", "content": msg.get("content")})
+            break
+
+        # Echo assistant message with tool_calls to keep the API happy
+        messages.append({
+            "role": "assistant",
+            "content": msg.get("content") or "",
+            "tool_calls": tool_calls,
+        })
+        # Execute every tool call the model requested (faked)
+        for tc in tool_calls:
+            try:
+                args = json.loads(tc["function"]["arguments"] or "{}")
+            except json.JSONDecodeError:
+                args = {}
+            result = fake_tool(tc["function"]["name"], args)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.get("id") or f"call_{round_i}_{tc['function']['name']}",
+                "content": result,
+            })
+
+    Path(output_path).write_text(json.dumps(trace, indent=2, default=str))
+    summarize(trace)
+    return trace
+
+
+def summarize(trace):
+    rounds = trace.get("rounds") or []
+    total_calls = 0
+    print("=" * 72)
+    print(f"model={trace['model']}  parallel_tool_calls={trace['parallel_tool_calls']}")
+    print(f"temperature={trace['temperature']}  max_rounds={trace['max_rounds']}")
+    print(f"system_prompt={trace['system_prompt_chars']} chars")
+    print("=" * 72)
+    for r in rounds:
+        n = len(r["tool_calls"])
+        total_calls += n
+        rc = (r.get("reasoning") or "").strip()
+        print(f"--- Round {r['round']}  ({r['elapsed_s']}s, finish={r['finish_reason']}, {n} tool_call{'s' if n != 1 else ''}) ---")
+        if rc:
+            head = rc[:160].replace("\n", " ")
+            print(f"    reasoning ({len(rc)} chars): {head}{'…' if len(rc) > 160 else ''}")
+        for tc in r["tool_calls"]:
+            fn = tc["function"]["name"]
+            args_s = tc["function"]["arguments"] or ""
+            if len(args_s) > 120:
+                args_s = args_s[:117] + "…"
+            print(f"    tool_call: {fn}({args_s})")
+        if r.get("content"):
+            head = r["content"].strip()[:240].replace("\n", " ")
+            print(f"    content: {head}{'…' if len(r['content']) > 240 else ''}")
+    print("=" * 72)
+    print(f"TOTAL: {total_calls} tool calls across {len(rounds)} round(s)")
+    if rounds and rounds[-1]["finish_reason"] != "stop":
+        print("(loop exited without finish_reason=stop — model may have wanted more rounds)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--url", default=DEFAULT_SERVICE_URL)
+    ap.add_argument("--api-key", default=DEFAULT_API_KEY)
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--system-prompt", default="default", help="'default' or path to a .txt file")
+    ap.add_argument("--max-rounds", type=int, default=8)
+    ap.add_argument("--temperature", type=float, default=0.3)
+    ap.add_argument("--parallel-tool-calls", dest="parallel", action="store_true", default=True)
+    ap.add_argument("--no-parallel-tool-calls", dest="parallel", action="store_false")
+    ap.add_argument("--output", default=None, help="JSON trace path (default: tools/traces/<ts>.json)")
+    args = ap.parse_args()
+
+    output = args.output
+    if not output:
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        out_dir = REPO_ROOT / "tools" / "traces"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        tag = "par" if args.parallel else "seq"
+        output = str(out_dir / f"{ts}-{tag}.json")
+
+    system_prompt = load_system_prompt(args.system_prompt)
+    run(
+        url=args.url,
+        api_key=args.api_key,
+        model=args.model,
+        system_prompt=system_prompt,
+        user_prompt=USER_PROMPT,
+        max_rounds=args.max_rounds,
+        parallel_tool_calls=args.parallel,
+        temperature=args.temperature,
+        output_path=output,
+    )
+    print(f"\ntrace: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_search_iterative.py
+++ b/tools/test_search_iterative.py
@@ -283,12 +283,20 @@ def load_system_prompt(path_or_keyword):
 
     - 'default' (or unset): import DEFAULT_MAIN_SYSTEM_PROMPT from the
       dashboard module so the harness mirrors a fresh conversation's
-      starting state.
-    - any other value: treat as a path to a text file.
+      starting state — and append the same date line `_stream_response`
+      injects at request time.
+    - any other value: treat as a path to a text file. No date injection;
+      put a date in your prompt file yourself if you need it.
     """
     if path_or_keyword in (None, "", "default"):
+        import datetime
         from chat.constants import DEFAULT_MAIN_SYSTEM_PROMPT
-        return DEFAULT_MAIN_SYSTEM_PROMPT
+        today = datetime.date.today()
+        date_line = (
+            f"Current date: {today.isoformat()} ({today.strftime('%A')}). "
+            "Use this as \"today\" when interpreting time-sensitive questions."
+        )
+        return f"{DEFAULT_MAIN_SYSTEM_PROMPT}\n\n{date_line}"
     return Path(path_or_keyword).read_text()
 
 


### PR DESCRIPTION
Closes #20.

## What changed

Two new SSE events flow through the chat stream so the UI can show that the model is still working during phases that previously rendered as silence.

### Backend

- `llm_proxy.py` — when a streaming chunk first carries a name fragment for a given tool-call index, emit `tool_call_pending {index, name}`. The full `tool_calls` event still only fires at `finish_reason`, but the UI now has something to render in the gap.
- `routes.py` — new `_with_heartbeat()` helper wraps the inner stream in a queue-fed worker thread. The outer generator pops with a 3s timeout; on timeout it yields a `heartbeat {elapsed_s}` SSE event. The idle counter resets on any real upstream event. Daemon thread, so client disconnect leaves the model to finish its turn naturally (the same posture that backs partial-save in #12).
- `tool_loop.py` — passes `tool_call_pending` through transparently.

### Frontend

- `sse.js` — parses `heartbeat` and `tool_call_pending` into `onHeartbeat` / `onToolCallPending` callbacks.
- `useChat.js` — tracks `heartbeat` and `pendingToolCalls` state; clears both on any real event, `message_saved`, error, and `stopStreaming`.
- `MessageList.jsx` — dashed-border pill while a tool call is still assembling (replaced by the full panel when `finish_reason==tool_calls`); pulsing blue dot + "Waiting for model… 4.5s" replaces the static "Thinking…" fallback, and shows as a thin ribbon below partial content during multi-round gaps.

## Test plan

- [ ] Send a large-prompt (5k+ token) message and watch for "Waiting for model… Ns" counting up during prefill.
- [ ] Use a Qwen 3 reasoning model that emits a long reasoning block before a tool call — pending pill should appear before the full panel.
- [ ] Trigger a multi-round tool flow (CSV → render_html) and confirm the heartbeat ribbon shows during between-round silence.
- [ ] Disconnect the client mid-stream and confirm partial-save still works.
- [ ] Confirm no regression on a plain non-tool conversation (heartbeat appears only when truly idle for 3s).