### PR TITLE
feat(security): one-click default API key rotation (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,35 @@ entries — but it also means a **typo** in the flag name (e.g. `--gpu-mem`)
 ships to the container as-is and fails at startup, not at config time.
 Verify with `mgr.preview_service(name)` before bringing the container up.
 
+## Default API key rotation
+
+All model services share one **default API key**: `LLM_DOCK_API_KEY` in
+`dashboard/.env` (exposed as `config.GLOBAL_API_KEY`), mirrored into every
+service's `api_key` in `services.json`. The dashboard can rotate it in one
+click (Services table → "Rotate default key"):
+
+- `GET /api/default-api-key/rotation-preview` — impact only, mutates
+  nothing: counts services, lists running containers (will be stopped) and
+  Open WebUI-registered services (keys go stale).
+- `POST /api/default-api-key/rotate` — generates a new key, writes it to
+  `.env` via `config.set_global_api_key()`, rewrites every `services.json`
+  entry, rebuilds `docker-compose.yml`, then **stops** every running
+  affected container (they keep the revoked key in memory; they are not
+  auto-restarted — start them manually afterwards).
+
+Gotchas:
+
+- Reference `config.GLOBAL_API_KEY` (the module attribute), not a
+  `from config import GLOBAL_API_KEY` name binding — only the attribute
+  reflects an in-process rotation without a dashboard restart.
+- **Open WebUI is not touched.** It stores its own copy of each
+  connection's key in its sqlite DB; after rotation those are stale and
+  must be re-entered manually under Open WebUI → Admin → Settings →
+  Connections. The preview/rotate responses list the affected services.
+- Core rotation logic is `key_rotation.rotate_keys_in_db()` (pure, unit
+  tested in `dashboard/tests/test_key_rotation.py`); container stops and
+  preview live in `routes/services.py`.
+
 ## Adding an external MCP server
 
 Built-in MCP tools live in `dashboard/chat/mcp_registry.py` and ship with

--- a/dashboard/benchmarking/routes.py
+++ b/dashboard/benchmarking/routes.py
@@ -3,6 +3,7 @@ import os
 from flask import Blueprint, jsonify, request, current_app
 
 from auth import require_auth
+from db_lock import serialize_db
 from .db import BenchmarkDB
 from .executor import BenchmarkExecutor
 from .validators import validate_params, validate_service_name, BENCHMARK_ONLY_FLAGS
@@ -137,6 +138,7 @@ def delete_benchmark(run_id):
 
 @benchmarks_bp.route("/api/benchmarks/<run_id>/apply", methods=["PUT"])
 @require_auth
+@serialize_db
 def apply_benchmark(run_id):
     db = current_app.config["BENCHMARK_DB"]
     run = db.get_run(run_id)

--- a/dashboard/compose_manager.py
+++ b/dashboard/compose_manager.py
@@ -5,6 +5,7 @@ Docker Compose file manager with safe atomic updates.
 import os
 import shutil
 import subprocess
+import tempfile
 import fcntl
 import yaml
 import json
@@ -408,9 +409,27 @@ class ComposeManager:
             return {}
 
     def _save_services_db(self, services: Dict[str, Any]):
-        """Save services database to JSON file"""
-        with open(self.services_db_path, "w") as f:
-            json.dump(services, f, indent=2)
+        """Save services database to JSON file atomically.
+
+        Write to a same-directory temp file, fsync, then ``os.replace()`` so
+        an interrupted/failed write can never leave a truncated or partial
+        ``services.json`` (which ``_load_services_db`` would silently treat as
+        ``{}``, dropping every dynamic service on the next compose rebuild).
+        """
+        directory = self.services_db_path.parent
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".services.", suffix=".json.tmp", dir=str(directory)
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(services, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.services_db_path)
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
 
     def save_services_db(self, services: Dict[str, Any]):
         """Replace the entire services database in one write.

--- a/dashboard/compose_manager.py
+++ b/dashboard/compose_manager.py
@@ -412,6 +412,16 @@ class ComposeManager:
         with open(self.services_db_path, "w") as f:
             json.dump(services, f, indent=2)
 
+    def save_services_db(self, services: Dict[str, Any]):
+        """Replace the entire services database in one write.
+
+        Used by atomic multi-service operations (e.g. default API key
+        rotation) that must commit all entries together rather than
+        per-service, so a mid-operation failure can't leave services.json
+        half-rotated.
+        """
+        self._save_services_db(services)
+
     def add_service_to_db(self, service_name: str, config: Dict[str, Any]):
         """Add service to database"""
         services = self._load_services_db()

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,8 +1,10 @@
 import os
 import logging
-from dotenv import load_dotenv
+from dotenv import load_dotenv, set_key
 
-load_dotenv()
+# Resolve .env next to this file so it works regardless of CWD.
+DOTENV_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+load_dotenv(DOTENV_PATH)
 
 DASHBOARD_PORT = int(os.getenv("DASHBOARD_PORT", 3305))
 DASHBOARD_HOST = os.getenv("DASHBOARD_HOST", "127.0.0.1")
@@ -11,6 +13,19 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 COMPOSE_FILE = os.getenv("COMPOSE_FILE", "../docker-compose.yml")
 COMPOSE_PROJECT = os.getenv("COMPOSE_PROJECT_NAME", "dockerized-models")
 GLOBAL_API_KEY = os.getenv("LLM_DOCK_API_KEY")
+
+
+def set_global_api_key(new_key: str, dotenv_path: str = DOTENV_PATH):
+    """Persist a new global API key to .env and update the in-process value.
+
+    Other modules must reference ``config.GLOBAL_API_KEY`` (not a name imported
+    via ``from config import GLOBAL_API_KEY``) to observe the rotated value
+    without a process restart.
+    """
+    global GLOBAL_API_KEY
+    set_key(dotenv_path, "LLM_DOCK_API_KEY", new_key)
+    GLOBAL_API_KEY = new_key
+    return new_key
 
 
 _config_initialized = False

--- a/dashboard/db_lock.py
+++ b/dashboard/db_lock.py
@@ -1,0 +1,33 @@
+"""Shared lock serializing every services.json read-modify-write + compose
+rebuild, across *all* blueprints (services routes and benchmarking routes).
+
+Flask's dev server runs threaded (``app.run`` defaults ``threaded=True``), so
+handlers in different blueprints that each do
+``load services.json -> mutate -> save -> rebuild_compose_file`` can interleave
+and clobber each other (e.g. benchmark "apply" writing a stale full service
+config back over a concurrent key rotation). The lock must live below every
+blueprint so they all contend on the *same* object.
+
+``RLock`` (not ``Lock``) so a handler that nests guarded helpers on the same
+thread can't self-deadlock.
+"""
+
+import threading
+from functools import wraps
+
+SERVICES_DB_LOCK = threading.RLock()
+
+
+def serialize_db(fn):
+    """Run the wrapped Flask view under :data:`SERVICES_DB_LOCK`.
+
+    Place it *below* ``@require_auth`` so unauthenticated requests are
+    rejected without contending for the lock.
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        with SERVICES_DB_LOCK:
+            return fn(*args, **kwargs)
+
+    return wrapper

--- a/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
+++ b/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
@@ -62,7 +62,11 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
       <div className="bg-gray-800 rounded-lg border border-gray-700 max-w-xl w-full max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
         <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
           <h3 className="text-lg font-semibold text-gray-200">
-            {result ? 'Default API Key Rotated' : 'Rotate Default API Key'}
+            {result
+              ? (result.success === false
+                  ? 'Default API Key Rotated — Action Required'
+                  : 'Default API Key Rotated')
+              : 'Rotate Default API Key'}
           </h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-200 cursor-pointer" aria-label="Close">✕</button>
         </div>

--- a/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
+++ b/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
@@ -1,0 +1,172 @@
+import { useState, useEffect, useCallback } from 'react'
+import { fetchAPI } from '../api'
+
+function KeyCopy({ value }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="flex items-center gap-2 bg-gray-900 border border-gray-700 rounded px-3 py-2">
+      <code className="text-green-300 text-xs break-all flex-1">{value}</code>
+      <button
+        onClick={() => {
+          navigator.clipboard.writeText(value)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        }}
+        className="text-gray-400 hover:text-gray-200 text-lg leading-none cursor-pointer shrink-0"
+        title="Copy"
+      >
+        {copied ? '✓' : '⧉'}
+      </button>
+    </div>
+  )
+}
+
+function ServiceList({ names }) {
+  return (
+    <ul className="mt-1.5 max-h-40 overflow-auto text-xs font-mono text-gray-300 space-y-0.5 pl-1">
+      {names.map(n => <li key={n}>• {n}</li>)}
+    </ul>
+  )
+}
+
+export default function RotateDefaultKeyModal({ onClose, onDone }) {
+  const [preview, setPreview] = useState(null)
+  const [error, setError] = useState(null)
+  const [rotating, setRotating] = useState(false)
+  const [result, setResult] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchAPI('/default-api-key/rotation-preview')
+      .then(d => { if (!cancelled) setPreview(d) })
+      .catch(e => { if (!cancelled) setError(e.message) })
+    return () => { cancelled = true }
+  }, [])
+
+  const handleRotate = useCallback(async () => {
+    setRotating(true)
+    setError(null)
+    try {
+      const d = await fetchAPI('/default-api-key/rotate', { method: 'POST' })
+      setResult(d)
+      onDone?.()
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setRotating(false)
+    }
+  }, [onDone])
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div className="bg-gray-800 rounded-lg border border-gray-700 max-w-xl w-full max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
+          <h3 className="text-lg font-semibold text-gray-200">
+            {result ? 'Default API Key Rotated' : 'Rotate Default API Key'}
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-200 cursor-pointer" aria-label="Close">✕</button>
+        </div>
+
+        <div className="px-5 py-4 overflow-auto space-y-4 text-sm text-gray-300">
+          {error && (
+            <div className="bg-red-900/40 border border-red-700 text-red-300 rounded px-3 py-2">{error}</div>
+          )}
+
+          {/* Result view */}
+          {result && (
+            <>
+              <p>{result.message}</p>
+              <div>
+                <p className="text-gray-400 mb-1">New default API key (shared by all services):</p>
+                <KeyCopy value={result.new_api_key} />
+              </div>
+              {result.stopped?.length > 0 && (
+                <div>
+                  <p className="text-gray-400">Stopped containers (restart them when ready):</p>
+                  <ServiceList names={result.stopped} />
+                </div>
+              )}
+              {Object.keys(result.stop_errors || {}).length > 0 && (
+                <div className="bg-red-900/40 border border-red-700 text-red-300 rounded px-3 py-2">
+                  <p>Some containers failed to stop:</p>
+                  <ul className="mt-1 text-xs font-mono space-y-0.5">
+                    {Object.entries(result.stop_errors).map(([n, e]) => <li key={n}>• {n}: {e}</li>)}
+                  </ul>
+                </div>
+              )}
+              {result.openwebui_registered?.length > 0 && (
+                <div className="bg-amber-900/30 border border-amber-700/60 text-amber-200 rounded px-3 py-2">
+                  <p className="font-medium">⚠ Open WebUI still holds the old key</p>
+                  <p className="mt-1 text-xs">
+                    Open WebUI keeps its own copy of each connection's API key. Update it in
+                    {' '}<span className="font-mono">Admin → Settings → Connections</span> for these registered services:
+                  </p>
+                  <ServiceList names={result.openwebui_registered} />
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Confirmation view */}
+          {!result && !preview && !error && (
+            <p className="text-gray-500">Loading impact…</p>
+          )}
+
+          {!result && preview && (
+            <>
+              <p>
+                This generates a new shared API key, writes it to
+                {' '}<span className="font-mono">.env</span> and applies it to all
+                {' '}<span className="font-semibold text-gray-100">{preview.total_services}</span> service(s)
+                in <span className="font-mono">services.json</span> and the compose file.
+              </p>
+
+              {preview.running.length > 0 ? (
+                <div className="bg-red-900/30 border border-red-700/60 text-red-200 rounded px-3 py-2">
+                  <p className="font-medium">⚠ {preview.running.length} running model(s) will be STOPPED</p>
+                  <p className="mt-1 text-xs">They keep serving the revoked key until stopped. Restart them manually afterwards.</p>
+                  <ServiceList names={preview.running} />
+                </div>
+              ) : (
+                <p className="text-gray-500 text-xs">No running models — nothing will be stopped.</p>
+              )}
+
+              {preview.openwebui_registered.length > 0 && (
+                <div className="bg-amber-900/30 border border-amber-700/60 text-amber-200 rounded px-3 py-2">
+                  <p className="font-medium">⚠ Open WebUI needs a manual update</p>
+                  <p className="mt-1 text-xs">
+                    These services are registered in Open WebUI, which stores its own copy of the key.
+                    After rotation they will fail in Open WebUI until you re-enter the new key under
+                    {' '}<span className="font-mono">Admin → Settings → Connections</span>:
+                  </p>
+                  <ServiceList names={preview.openwebui_registered} />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="px-5 py-4 border-t border-gray-700 flex justify-end gap-3">
+          {result ? (
+            <button onClick={onClose} className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors cursor-pointer">
+              Done
+            </button>
+          ) : (
+            <>
+              <button onClick={onClose} disabled={rotating} className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors disabled:opacity-50 cursor-pointer">
+                Cancel
+              </button>
+              <button
+                onClick={handleRotate}
+                disabled={rotating || !preview}
+                className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white text-sm rounded transition-colors disabled:opacity-50 cursor-pointer"
+              >
+                {rotating ? 'Rotating…' : 'Rotate key'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { fetchAPI } from '../api'
 import { startService, stopService, restartService } from '../services/lifecycle'
 import useServicesSSE from '../hooks/useServicesSSE'
+import RotateDefaultKeyModal from './RotateDefaultKeyModal'
 
 function getEngine(name) {
   if (name === 'open-webui') return 'WebUI'
@@ -168,6 +169,7 @@ export default function ServicesTable() {
   const [transitioning, setTransitioning] = useState({})
   const [toast, setToast] = useState(null)
   const [search, setSearch] = useState('')
+  const [showRotateKey, setShowRotateKey] = useState(false)
 
   const withTransition = useCallback(async (name, action, apiCall) => {
     setTransitioning(prev => ({ ...prev, [name]: action }))
@@ -286,6 +288,14 @@ export default function ServicesTable() {
             )}
           </div>
           <button
+            onClick={() => setShowRotateKey(true)}
+            className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors flex items-center gap-1.5"
+            title="Generate a new shared API key for all services"
+          >
+            <i className="fa-solid fa-key text-xs"></i>
+            Rotate default key
+          </button>
+          <button
             onClick={() => navigate('/services/new')}
             className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition-colors"
           >
@@ -338,6 +348,12 @@ export default function ServicesTable() {
         </table>
       </div>
       {toast && <Toast message={toast} onDone={() => setToast(null)} />}
+      {showRotateKey && (
+        <RotateDefaultKeyModal
+          onClose={() => setShowRotateKey(false)}
+          onDone={refresh}
+        />
+      )}
     </div>
   )
 }

--- a/dashboard/frontend/src/components/TokenSparkline.test.jsx
+++ b/dashboard/frontend/src/components/TokenSparkline.test.jsx
@@ -16,8 +16,10 @@ describe('TokenSparkline', () => {
     const { container } = render(<TokenSparkline history={[
       { promptTokensRate: 12.5, generationTokensRate: 33.3 }
     ]} />)
-    expect(container.textContent).toMatch(/Prompt: 12\.5 t\/s/)
-    expect(container.textContent).toMatch(/Gen: 33\.3 t\/s/)
+    // Label and value are separate spans (spaced via CSS flex gap), so
+    // textContent has no literal space between them — match optionally.
+    expect(container.textContent).toMatch(/Prompt:\s*12\.5 t\/s/)
+    expect(container.textContent).toMatch(/Gen:\s*33\.3 t\/s/)
   })
 
   it('empty history still renders canvas (placeholder drawn on canvas)', () => {

--- a/dashboard/key_rotation.py
+++ b/dashboard/key_rotation.py
@@ -29,19 +29,40 @@ def rotate_keys_in_db(compose_mgr, new_key: str | None = None) -> dict:
         ``{"new_key": str, "updated": [service_name, ...]}`` — ``updated`` lists
         services whose key actually changed (already-matching entries are left
         untouched, but compose is still rebuilt for consistency).
+
+    Atomicity: ``services.json`` is written in a single replace (not
+    per-service), and if the compose rebuild fails the original
+    ``services.json`` is restored before re-raising — so a failure leaves
+    ``services.json`` and ``docker-compose.yml`` consistent with each other
+    and with the pre-rotation key. The caller is responsible for ordering
+    the ``.env`` commit *after* this returns successfully.
     """
     if not new_key:
         new_key = generate_api_key()
 
+    # Two independent fresh loads: one to mutate, one kept as the rollback
+    # snapshot of the on-disk state before any write.
     services = compose_mgr.list_services_in_db()
-    updated = []
-    for name, config in services.items():
-        if config.get("api_key") != new_key:
-            config["api_key"] = new_key
-            compose_mgr.update_service_in_db(name, config)
-            updated.append(name)
+    original = compose_mgr.list_services_in_db()
 
-    compose_mgr.rebuild_compose_file()
+    updated = [
+        name
+        for name, cfg in services.items()
+        if cfg.get("api_key") != new_key
+    ]
+    for cfg in services.values():
+        cfg["api_key"] = new_key
+
+    compose_mgr.save_services_db(services)
+    try:
+        compose_mgr.rebuild_compose_file()
+    except Exception:
+        # Restore services.json so it stays consistent with the compose
+        # file (rebuild_compose_file already rolled docker-compose.yml back
+        # to its pre-call backup on failure).
+        compose_mgr.save_services_db(original)
+        raise
+
     logger.info(
         "Rotated default API key across %d service(s) (%d changed)",
         len(services),

--- a/dashboard/key_rotation.py
+++ b/dashboard/key_rotation.py
@@ -1,0 +1,50 @@
+"""Default API-key rotation.
+
+The "default API key" is the single shared key every model service in
+``services.json`` authenticates with, mirrored into ``LLM_DOCK_API_KEY`` in
+``.env``. Rotating it rewrites every service entry, regenerates the compose
+file, and (at the route layer) stops any running containers so they don't keep
+serving with the now-revoked key still held in memory.
+
+This module holds the pure, file-level mutation so it can be unit tested
+without Docker.
+"""
+
+import logging
+
+from service_templates import generate_api_key
+
+logger = logging.getLogger(__name__)
+
+
+def rotate_keys_in_db(compose_mgr, new_key: str | None = None) -> dict:
+    """Set every service's ``api_key`` to ``new_key`` and rebuild compose.
+
+    Args:
+        compose_mgr: a :class:`ComposeManager` bound to the target
+            ``docker-compose.yml`` / ``services.json``.
+        new_key: the key to apply. Generated if not supplied.
+
+    Returns:
+        ``{"new_key": str, "updated": [service_name, ...]}`` — ``updated`` lists
+        services whose key actually changed (already-matching entries are left
+        untouched, but compose is still rebuilt for consistency).
+    """
+    if not new_key:
+        new_key = generate_api_key()
+
+    services = compose_mgr.list_services_in_db()
+    updated = []
+    for name, config in services.items():
+        if config.get("api_key") != new_key:
+            config["api_key"] = new_key
+            compose_mgr.update_service_in_db(name, config)
+            updated.append(name)
+
+    compose_mgr.rebuild_compose_file()
+    logger.info(
+        "Rotated default API key across %d service(s) (%d changed)",
+        len(services),
+        len(updated),
+    )
+    return {"new_key": new_key, "updated": updated}

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -891,10 +891,25 @@ def rotate_default_api_key():
         db_services, running, openwebui_registered = _affected_services_state()
 
         new_key = generate_api_key()
-        config.set_global_api_key(new_key)
-
         compose_mgr = ComposeManager(COMPOSE_FILE)
+
+        # Snapshot before any mutation so a late failure can fully roll back.
+        services_before = compose_mgr.list_services_in_db()
+
+        # Commit the riskiest, validated work (services.json + compose) FIRST.
+        # rotate_keys_in_db self-rolls-back services.json/compose on failure,
+        # so if this raises nothing has been changed and .env is untouched.
         result = rotate_keys_in_db(compose_mgr, new_key)
+
+        # Only now commit .env / in-process key. If this fails, undo the
+        # services.json + compose changes so we never advertise a new key
+        # while files still hold the old one (or vice versa).
+        try:
+            config.set_global_api_key(new_key)
+        except Exception:
+            compose_mgr.save_services_db(services_before)
+            compose_mgr.rebuild_compose_file()
+            raise
 
         stopped = []
         stop_errors = {}

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -120,8 +120,15 @@ def get_service(service_name):
 
 @services_bp.route("/api/services/<service_name>/start", methods=["POST"])
 @require_auth
+@_serialize_db
 def start_service(service_name):
-    """Start a Docker Compose service"""
+    """Start a Docker Compose service.
+
+    Serialized on the shared lock so a start can't `docker compose up` with
+    the pre-rotation compose file mid-rotation and bring a container up on
+    the just-revoked key (rotation only stops the containers it snapshotted
+    as running, so such a container would otherwise be missed).
+    """
     result = control_service(service_name, "start")
 
     if result["success"]:
@@ -134,8 +141,10 @@ def start_service(service_name):
 
 @services_bp.route("/api/services/<service_name>/stop", methods=["POST"])
 @require_auth
+@_serialize_db
 def stop_service(service_name):
-    """Stop a Docker Compose service"""
+    """Stop a Docker Compose service (serialized on the shared lock for
+    symmetry with start/rotation)."""
     result = control_service(service_name, "stop")
 
     if result["success"]:

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -3,12 +3,12 @@ import logging
 import threading
 import time
 import subprocess
-from functools import wraps
 from datetime import datetime
 from typing import Generator
 from flask import Blueprint, jsonify, request, Response, stream_with_context, current_app
 
 from auth import require_auth
+from db_lock import SERVICES_DB_LOCK, serialize_db
 import config
 from config import COMPOSE_FILE
 from compose_manager import ComposeManager
@@ -32,29 +32,10 @@ logger = logging.getLogger(__name__)
 
 services_bp = Blueprint("services", __name__)
 
-# Serializes every services.json read-modify-write + compose rebuild.
-# Flask's dev server runs threaded (app.run defaults threaded=True), so
-# create/update/delete/rename/set-*-key and key rotation can otherwise
-# interleave: e.g. rotation snapshots the DB, a concurrent create adds a
-# service and rebuilds, then rotation writes its stale snapshot back and
-# drops the just-created service. One process-wide RLock around all of
-# these makes each a critical section. RLock (not Lock) so a handler that
-# nests guarded helpers in the same thread can't self-deadlock.
-_SERVICES_DB_LOCK = threading.RLock()
-
-
-def _serialize_db(fn):
-    """Run the view under the shared services-DB lock.
-
-    Placed below @require_auth so unauthenticated requests are rejected
-    without contending for the lock.
-    """
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        with _SERVICES_DB_LOCK:
-            return fn(*args, **kwargs)
-
-    return wrapper
+# Shared across all blueprints — see db_lock.py. Aliased to preserve the
+# existing private-looking names used throughout this module.
+_SERVICES_DB_LOCK = SERVICES_DB_LOCK
+_serialize_db = serialize_db
 def _recreate_if_running(service_name):
     """Recreate the container if it was running. Returns restart status dict."""
     container = get_service_container(service_name)
@@ -953,27 +934,46 @@ def rotate_default_api_key():
                 else:
                     stop_errors[name] = res.get("error", "unknown error")
 
+        # A failed stop is a partial failure: the key is rotated in
+        # services.json/.env, but that container keeps accepting the OLD key
+        # in memory until stopped. Don't report unqualified success — callers
+        # that key off `success`/HTTP status must not treat the old key as
+        # revoked when it isn't.
+        ok = not stop_errors
+
         logger.info(
-            "Default API key rotated: %d services updated, %d containers stopped",
+            "Default API key rotated: %d services updated, %d stopped, %d stop failures",
             len(result["updated"]),
             len(stopped),
+            len(stop_errors),
         )
+
+        if ok:
+            message = (
+                f"Default API key rotated across {len(result['updated'])} "
+                f"service(s); {len(stopped)} running container(s) stopped."
+            )
+        else:
+            message = (
+                f"Default API key rotated across {len(result['updated'])} "
+                f"service(s), but {len(stop_errors)} running container(s) "
+                f"could NOT be stopped and still accept the OLD key — stop "
+                f"them manually: {', '.join(sorted(stop_errors))}."
+            )
 
         return jsonify(
             {
-                "success": True,
+                "success": ok,
+                "partial": not ok,
                 "new_api_key": new_key,
                 "services_updated": len(result["updated"]),
                 "total_services": len(db_services),
                 "stopped": stopped,
                 "stop_errors": stop_errors,
                 "openwebui_registered": openwebui_registered,
-                "message": (
-                    f"Default API key rotated across {len(result['updated'])} "
-                    f"service(s); {len(stopped)} running container(s) stopped."
-                ),
+                "message": message,
             }
-        ), 200
+        ), (200 if ok else 207)
 
     except Exception as e:
         logger.error(f"Failed to rotate default API key: {e}", exc_info=True)

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -3,6 +3,7 @@ import logging
 import threading
 import time
 import subprocess
+from functools import wraps
 from datetime import datetime
 from typing import Generator
 from flask import Blueprint, jsonify, request, Response, stream_with_context, current_app
@@ -31,12 +32,29 @@ logger = logging.getLogger(__name__)
 
 services_bp = Blueprint("services", __name__)
 
-# Serializes default API key rotation. Two concurrent rotations could
-# otherwise interleave their services.json/compose vs .env writes and leave
-# the default key un-mirrored across stores. The dashboard runs as a single
-# process (systemd: `python app.py`), so a process-wide lock fully
-# serializes; it is held across the whole commit + container-stop sequence.
-_ROTATION_LOCK = threading.Lock()
+# Serializes every services.json read-modify-write + compose rebuild.
+# Flask's dev server runs threaded (app.run defaults threaded=True), so
+# create/update/delete/rename/set-*-key and key rotation can otherwise
+# interleave: e.g. rotation snapshots the DB, a concurrent create adds a
+# service and rebuilds, then rotation writes its stale snapshot back and
+# drops the just-created service. One process-wide RLock around all of
+# these makes each a critical section. RLock (not Lock) so a handler that
+# nests guarded helpers in the same thread can't self-deadlock.
+_SERVICES_DB_LOCK = threading.RLock()
+
+
+def _serialize_db(fn):
+    """Run the view under the shared services-DB lock.
+
+    Placed below @require_auth so unauthenticated requests are rejected
+    without contending for the lock.
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _SERVICES_DB_LOCK:
+            return fn(*args, **kwargs)
+
+    return wrapper
 def _recreate_if_running(service_name):
     """Recreate the container if it was running. Returns restart status dict."""
     container = get_service_container(service_name)
@@ -207,6 +225,7 @@ def get_service_logs(service_name):
 
 @services_bp.route("/api/services", methods=["POST"])
 @require_auth
+@_serialize_db
 def create_service():
     """
     Create a new service in services database and rebuild compose file.
@@ -287,6 +306,7 @@ def create_service():
 
 @services_bp.route("/api/services/<service_name>", methods=["PUT"])
 @require_auth
+@_serialize_db
 def update_service(service_name):
     """
     Update service configuration and rebuild compose file.
@@ -354,6 +374,7 @@ def update_service(service_name):
 
 @services_bp.route("/api/services/<service_name>", methods=["DELETE"])
 @require_auth
+@_serialize_db
 def delete_service(service_name):
     """Delete service from database and rebuild compose file"""
     try:
@@ -407,6 +428,7 @@ def delete_service(service_name):
 
 @services_bp.route("/api/services/<service_name>/rename", methods=["POST"])
 @require_auth
+@_serialize_db
 def rename_service(service_name):
     """
     Rename a service. Service must be stopped.
@@ -533,6 +555,7 @@ def get_flags_metadata(template_type):
 
 @services_bp.route("/api/services/<service_name>/set-public-port", methods=["POST"])
 @require_auth
+@_serialize_db
 def set_public_port(service_name):
     """
     Set service to use the public port (3301).
@@ -798,6 +821,7 @@ def get_global_api_key():
 
 @services_bp.route("/api/services/<service_name>/set-global-api-key", methods=["PUT"])
 @require_auth
+@_serialize_db
 def set_service_global_api_key(service_name):
     """
     Update a service's API key with the global API key from environment.
@@ -895,7 +919,7 @@ def rotate_default_api_key():
     services are reported back so the user can re-enter the key manually.
     """
     try:
-        with _ROTATION_LOCK:
+        with _SERVICES_DB_LOCK:
             db_services, running, openwebui_registered = _affected_services_state()
 
             new_key = generate_api_key()

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -8,11 +8,13 @@ from typing import Generator
 from flask import Blueprint, jsonify, request, Response, stream_with_context, current_app
 
 from auth import require_auth
-from config import COMPOSE_FILE, GLOBAL_API_KEY
+import config
+from config import COMPOSE_FILE
 from compose_manager import ComposeManager
 from docker_utils import get_docker_services, get_service_container, control_service
 from model_discovery import compute_model_size
 from service_templates import generate_api_key
+from key_rotation import rotate_keys_in_db
 from flag_metadata import (
     generate_service_name as gen_service_name,
     validate_service_config,
@@ -771,13 +773,13 @@ def stream_service_logs(service_name):
 def get_global_api_key():
     """Return the global API key (authentication required)"""
     try:
-        if not GLOBAL_API_KEY:
+        if not config.GLOBAL_API_KEY:
             return jsonify(
                 {"api_key": None, "message": "Global API key not configured"}
             ), 200
 
         return jsonify(
-            {"api_key": GLOBAL_API_KEY, "message": "Global API key is configured"}
+            {"api_key": config.GLOBAL_API_KEY, "message": "Global API key is configured"}
         ), 200
 
     except Exception as e:
@@ -795,7 +797,7 @@ def set_service_global_api_key(service_name):
     The global API key is read from .env file, not received in the request.
     """
     try:
-        if not GLOBAL_API_KEY:
+        if not config.GLOBAL_API_KEY:
             return jsonify(
                 {
                     "success": False,
@@ -810,7 +812,7 @@ def set_service_global_api_key(service_name):
             return jsonify({"error": f'Service "{service_name}" not found'}), 404
 
         old_api_key = service_config.get("api_key", "")
-        service_config["api_key"] = GLOBAL_API_KEY
+        service_config["api_key"] = config.GLOBAL_API_KEY
         compose_mgr.update_service_in_db(service_name, service_config)
 
         _rebuild_and_restart(compose_mgr, service_name)
@@ -822,11 +824,109 @@ def set_service_global_api_key(service_name):
                 "success": True,
                 "service_name": service_name,
                 "old_api_key": old_api_key[:10] + "..." if old_api_key else None,
-                "new_api_key": GLOBAL_API_KEY[:10] + "...",
+                "new_api_key": config.GLOBAL_API_KEY[:10] + "...",
                 "message": f'Service "{service_name}" API key updated successfully',
             }
         ), 200
 
     except Exception as e:
         logger.error(f"Failed to set global API key: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+def _affected_services_state():
+    """Return (db_service_names, running, openwebui_registered) for rotation.
+
+    Only services present in services.json are affected by a rotation; infra
+    containers like open-webui are never in services.json so they're excluded
+    naturally.
+    """
+    compose_mgr = ComposeManager(COMPOSE_FILE)
+    db_services = set(compose_mgr.list_services_in_db().keys())
+
+    running = []
+    openwebui_registered = []
+    for svc in get_docker_services():
+        name = svc["name"]
+        if name not in db_services:
+            continue
+        if svc.get("status") == "running":
+            running.append(name)
+        if svc.get("openwebui_registered"):
+            openwebui_registered.append(name)
+
+    return sorted(db_services), sorted(running), sorted(openwebui_registered)
+
+
+@services_bp.route("/api/default-api-key/rotation-preview", methods=["GET"])
+@require_auth
+def default_api_key_rotation_preview():
+    """Describe the impact of rotating the default API key without changing anything."""
+    try:
+        db_services, running, openwebui_registered = _affected_services_state()
+        return jsonify(
+            {
+                "total_services": len(db_services),
+                "running": running,
+                "openwebui_registered": openwebui_registered,
+            }
+        ), 200
+    except Exception as e:
+        logger.error(f"Failed to build rotation preview: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@services_bp.route("/api/default-api-key/rotate", methods=["POST"])
+@require_auth
+def rotate_default_api_key():
+    """Rotate the default API key.
+
+    Generates a new key, persists it to .env (LLM_DOCK_API_KEY), rewrites every
+    service's api_key in services.json, regenerates docker-compose.yml, and
+    stops every running affected container (they keep the revoked key in memory
+    until restarted). Open WebUI's stored copies are NOT touched — registered
+    services are reported back so the user can re-enter the key manually.
+    """
+    try:
+        db_services, running, openwebui_registered = _affected_services_state()
+
+        new_key = generate_api_key()
+        config.set_global_api_key(new_key)
+
+        compose_mgr = ComposeManager(COMPOSE_FILE)
+        result = rotate_keys_in_db(compose_mgr, new_key)
+
+        stopped = []
+        stop_errors = {}
+        for name in running:
+            res = control_service(name, "stop")
+            if res.get("success"):
+                stopped.append(name)
+            else:
+                stop_errors[name] = res.get("error", "unknown error")
+
+        logger.info(
+            "Default API key rotated: %d services updated, %d containers stopped",
+            len(result["updated"]),
+            len(stopped),
+        )
+
+        return jsonify(
+            {
+                "success": True,
+                "new_api_key": new_key,
+                "services_updated": len(result["updated"]),
+                "total_services": len(db_services),
+                "stopped": stopped,
+                "stop_errors": stop_errors,
+                "openwebui_registered": openwebui_registered,
+                "message": (
+                    f"Default API key rotated across {len(result['updated'])} "
+                    f"service(s); {len(stopped)} running container(s) stopped."
+                ),
+            }
+        ), 200
+
+    except Exception as e:
+        logger.error(f"Failed to rotate default API key: {e}", exc_info=True)
         return jsonify({"success": False, "error": str(e)}), 500

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -30,6 +30,13 @@ from openwebui_integration import (
 logger = logging.getLogger(__name__)
 
 services_bp = Blueprint("services", __name__)
+
+# Serializes default API key rotation. Two concurrent rotations could
+# otherwise interleave their services.json/compose vs .env writes and leave
+# the default key un-mirrored across stores. The dashboard runs as a single
+# process (systemd: `python app.py`), so a process-wide lock fully
+# serializes; it is held across the whole commit + container-stop sequence.
+_ROTATION_LOCK = threading.Lock()
 def _recreate_if_running(service_name):
     """Recreate the container if it was running. Returns restart status dict."""
     container = get_service_container(service_name)
@@ -888,37 +895,39 @@ def rotate_default_api_key():
     services are reported back so the user can re-enter the key manually.
     """
     try:
-        db_services, running, openwebui_registered = _affected_services_state()
+        with _ROTATION_LOCK:
+            db_services, running, openwebui_registered = _affected_services_state()
 
-        new_key = generate_api_key()
-        compose_mgr = ComposeManager(COMPOSE_FILE)
+            new_key = generate_api_key()
+            compose_mgr = ComposeManager(COMPOSE_FILE)
 
-        # Snapshot before any mutation so a late failure can fully roll back.
-        services_before = compose_mgr.list_services_in_db()
+            # Snapshot before any mutation so a late failure can fully roll back.
+            services_before = compose_mgr.list_services_in_db()
 
-        # Commit the riskiest, validated work (services.json + compose) FIRST.
-        # rotate_keys_in_db self-rolls-back services.json/compose on failure,
-        # so if this raises nothing has been changed and .env is untouched.
-        result = rotate_keys_in_db(compose_mgr, new_key)
+            # Commit the riskiest, validated work (services.json + compose)
+            # FIRST. rotate_keys_in_db self-rolls-back services.json/compose
+            # on failure, so if this raises nothing has been changed and .env
+            # is untouched.
+            result = rotate_keys_in_db(compose_mgr, new_key)
 
-        # Only now commit .env / in-process key. If this fails, undo the
-        # services.json + compose changes so we never advertise a new key
-        # while files still hold the old one (or vice versa).
-        try:
-            config.set_global_api_key(new_key)
-        except Exception:
-            compose_mgr.save_services_db(services_before)
-            compose_mgr.rebuild_compose_file()
-            raise
+            # Only now commit .env / in-process key. If this fails, undo the
+            # services.json + compose changes so we never advertise a new key
+            # while files still hold the old one (or vice versa).
+            try:
+                config.set_global_api_key(new_key)
+            except Exception:
+                compose_mgr.save_services_db(services_before)
+                compose_mgr.rebuild_compose_file()
+                raise
 
-        stopped = []
-        stop_errors = {}
-        for name in running:
-            res = control_service(name, "stop")
-            if res.get("success"):
-                stopped.append(name)
-            else:
-                stop_errors[name] = res.get("error", "unknown error")
+            stopped = []
+            stop_errors = {}
+            for name in running:
+                res = control_service(name, "stop")
+                if res.get("success"):
+                    stopped.append(name)
+                else:
+                    stop_errors[name] = res.get("error", "unknown error")
 
         logger.info(
             "Default API key rotated: %d services updated, %d containers stopped",

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -81,6 +81,77 @@ def test_rotate_is_idempotent(compose_manager):
     assert all(cfg["api_key"] == "same-key" for cfg in db.values())
 
 
+def test_rotate_rolls_back_services_json_on_compose_failure(compose_manager, monkeypatch):
+    """If the compose rebuild fails, services.json must be restored and the
+    exception propagated — no half-rotated state."""
+    def boom():
+        raise RuntimeError("compose validation failed")
+
+    monkeypatch.setattr(compose_manager, "rebuild_compose_file", boom)
+
+    with pytest.raises(RuntimeError, match="compose validation failed"):
+        rotate_keys_in_db(compose_manager, "new-shared-key")
+
+    db = compose_manager.list_services_in_db()
+    assert all(cfg["api_key"] == "old-key" for cfg in db.values()), (
+        "services.json should be rolled back to the pre-rotation key"
+    )
+
+
+def test_route_does_not_commit_env_before_services_and_compose(tmp_path, monkeypatch):
+    """Route-level: a compose failure must NOT have touched .env /
+    GLOBAL_API_KEY, and services.json must be unchanged (codex iter 1)."""
+    import config
+    from compose_manager import ComposeManager
+    import routes.services as svc
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"svc-a": {"template_type": "vllm", "port": 3301,
+                              "model_name": "o/m", "api_key": "old-key",
+                              "params": {}}})
+    )
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(
+        svc, "_affected_services_state", lambda: (["svc-a"], [], [])
+    )
+    monkeypatch.setattr(
+        svc, "ComposeManager",
+        lambda *_a, **_k: ComposeManager(str(compose_path), services_db_file=str(services_path)),
+    )
+    # Force the compose rebuild to fail mid-rotation.
+    monkeypatch.setattr(
+        ComposeManager, "rebuild_compose_file",
+        lambda self: (_ for _ in ()).throw(RuntimeError("rebuild failed")),
+    )
+    # Guard: .env writer must never run in this failure path.
+    monkeypatch.setattr(
+        config, "set_global_api_key",
+        lambda *a, **k: pytest.fail("set_global_api_key called before services/compose committed"),
+    )
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={"TESTING": True, "DASHBOARD_TOKEN": "test-token"})
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/default-api-key/rotate",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert resp.status_code == 500
+    assert config.GLOBAL_API_KEY == "old-key"
+    db = json.loads(services_path.read_text())
+    assert db["svc-a"]["api_key"] == "old-key"
+
+
 def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -152,6 +152,96 @@ def test_route_does_not_commit_env_before_services_and_compose(tmp_path, monkeyp
     assert db["svc-a"]["api_key"] == "old-key"
 
 
+def test_save_services_db_atomic_on_write_failure(compose_manager, monkeypatch):
+    """A failed services.json write must leave the original file intact
+    (codex iter 2: truncate-then-write would corrupt the rotation commit)."""
+    import os as _os
+
+    original_bytes = compose_manager.services_db_path.read_bytes()
+
+    # Temp file is written, but the atomic os.replace fails.
+    monkeypatch.setattr(
+        "compose_manager.os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+
+    with pytest.raises(OSError, match="replace failed"):
+        compose_manager.save_services_db({"corrupt": {"api_key": "x"}})
+
+    assert compose_manager.services_db_path.read_bytes() == original_bytes
+    # No leftover temp files in the directory.
+    leftovers = [
+        p for p in compose_manager.services_db_path.parent.iterdir()
+        if p.name.startswith(".services.") and p.name.endswith(".json.tmp")
+    ]
+    assert leftovers == [], f"temp files not cleaned up: {leftovers}"
+
+
+def test_concurrent_rotations_keep_stores_consistent(tmp_path, monkeypatch):
+    """Two concurrent rotate requests must not interleave their
+    services.json/compose vs .env writes (codex iter 2)."""
+    import threading
+    import time
+    import config
+    from compose_manager import ComposeManager
+    import routes.services as svc
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"svc-a": {"template_type": "vllm", "alias": "a",
+                              "port": 3301, "model_name": "o/m",
+                              "api_key": "old-key", "params": {}}})
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_DOCK_API_KEY=old-key\n")
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(svc, "_affected_services_state", lambda: (["svc-a"], [], []))
+    monkeypatch.setattr(
+        svc, "ComposeManager",
+        lambda *_a, **_k: ComposeManager(str(compose_path), services_db_file=str(services_path)),
+    )
+
+    def fake_set_global(new_key, dotenv_path=None):
+        # Widen the interleave window between the services/compose commit
+        # and the .env commit; serialized access keeps stores consistent.
+        time.sleep(0.05)
+        config.GLOBAL_API_KEY = new_key
+        env_path.write_text(f"LLM_DOCK_API_KEY={new_key}\n")
+
+    monkeypatch.setattr(config, "set_global_api_key", fake_set_global)
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={"TESTING": True, "DASHBOARD_TOKEN": "test-token"})
+
+    results = {}
+
+    def rotate(tag):
+        c = app.test_client()
+        r = c.post("/api/default-api-key/rotate",
+                   headers={"Authorization": "Bearer test-token"})
+        results[tag] = (r.status_code, r.get_data(as_text=True))
+
+    t1 = threading.Thread(target=rotate, args=("a",))
+    t2 = threading.Thread(target=rotate, args=("b",))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    assert results["a"][0] == 200, results["a"]
+    assert results["b"][0] == 200, results["b"]
+
+    # Invariant: whatever the final key, every store agrees on it.
+    final_db_key = json.loads(services_path.read_text())["svc-a"]["api_key"]
+    final_env = env_path.read_text().strip().split("=", 1)[1]
+    assert final_db_key == config.GLOBAL_API_KEY == final_env
+
+
 def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -317,6 +317,147 @@ def test_rotation_does_not_drop_concurrent_create(tmp_path, monkeypatch):
     assert db["vllm-existing"]["api_key"] == config.GLOBAL_API_KEY
 
 
+def test_shared_lock_is_one_object_across_blueprints():
+    """services routes, benchmarking routes, and db_lock must all serialize
+    on the *same* lock object (codex iter 4)."""
+    import db_lock
+    import routes.services as svc
+    import benchmarking.routes as bench
+
+    assert svc._SERVICES_DB_LOCK is db_lock.SERVICES_DB_LOCK
+    assert svc._serialize_db is db_lock.serialize_db
+    # apply_benchmark is wrapped by serialize_db (shares the lock).
+    assert hasattr(bench.apply_benchmark, "__wrapped__")
+
+
+def test_rotation_not_reverted_by_concurrent_benchmark_apply(tmp_path, monkeypatch):
+    """A benchmark apply running concurrently with a rotation must not write
+    its stale full service config back and revert the api_key (codex iter 4)."""
+    import threading
+    import time
+    import config
+    from compose_manager import ComposeManager
+    from benchmarking.models import BenchmarkRun
+    import routes.services as svc
+    import benchmarking.routes as bench
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"vllm-existing": {"template_type": "vllm", "alias": "existing",
+                                      "port": 3301, "model_name": "o/m",
+                                      "api_key": "old-key", "params": {}}})
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_DOCK_API_KEY=old-key\n")
+
+    def cm(*_a, **_k):
+        return ComposeManager(str(compose_path), services_db_file=str(services_path))
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(svc, "_affected_services_state", lambda: (["vllm-existing"], [], []))
+    monkeypatch.setattr(svc, "ComposeManager", cm)
+    monkeypatch.setattr(bench, "_get_compose_manager", cm)
+
+    def fake_set_global(new_key, dotenv_path=None):
+        time.sleep(0.1)
+        config.GLOBAL_API_KEY = new_key
+        env_path.write_text(f"LLM_DOCK_API_KEY={new_key}\n")
+
+    monkeypatch.setattr(config, "set_global_api_key", fake_set_global)
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={
+        "TESTING": True,
+        "DASHBOARD_TOKEN": "test-token",
+        "BENCHMARK_DB_PATH": str(tmp_path / "bench.db"),
+    })
+    db = app.config["BENCHMARK_DB"]
+    db.create_run(BenchmarkRun(
+        id="run-1", service_name="vllm-existing", model_path="",
+        status="completed", params_json={"--gpu-memory-utilization": "0.5"},
+    ))
+
+    hdr = {"Authorization": "Bearer test-token"}
+    results = {}
+
+    def do_rotate():
+        results["rotate"] = app.test_client().post(
+            "/api/default-api-key/rotate", headers=hdr).status_code
+
+    def do_apply():
+        results["apply"] = app.test_client().put(
+            "/api/benchmarks/run-1/apply", headers=hdr).status_code
+
+    tr = threading.Thread(target=do_rotate)
+    ta = threading.Thread(target=do_apply)
+    tr.start()
+    time.sleep(0.02)
+    ta.start()
+    tr.join(); ta.join()
+
+    assert results["rotate"] == 200, results
+    assert results["apply"] == 200, results
+
+    cfg = json.loads(services_path.read_text())["vllm-existing"]
+    # Apply must not have reverted the rotated key...
+    assert cfg["api_key"] == config.GLOBAL_API_KEY
+    # ...and the applied benchmark param must still be present.
+    assert cfg["params"].get("--gpu-memory-utilization") == "0.5"
+
+
+def test_rotate_partial_failure_when_container_stop_fails(tmp_path, monkeypatch):
+    """If a running affected container can't be stopped, the response must
+    NOT report unqualified success (codex iter 4)."""
+    import config
+    from compose_manager import ComposeManager
+    import routes.services as svc
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"vllm-x": {"template_type": "vllm", "alias": "x",
+                               "port": 3301, "model_name": "o/m",
+                               "api_key": "old-key", "params": {}}})
+    )
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(svc, "_affected_services_state", lambda: (["vllm-x"], ["vllm-x"], []))
+    monkeypatch.setattr(
+        svc, "ComposeManager",
+        lambda *_a, **_k: ComposeManager(str(compose_path), services_db_file=str(services_path)),
+    )
+    monkeypatch.setattr(config, "set_global_api_key",
+                        lambda *a, **k: setattr(config, "GLOBAL_API_KEY", a[0]))
+    monkeypatch.setattr(
+        svc, "control_service",
+        lambda name, action: {"success": False, "error": "docker daemon unreachable"},
+    )
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={"TESTING": True, "DASHBOARD_TOKEN": "test-token"})
+    resp = app.test_client().post(
+        "/api/default-api-key/rotate", headers={"Authorization": "Bearer test-token"})
+
+    body = resp.get_json()
+    assert resp.status_code == 207
+    assert body["success"] is False
+    assert body["partial"] is True
+    assert "vllm-x" in body["stop_errors"]
+    # Key still rotated in files (that part succeeded) and returned.
+    assert body["new_api_key"] == config.GLOBAL_API_KEY
+
+
 def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -242,6 +242,81 @@ def test_concurrent_rotations_keep_stores_consistent(tmp_path, monkeypatch):
     assert final_db_key == config.GLOBAL_API_KEY == final_env
 
 
+def test_rotation_does_not_drop_concurrent_create(tmp_path, monkeypatch):
+    """A service created while a rotation is in flight must not be silently
+    dropped by rotation's wholesale snapshot write (codex iter 3)."""
+    import threading
+    import time
+    import config
+    from compose_manager import ComposeManager
+    import routes.services as svc
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"vllm-existing": {"template_type": "vllm", "alias": "existing",
+                                      "port": 3301, "model_name": "o/m",
+                                      "api_key": "old-key", "params": {}}})
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_DOCK_API_KEY=old-key\n")
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(svc, "_affected_services_state", lambda: (["vllm-existing"], [], []))
+    monkeypatch.setattr(
+        svc, "ComposeManager",
+        lambda *_a, **_k: ComposeManager(str(compose_path), services_db_file=str(services_path)),
+    )
+
+    def fake_set_global(new_key, dotenv_path=None):
+        # Hold the rotation critical section open long enough that the
+        # concurrent create would interleave if it weren't serialized.
+        time.sleep(0.1)
+        config.GLOBAL_API_KEY = new_key
+        env_path.write_text(f"LLM_DOCK_API_KEY={new_key}\n")
+
+    monkeypatch.setattr(config, "set_global_api_key", fake_set_global)
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={"TESTING": True, "DASHBOARD_TOKEN": "test-token"})
+    hdr = {"Authorization": "Bearer test-token"}
+    results = {}
+
+    def do_rotate():
+        results["rotate"] = app.test_client().post(
+            "/api/default-api-key/rotate", headers=hdr).status_code
+
+    def do_create():
+        results["create"] = app.test_client().post(
+            "/api/services",
+            headers=hdr,
+            json={"template_type": "vllm", "port": 3302,
+                  "model_name": "o/new", "alias": "created", "params": {}},
+        ).status_code
+
+    tr = threading.Thread(target=do_rotate)
+    tc = threading.Thread(target=do_create)
+    tr.start()
+    time.sleep(0.02)  # let rotation enter its critical section first
+    tc.start()
+    tr.join(); tc.join()
+
+    assert results["rotate"] == 200, results
+    assert results["create"] == 201, results
+
+    db = json.loads(services_path.read_text())
+    # Both the rotated pre-existing service AND the concurrently-created one
+    # must survive — rotation must not clobber the create.
+    assert "vllm-existing" in db
+    assert "vllm-created" in db
+    assert db["vllm-existing"]["api_key"] == config.GLOBAL_API_KEY
+
+
 def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -458,6 +458,97 @@ def test_rotate_partial_failure_when_container_stop_fails(tmp_path, monkeypatch)
     assert body["new_api_key"] == config.GLOBAL_API_KEY
 
 
+def test_rotation_vs_concurrent_start_no_stale_key_container(tmp_path, monkeypatch):
+    """A previously-stopped service started concurrently with a rotation must
+    not end up running with the revoked key (codex iter 5)."""
+    import threading
+    import time
+    import config
+    from compose_manager import ComposeManager
+    import routes.services as svc
+
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n  # <<<<<<< BEGIN DYNAMIC\n  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps({"vllm-x": {"template_type": "vllm", "alias": "x",
+                               "port": 3301, "model_name": "o/m",
+                               "api_key": "old-key", "params": {}}})
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_DOCK_API_KEY=old-key\n")
+
+    # Model of running containers: name -> api_key the container booted with.
+    mlock = threading.Lock()
+    running = {}  # vllm-x starts STOPPED
+
+    def fake_affected():
+        with mlock:
+            snap = list(running)
+        return (["vllm-x"], snap, [])
+
+    def fake_control(name, action):
+        if action == "start":
+            time.sleep(0.03)  # widen the window
+            key = json.loads(services_path.read_text())[name]["api_key"]
+            with mlock:
+                running[name] = key
+            return {"success": True}
+        if action == "stop":
+            with mlock:
+                running.pop(name, None)
+            return {"success": True}
+        return {"success": False, "error": "unsupported"}
+
+    def fake_set_global(new_key, dotenv_path=None):
+        time.sleep(0.1)
+        config.GLOBAL_API_KEY = new_key
+        env_path.write_text(f"LLM_DOCK_API_KEY={new_key}\n")
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    monkeypatch.setattr(config, "set_global_api_key", fake_set_global)
+    monkeypatch.setattr(svc, "_affected_services_state", fake_affected)
+    monkeypatch.setattr(svc, "control_service", fake_control)
+    monkeypatch.setattr(
+        svc, "ComposeManager",
+        lambda *_a, **_k: ComposeManager(str(compose_path), services_db_file=str(services_path)),
+    )
+
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+    from app import create_app
+    app = create_app(config={"TESTING": True, "DASHBOARD_TOKEN": "test-token"})
+    hdr = {"Authorization": "Bearer test-token"}
+    results = {}
+
+    def do_rotate():
+        results["rotate"] = app.test_client().post(
+            "/api/default-api-key/rotate", headers=hdr).status_code
+
+    def do_start():
+        results["start"] = app.test_client().post(
+            "/api/services/vllm-x/start", headers=hdr).status_code
+
+    tr = threading.Thread(target=do_rotate)
+    ts = threading.Thread(target=do_start)
+    tr.start()
+    time.sleep(0.02)
+    ts.start()
+    tr.join(); ts.join()
+
+    assert results["rotate"] in (200, 207), results
+    assert results["start"] == 200, results
+    # Invariant: no container is left running on a key other than the final
+    # rotated key.
+    for name, booted_key in running.items():
+        assert booted_key == config.GLOBAL_API_KEY, (
+            f"{name} is running with stale key {booted_key!r} "
+            f"(current default {config.GLOBAL_API_KEY!r})"
+        )
+
+
 def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")

