### PR TITLE
feat(chat): centered empty-state composer + model preselect

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -15,6 +15,7 @@ let spinoffCounter = 0
 
 export default function ChatArea({
   conversation,
+  awaitingConversation,
   defaultModelName,
   onCreateAndSend,
   messages,
@@ -91,6 +92,21 @@ export default function ChatArea({
     topZRef.current++
     setSpinoffs(prev => prev.map(s => s.id === id ? { ...s, zIndex: topZRef.current } : s))
   }, [])
+
+  // A conversation is in the URL but its fetch hasn't returned yet. Show a
+  // loading state — NOT the create composer — otherwise typing here would
+  // spawn a different new conversation instead of waiting for the requested
+  // one (codex iteration 1, P1).
+  if (!conversation && awaitingConversation) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-500">
+        <div className="text-center">
+          <i className="fa-solid fa-spinner fa-spin text-3xl mb-3 block opacity-40"></i>
+          <p>Loading conversation…</p>
+        </div>
+      </div>
+    )
+  }
 
   if (!conversation) {
     return (

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -15,6 +15,8 @@ let spinoffCounter = 0
 
 export default function ChatArea({
   conversation,
+  defaultModelName,
+  onCreateAndSend,
   messages,
   critiques,
   setCritiques,
@@ -92,10 +94,22 @@ export default function ChatArea({
 
   if (!conversation) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-500">
-        <div className="text-center">
-          <i className="fa-solid fa-comments text-5xl mb-4 block opacity-20"></i>
-          <p>Select or create a conversation</p>
+      <div className="flex-1 flex flex-col items-center justify-center px-4">
+        <div className="w-full max-w-2xl flex flex-col items-center">
+          <i className="fa-solid fa-comments text-6xl mb-5 text-blue-500/40"></i>
+          <h2 className="text-2xl font-semibold text-gray-200 mb-2">Start a new conversation</h2>
+          <p className="text-sm text-gray-500 mb-6 text-center">
+            {defaultModelName
+              ? <>Type a message below — a chat will be created with <span className="text-gray-400">{defaultModelName}</span>.</>
+              : 'No running model services available. Start a model first.'}
+          </p>
+          <div className="w-full">
+            <ChatInput
+              focusKey="empty-state"
+              onSend={(msg, images) => onCreateAndSend?.(msg, images)}
+              disabled={!defaultModelName}
+            />
+          </div>
         </div>
       </div>
     )
@@ -193,6 +207,7 @@ export default function ChatArea({
         {/* Input */}
         <ChatInput
           ref={composerRef}
+          focusKey={conversation.id}
           onSend={(msg, images) => { onSend(msg, images); setPendingInserts([]) }}
           disabled={streaming || !conversation.main_service}
           pendingInserts={pendingInserts}

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -93,11 +93,13 @@ export default function ChatArea({
     setSpinoffs(prev => prev.map(s => s.id === id ? { ...s, zIndex: topZRef.current } : s))
   }, [])
 
-  // A conversation is in the URL but its fetch hasn't returned yet. Show a
-  // loading state — NOT the create composer — otherwise typing here would
-  // spawn a different new conversation instead of waiting for the requested
-  // one (codex iteration 1, P1).
-  if (!conversation && awaitingConversation) {
+  // The route points at a conversation whose fetch hasn't resolved yet
+  // (direct load, or switching from another conversation). Authoritative
+  // over a possibly-stale `conversation`: render loading, never the active
+  // chat or the create composer. Otherwise typing would either spawn a
+  // different new conversation (codex iter 1) or, worse, send into the
+  // previously-loaded chat via its stale sendMessage closure (codex iter 2).
+  if (awaitingConversation) {
     return (
       <div className="flex-1 flex items-center justify-center text-gray-500">
         <div className="text-center">

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -46,4 +46,25 @@ describe('ChatArea no-conversation states', () => {
     expect(container.textContent).not.toContain('Start a new conversation')
     expect(container.querySelector('textarea')).toBeNull()
   })
+
+  it('shows loading (not the stale chat) when switching to a different route id', () => {
+    // Regression for codex iteration 2 P1: loadConversation does not clear
+    // the previous conversation before fetching, so when switching from A
+    // to B, `conversation` is still A while awaitingConversation is true.
+    // awaitingConversation must be authoritative — render loading, not A's
+    // composer — or an Enter would send into A via its stale closure.
+    const { container } = render(
+      <ChatArea
+        conversation={{ id: 'conv-A', main_service: 'vllm-test' }}
+        awaitingConversation={true}
+        defaultModelName="vllm-test"
+        onCreateAndSend={() => {}}
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+      />
+    )
+    expect(container.textContent).toContain('Loading conversation')
+    expect(container.querySelector('textarea')).toBeNull()
+  })
 })

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import ChatArea from './ChatArea'
+
+// useRunningServices (pulled in transitively by the empty-state composer's
+// ChatInput-less path is fine, but ChatArea itself doesn't use it). We only
+// exercise the no-conversation branches here, so no router/hook mocking is
+// needed beyond what ChatArea's own imports require.
+vi.mock('../../hooks/useRunningServices', () => ({
+  default: () => ({ services: [], loading: false }),
+}))
+
+describe('ChatArea no-conversation states', () => {
+  it('shows the create composer when there is no route conversation', () => {
+    const { container } = render(
+      <ChatArea
+        conversation={null}
+        awaitingConversation={false}
+        defaultModelName="vllm-test"
+        onCreateAndSend={() => {}}
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+      />
+    )
+    expect(container.textContent).toContain('Start a new conversation')
+    expect(container.querySelector('textarea')).toBeTruthy()
+  })
+
+  it('shows a loading state (no composer) while a URL conversation is fetching', () => {
+    // Regression for codex iteration 1 P1: opening /v2/chat/<id> directly
+    // leaves `conversation` null during loadConversation — the empty-state
+    // composer must NOT render, or typing would create a different chat.
+    const { container } = render(
+      <ChatArea
+        conversation={null}
+        awaitingConversation={true}
+        defaultModelName="vllm-test"
+        onCreateAndSend={() => {}}
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+      />
+    )
+    expect(container.textContent).toContain('Loading conversation')
+    expect(container.textContent).not.toContain('Start a new conversation')
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 
-const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert }, ref) {
+const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert, focusKey }, ref) {
   const [value, setValue] = useState('')
   const [images, setImages] = useState([]) // [{dataUrl, name, size}]
   const textareaRef = useRef(null)
@@ -17,11 +17,14 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     },
   }), [])
 
+  // Refocus when the input becomes enabled, and whenever the active
+  // conversation changes (focusKey) — so opening/creating a conversation
+  // lands the cursor in the composer without an extra click.
   useEffect(() => {
     if (!disabled && textareaRef.current) {
       textareaRef.current.focus()
     }
-  }, [disabled])
+  }, [disabled, focusKey])
 
   // Auto-resize textarea
   useEffect(() => {

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -5,6 +5,7 @@ import ChatArea from './ChatArea'
 import useConversations from '../../hooks/useConversations'
 import useChat from '../../hooks/useChat'
 import useRunningServices from '../../hooks/useRunningServices'
+import { pendingFlushDecision } from './pendingFlush'
 
 export default function ChatPage() {
   const { conversationId } = useParams()
@@ -50,13 +51,23 @@ export default function ChatPage() {
   }, [convId, loadConversation])
 
   // Flush the queued first message once its conversation is loaded.
+  // loadConversation() has no request sequencing, so a late getConversation
+  // for the just-created chat C can resolve and set `conversation` to C
+  // even after the user has already navigated to a different chat B. Gate
+  // the flush on the live route too, and abandon the queued message the
+  // moment the route no longer points at it — otherwise a stale fetch
+  // would fire a background send into a non-active conversation (codex
+  // iteration 3, P1).
   useEffect(() => {
     const pending = pendingMsgRef.current
-    if (pending && conversation && conversation.id === pending.convId && !streaming) {
+    const decision = pendingFlushDecision(pending, convId, conversation, streaming)
+    if (decision === 'abandon') {
+      pendingMsgRef.current = null
+    } else if (decision === 'send') {
       pendingMsgRef.current = null
       sendMessage(pending.content, pending.images)
     }
-  }, [conversation, streaming, sendMessage])
+  }, [convId, conversation, streaming, sendMessage])
 
   // Refresh conversation list when streaming completes (for auto-title)
   useEffect(() => {

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -137,6 +137,7 @@ export default function ChatPage() {
       />
       <ChatArea
         conversation={conversation}
+        awaitingConversation={!!convId && (!conversation || conversation.id !== convId)}
         defaultModelName={runningServices[0]?.name || null}
         onCreateAndSend={handleCreateAndSend}
         messages={messages}

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -1,16 +1,18 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
 import useConversations from '../../hooks/useConversations'
 import useChat from '../../hooks/useChat'
+import useRunningServices from '../../hooks/useRunningServices'
 
 export default function ChatPage() {
   const { conversationId } = useParams()
   const convId = conversationId || null
   const navigate = useNavigate()
 
-  const { conversations, loading: convsLoading, refresh, create, remove, removeMany, patchConversation } = useConversations()
+  const { conversations, refresh, create, remove, removeMany, patchConversation } = useConversations()
+  const { services: runningServices } = useRunningServices()
   const {
     conversation,
     messages,
@@ -34,12 +36,27 @@ export default function ChatPage() {
     onConversationUpdated: (evt) => patchConversation(evt.id, { title: evt.title }),
   })
 
+  // Holds the first message typed in the empty-state composer. The
+  // conversation has to exist (and be loaded into useChat) before
+  // sendMessage can fire, so we stash it here and flush it from an effect
+  // once the freshly-created conversation is the active one.
+  const pendingMsgRef = useRef(null)
+
   // Load conversation when URL changes
   useEffect(() => {
     if (convId) {
       loadConversation(convId)
     }
   }, [convId, loadConversation])
+
+  // Flush the queued first message once its conversation is loaded.
+  useEffect(() => {
+    const pending = pendingMsgRef.current
+    if (pending && conversation && conversation.id === pending.convId && !streaming) {
+      pendingMsgRef.current = null
+      sendMessage(pending.content, pending.images)
+    }
+  }, [conversation, streaming, sendMessage])
 
   // Refresh conversation list when streaming completes (for auto-title)
   useEffect(() => {
@@ -49,13 +66,30 @@ export default function ChatPage() {
   }, [streaming]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleCreate = useCallback(async () => {
-    // Use first available running service as default
+    // Default the main model to the first running service. When exactly
+    // one model is up this preselects it; the backend requires a non-empty
+    // main_service so we can't create without one.
+    if (runningServices.length === 0) {
+      window.alert('No running model services available. Start a model first.')
+      return
+    }
     const conv = await create({
-      main_service: 'llamacpp-gemma-4-31b-it-q8',
-      sidekick_service: 'llamacpp-UNSLOTH-qwen3-5-27b-q8',
+      main_service: runningServices[0].name,
     })
     navigate(`/chat/${conv.id}`)
-  }, [create, navigate])
+  }, [create, navigate, runningServices])
+
+  // Empty-state composer: create a conversation, then queue the typed
+  // message so it sends as soon as the new conversation loads.
+  const handleCreateAndSend = useCallback(async (content, images) => {
+    if (runningServices.length === 0) {
+      window.alert('No running model services available. Start a model first.')
+      return
+    }
+    const conv = await create({ main_service: runningServices[0].name })
+    pendingMsgRef.current = { convId: conv.id, content, images }
+    navigate(`/chat/${conv.id}`)
+  }, [create, navigate, runningServices])
 
   const handleSelect = useCallback((id) => {
     navigate(`/chat/${id}`)
@@ -103,6 +137,8 @@ export default function ChatPage() {
       />
       <ChatArea
         conversation={conversation}
+        defaultModelName={runningServices[0]?.name || null}
+        onCreateAndSend={handleCreateAndSend}
         messages={messages}
         critiques={critiques}
         setCritiques={setCritiques}

--- a/dashboard/frontend/src/components/chat/pendingFlush.js
+++ b/dashboard/frontend/src/components/chat/pendingFlush.js
@@ -1,0 +1,13 @@
+// Pure decision for ChatPage's queued first-message flush. Lives in its
+// own module (not ChatPage.jsx) so react-refresh stays happy and the
+// codex-iter-3 race (a stale getConversation resolving for an abandoned
+// route) is unit-testable without router/hook mocking.
+//   'wait'    — keep the pending message; conditions not yet met
+//   'abandon' — drop it; the route no longer points at the pending chat
+//   'send'    — route + loaded conversation match and not streaming
+export function pendingFlushDecision(pending, convId, conversation, streaming) {
+  if (!pending) return 'wait'
+  if (convId !== pending.convId) return 'abandon'
+  if (conversation && conversation.id === pending.convId && !streaming) return 'send'
+  return 'wait'
+}

--- a/dashboard/frontend/src/components/chat/pendingFlush.test.js
+++ b/dashboard/frontend/src/components/chat/pendingFlush.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { pendingFlushDecision } from './pendingFlush'
+
+const pending = { convId: 'C', content: 'hi', images: undefined }
+
+describe('pendingFlushDecision', () => {
+  it('waits when there is no pending message', () => {
+    expect(pendingFlushDecision(null, 'C', { id: 'C' }, false)).toBe('wait')
+  })
+
+  it('waits while the pending conversation has not loaded yet', () => {
+    expect(pendingFlushDecision(pending, 'C', null, false)).toBe('wait')
+    expect(pendingFlushDecision(pending, 'C', { id: 'A' }, false)).toBe('wait')
+  })
+
+  it('waits while streaming even if route and conversation match', () => {
+    expect(pendingFlushDecision(pending, 'C', { id: 'C' }, true)).toBe('wait')
+  })
+
+  it('sends when route + loaded conversation match and not streaming', () => {
+    expect(pendingFlushDecision(pending, 'C', { id: 'C' }, false)).toBe('send')
+  })
+
+  it('abandons when the user has navigated away from the pending route', () => {
+    // codex iter 3 P1: a late getConversation resolving for C must not
+    // trigger a background send once the route is B.
+    expect(pendingFlushDecision(pending, 'B', { id: 'C' }, false)).toBe('abandon')
+    expect(pendingFlushDecision(pending, null, { id: 'C' }, false)).toBe('abandon')
+  })
+})


### PR DESCRIPTION
## Summary

Improves the `/v2/chat` first-run experience so a user can land on the page and immediately type.

- **Centered empty state**: with no conversation selected, `ChatArea` now renders a centered hero (icon, "Start a new conversation" title, subtitle naming the model) with a focused composer instead of the bare "Select or create a conversation" text.
- **Type-to-start**: sending from the empty-state composer creates a conversation with the first running model, navigates to it, and flushes the queued first message via `pendingMsgRef` once the conversation loads — no extra click.
- **Model preselect**: "New Conversation" defaults `main_service` to the first running service (replacing a stale hardcoded model name). When exactly one model is up it's preselected; when none are running it alerts / disables the composer (the backend requires a non-empty `main_service`).
- **Focus on conversation change**: `ChatInput` gained a `focusKey` so opening or creating a conversation lands the cursor in the composer (previously focus only moved on the `disabled` transition).

## Testing

- `npm run lint` — clean (also removed a pre-existing unused `convsLoading` binding in the touched file).
- `npm run build` — succeeds; bundle output to the gitignored `dashboard/frontend/dist/` that `app.py` serves `/v2` from.