### PR TITLE
feat(chat): collapsible global app nav — issue #29 phase 2

### DIFF
--- a/dashboard/frontend/src/components/Sidebar.jsx
+++ b/dashboard/frontend/src/components/Sidebar.jsx
@@ -1,77 +1,137 @@
+import { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 
+const STORAGE_KEY = 'llmdock.sidebar.collapsed'
+
+function readCollapsed() {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    // Default collapsed (issue #29 §2) when nothing stored.
+    return v === null ? true : v === 'true'
+  } catch {
+    return true
+  }
+}
+
+const NAV_ITEMS = [
+  { to: '/', end: true, icon: 'fa-server', label: 'Services' },
+  { to: '/chat', end: false, icon: 'fa-comments', label: 'Chat' },
+  { to: '/tools', end: false, icon: 'fa-toolbox', label: 'Tools' },
+]
+
 function Sidebar() {
+  const [collapsed, setCollapsed] = useState(readCollapsed)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(collapsed))
+    } catch {
+      /* localStorage unavailable — keep in-memory state only */
+    }
+  }, [collapsed])
+
   return (
-    <aside className="hidden md:flex w-56 bg-gray-900 border-r border-gray-800 flex-col flex-shrink-0">
-      {/* Logo */}
-      <div className="h-16 px-4 border-b border-gray-800 flex items-center">
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
-            <i className="fa-solid fa-cube text-white text-sm"></i>
+    <aside
+      className={`hidden md:flex ${
+        collapsed ? 'w-16' : 'w-56'
+      } bg-gray-900 border-r border-gray-800 flex-col flex-shrink-0 transition-[width] duration-200 ease-in-out`}
+    >
+      {/* Logo + collapse toggle */}
+      <div
+        className={`h-16 border-b border-gray-800 flex items-center ${
+          collapsed ? 'justify-center px-0' : 'justify-between px-4'
+        }`}
+      >
+        {!collapsed && (
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
+              <i className="fa-solid fa-cube text-white text-sm"></i>
+            </div>
+            <div className="min-w-0">
+              <h1 className="font-bold text-lg truncate">LLM-Dock</h1>
+              <p className="text-xs text-gray-500">v1.0.0</p>
+            </div>
           </div>
-          <div>
-            <h1 className="font-bold text-lg">LLM-Dock</h1>
-            <p className="text-xs text-gray-500">v1.0.0</p>
-          </div>
-        </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
+          title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-white hover:bg-gray-800/60 transition-colors"
+        >
+          <i
+            className={`fa-solid ${
+              collapsed ? 'fa-angles-right' : 'fa-angles-left'
+            } text-sm`}
+          ></i>
+        </button>
       </div>
 
       {/* Navigation */}
       <nav className="flex-1 py-4">
-        <NavLink
-          to="/"
-          end
-          className={({ isActive }) =>
-            `flex items-center gap-3 px-4 py-2.5 ${
-              isActive
-                ? 'text-white bg-gray-800/70'
-                : 'text-gray-400 hover:bg-gray-800/50'
-            }`
-          }
-        >
-          <i className="fa-solid fa-server w-5 text-center"></i>
-          <span>Services</span>
-        </NavLink>
-        <NavLink
-          to="/chat"
-          className={({ isActive }) =>
-            `flex items-center gap-3 px-4 py-2.5 ${
-              isActive
-                ? 'text-white bg-gray-800/70'
-                : 'text-gray-400 hover:bg-gray-800/50'
-            }`
-          }
-        >
-          <i className="fa-solid fa-comments w-5 text-center"></i>
-          <span>Chat</span>
-        </NavLink>
-        <NavLink
-          to="/tools"
-          className={({ isActive }) =>
-            `flex items-center gap-3 px-4 py-2.5 ${
-              isActive
-                ? 'text-white bg-gray-800/70'
-                : 'text-gray-400 hover:bg-gray-800/50'
-            }`
-          }
-        >
-          <i className="fa-solid fa-toolbox w-5 text-center"></i>
-          <span>Tools</span>
-        </NavLink>
+        {NAV_ITEMS.map(({ to, end, icon, label }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            title={collapsed ? label : undefined}
+            className={({ isActive }) =>
+              `group/nav relative flex items-center gap-3 py-2.5 ${
+                collapsed ? 'justify-center px-0' : 'px-4'
+              } ${
+                isActive
+                  ? 'text-white bg-gray-800/70'
+                  : 'text-gray-400 hover:bg-gray-800/50'
+              }`
+            }
+          >
+            <i className={`fa-solid ${icon} w-5 text-center`}></i>
+            {!collapsed && <span>{label}</span>}
+            {collapsed && (
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-full ml-2 z-20 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-gray-100 border border-gray-700 opacity-0 shadow-lg transition-opacity duration-150 group-hover/nav:opacity-100"
+              >
+                {label}
+              </span>
+            )}
+          </NavLink>
+        ))}
       </nav>
 
       {/* User section */}
-      <div className="p-4 border-t border-gray-800">
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center">
+      <div
+        className={`border-t border-gray-800 ${
+          collapsed ? 'p-2' : 'p-4'
+        }`}
+      >
+        <div
+          className={`flex items-center ${
+            collapsed ? 'justify-center' : 'gap-3'
+          }`}
+        >
+          <div
+            className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center flex-shrink-0"
+            title={collapsed ? 'Admin' : undefined}
+          >
             <i className="fa-solid fa-user text-gray-400 text-sm"></i>
           </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">Admin</p>
-          </div>
-          <button className="text-gray-500 hover:text-gray-300">
-            <i className="fa-solid fa-right-from-bracket"></i>
-          </button>
+          {!collapsed && (
+            <>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">Admin</p>
+              </div>
+              <button
+                className="text-gray-500 hover:text-gray-300"
+                aria-label="Log out"
+                title="Log out"
+              >
+                <i className="fa-solid fa-right-from-bracket"></i>
+              </button>
+            </>
+          )}
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Phase 2 of issue #29 — Chat visual redesign

Implements §2: collapsible global app nav (`components/Sidebar.jsx`).

### Changes
- Sidebar toggles between an **icon rail** (`w-16`) and the full **icon + label** rail (`w-56`) via an angles-chevron button in the header.
- **Collapsed** = icons only with hover tooltips (custom tooltip + native `title`) and avatar; **expanded** = logo, labels, user block, logout.
- State persisted in `localStorage` under `llmdock.sidebar.collapsed`. **Default collapsed** per the issue.
- Applies on **all routes** (Sidebar is rendered globally in the app layout).
- Smooth `width` transition; accessible `aria-label` / `aria-expanded` on the toggle.

### Verification
- `npm run build` ✓
- Playwright smoke test against local `vite preview` of this branch:
  - default state collapsed: width 64px, `localStorage` = `true` ✓
  - toggle → expanded: width 224px, `localStorage` = `false`, logo + labels visible ✓
  - reload on `/chat` route: expanded state persisted (width 224, storage `false`), sidebar present on non-root route ✓
  - 0 console errors ✓

No backend changes.