### PR TITLE
feat(chat): typography + palette tokens — issue #29 phase 1

### DIFF
--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:ital,wght@0,400;0,500;0,600;1,400&display=swap">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LLM-Dock</title>
   </head>

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -8,8 +8,10 @@
  * build on. Families/values are swappable later; the role structure is the
  * decision.
  */
-@theme {
-  /* §6 — distinctive trio. Replaces the previous undeclared system-sans. */
+@theme static {
+  /* §6 — distinctive trio. Replaces the previous undeclared system-sans.
+     `static` keeps every token in the built CSS even when not yet
+     referenced — later phases consume these as runtime `var(--...)`. */
   --font-sans: "Archivo", ui-sans-serif, system-ui, sans-serif;        /* UI chrome */
   --font-serif: "Newsreader", Georgia, Cambria, "Times New Roman", serif; /* assistant prose */
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace; /* user input, code, labels */

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -1,2 +1,49 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+
+/*
+ * Issue #29 — Phase 1: typography + palette tokens.
+ * Distinctive typography on a refined-but-familiar dark-blue palette.
+ * These tokens are the foundation later phases (nav, transcript, composer)
+ * build on. Families/values are swappable later; the role structure is the
+ * decision.
+ */
+@theme {
+  /* §6 — distinctive trio. Replaces the previous undeclared system-sans. */
+  --font-sans: "Archivo", ui-sans-serif, system-ui, sans-serif;        /* UI chrome */
+  --font-serif: "Newsreader", Georgia, Cambria, "Times New Roman", serif; /* assistant prose */
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace; /* user input, code, labels */
+
+  /* §7 — refine, don't reinvent. Deepen / de-muddy the gray surfaces and
+     tighten contrast. Keeps blue as primary; rejects the mock's amber/cyan. */
+  --color-gray-950: #07090d;
+  --color-gray-900: #0b0f15; /* app background */
+  --color-gray-850: #11161f; /* raised panels (also makes bg-gray-850 real) */
+  --color-gray-800: #161c27; /* blocks / inputs */
+  --color-gray-700: #232b38; /* hairline borders */
+  --color-gray-600: #36404f; /* strong borders */
+
+  /* Established semantic colors (kept): blue=primary, yellow=critique,
+     green=MCP-on, purple=spin-off, red=error. Available as bg-/text-/border-. */
+  --color-accent: #3b82f6;
+  --color-accent-strong: #2563eb;
+  --color-critique: #eab308;
+  --color-mcp: #22c55e;
+  --color-spinoff: #a855f7;
+  --color-error: #ef4444;
+
+  /* Hairline rules + timeline spine — re-expressed in the neutral/blue palette
+     (consumed by the transcript-as-log work, §4). */
+  --color-line: rgba(148, 163, 184, 0.10);
+  --color-line-strong: rgba(148, 163, 184, 0.20);
+}
+
+@layer base {
+  body {
+    font-family: var(--font-sans);
+    background-color: var(--color-gray-900);
+    color: #c7d0db;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}


### PR DESCRIPTION
## Phase 1 of issue #29 — Chat visual redesign

Foundational design tokens. Everything in later phases (collapsible nav, transcript-as-log, composer, vocabulary) builds on these.

### §6 — Typography (distinctive trio)
- Load **Newsreader** (serif), **IBM Plex Mono**, **Archivo** via a Google Fonts CDN `<link>` in `index.html`, mirroring the existing Font Awesome cdnjs approach.
- Tailwind v4 `@theme` font tokens establish the **role structure**:
  - `--font-sans` → Archivo (UI chrome, default body font; replaces the previous undeclared system-sans)
  - `--font-serif` → Newsreader (assistant prose — applied in phase 3)
  - `--font-mono` → IBM Plex Mono (user input, code, labels — applied in phases 3/4)
- Families/values are swappable later; the role structure is the decision.

### §7 — Palette (refine, don't reinvent)
- Deepen / de-muddy the gray surface ramp (`gray-600..950`) and tighten contrast, via `@theme` overrides — existing components pick this up without edits.
- Keep **blue** as primary; **reject** the mock's amber/cyan remap.
- Keep established semantic colors: yellow=critique, green=MCP-on, purple=spin-off, red=error.
- Added `--color-line` / `--color-line-strong` hairline + timeline-spine tokens for the upcoming transcript-as-log work (§4).

### Verification
- `npm run build` ✓
- Playwright smoke test against a local `vite preview` of this branch:
  - body `font-family` resolves to Archivo ✓
  - body background = deepened `#0b0f15` ✓
  - all three font families load from the Google Fonts stylesheet on demand ✓
  - 0 console errors ✓

No backend changes.