--- a/dashboard/tests/test_key_rotation.py
+++ b/dashboard/tests/test_key_rotation.py
@@ -1,0 +1,94 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import config
+from compose_manager import ComposeManager
+from key_rotation import rotate_keys_in_db
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars():
+    os.environ["DASHBOARD_TOKEN"] = "test-token"
+
+
+@pytest.fixture
+def compose_manager(tmp_path):
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(
+        "services:\n"
+        "  # <<<<<<< BEGIN DYNAMIC\n"
+        "  svc-a:\n"
+        "    image: test\n"
+        "  # >>>>>>> END DYNAMIC\n"
+        "\nnetworks:\n  llm-network:\n    driver: bridge\n"
+    )
+    services_path = tmp_path / "services.json"
+    services_path.write_text(
+        json.dumps(
+            {
+                "svc-a": {
+                    "template_type": "llamacpp",
+                    "alias": "a",
+                    "port": 3301,
+                    "model_path": "/models/a.gguf",
+                    "api_key": "old-key",
+                    "params": {},
+                },
+                "svc-b": {
+                    "template_type": "vllm",
+                    "alias": "b",
+                    "port": 3302,
+                    "model_name": "org/b",
+                    "api_key": "old-key",
+                    "params": {},
+                },
+            }
+        )
+    )
+    return ComposeManager(str(compose_path), services_db_file=str(services_path))
+
+
+def test_rotate_updates_every_service(compose_manager):
+    result = rotate_keys_in_db(compose_manager, "new-shared-key")
+
+    assert result["new_key"] == "new-shared-key"
+    assert sorted(result["updated"]) == ["svc-a", "svc-b"]
+
+    db = compose_manager.list_services_in_db()
+    assert all(cfg["api_key"] == "new-shared-key" for cfg in db.values())
+
+
+def test_rotate_generates_key_when_omitted(compose_manager):
+    result = rotate_keys_in_db(compose_manager)
+
+    assert result["new_key"].startswith("key-")
+    db = compose_manager.list_services_in_db()
+    assert all(cfg["api_key"] == result["new_key"] for cfg in db.values())
+
+
+def test_rotate_is_idempotent(compose_manager):
+    rotate_keys_in_db(compose_manager, "same-key")
+    second = rotate_keys_in_db(compose_manager, "same-key")
+
+    # Nothing changed the second time, but every service still carries the key.
+    assert second["updated"] == []
+    db = compose_manager.list_services_in_db()
+    assert all(cfg["api_key"] == "same-key" for cfg in db.values())
+
+
+def test_set_global_api_key_persists_and_updates_in_process(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_DOCK_API_KEY=old-key\nOTHER=keepme\n")
+
+    monkeypatch.setattr(config, "GLOBAL_API_KEY", "old-key")
+    config.set_global_api_key("rotated-key", dotenv_path=str(env_path))
+
+    assert config.GLOBAL_API_KEY == "rotated-key"
+    contents = env_path.read_text()
+    assert "LLM_DOCK_API_KEY='rotated-key'" in contents or 'LLM_DOCK_API_KEY="rotated-key"' in contents or "LLM_DOCK_API_KEY=rotated-key" in contents
+    assert "OTHER=keepme" in contents

--- a/install-service.sh
+++ b/install-service.sh
@@ -44,7 +44,10 @@ User=${INSTALL_USER}
 WorkingDirectory=${SCRIPT_DIR}/dashboard
 ExecStartPre=/usr/bin/docker compose -f ${SCRIPT_DIR}/docker-compose.yml up -d open-webui
 ExecStart=${SCRIPT_DIR}/dashboard/venv/bin/python ${SCRIPT_DIR}/dashboard/app.py
-ExecStop=/usr/bin/docker compose -f ${SCRIPT_DIR}/docker-compose.yml down
+# Intentionally NO ExecStop=docker compose down: the dashboard process
+# lifecycle is decoupled from the container lifecycle. Restarting/stopping
+# this unit must not tear down running model containers. Bring models down
+# explicitly with: cd ${SCRIPT_DIR} && docker compose down
 Restart=on-failure
 RestartSec=10
 Environment=PATH=/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
Closes #25.

## What

One click rotates the shared **default API key** across the whole stack.

- Generates a new key, persists it to `.env` (`LLM_DOCK_API_KEY`), and applies it to **every** service in `services.json` + regenerated `docker-compose.yml`.
- **Stops** running affected containers — they keep the revoked key in memory until restarted, so they must be stopped. Restart is left to the user (per issue requirement).
- A pre-rotation **preview/warning** lists:
  - running models that will be stopped, and
  - Open WebUI-registered services that will need a manual key re-entry.

## Open WebUI decision (the issue's open question)

**Warn-only.** Open WebUI stores its own copy of each connection's API key in its sqlite DB; rotation does not touch it. Affected registered services are surfaced in both the pre-warning and the result so the user knows to update them under *Admin → Settings → Connections*.

## Changes

**Backend**
- `config.set_global_api_key()` — atomic `.env` writer + in-process update; `DOTENV_PATH` resolved next to the module.
- `key_rotation.rotate_keys_in_db()` — pure, unit-tested mutation of `services.json` + compose rebuild.
- `GET /api/default-api-key/rotation-preview` and `POST /api/default-api-key/rotate`.
- `GLOBAL_API_KEY` references switched to `config.GLOBAL_API_KEY` so the rotated value is visible without a process restart.

**Frontend**
- `RotateDefaultKeyModal` — impact warnings (red: will be stopped / amber: Open WebUI) and a copyable new key.
- "Rotate default key" button in the services table header.

**Drive-by fix**
- `TokenSparkline.test.jsx`: relaxed a stale assertion (label/value are separate spans spaced via CSS flex gap, so `textContent` has no literal space between them). This test was failing on `main`; unrelated to the feature but fixed here so the branch is green.

## Testing

- New `dashboard/tests/test_key_rotation.py` (4 tests).
- Full backend suite: **147 passed**.
- Frontend: **36 passed** (was 35 + 1 pre-existing failure, now fixed).
- Frontend builds clean.

## Notes

- A pre-existing unrelated local modification to `install-service.sh` was deliberately **not** included in this PR.