### PR TITLE
feat(chat): transcript-as-log — issue #29 phase 3

### DIFF
--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -46,12 +46,20 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
   }
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} group`}>
-      <div className={`max-w-[90%] ${isUser ? 'order-1' : ''}`}>
-        {/* Role label */}
-        <div className={`text-[10px] text-gray-500 mb-1 ${isUser ? 'text-right' : ''}`}>
-          {isUser ? 'You' : message.model_service || 'Assistant'}
-        </div>
+    <div className="relative pl-8 group">
+      {/* Timeline tick node — sits in the left gutter on the shared spine. */}
+      <span
+        aria-hidden="true"
+        className={`absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-gray-850 border ${
+          isUser ? 'border-accent-strong' : 'border-accent'
+        }`}
+      ></span>
+      <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+        <div className={`max-w-[90%] ${isUser ? 'order-1' : ''}`}>
+          {/* Role label — light/minimal, no mono meta line */}
+          <div className={`text-[10px] text-gray-500 mb-1 ${isUser ? 'text-right' : ''}`}>
+            {isUser ? 'You' : message.model_service || 'Assistant'}
+          </div>
 
         {/* Thinking block for assistant */}
         {!isUser && message.reasoning_content && (
@@ -100,11 +108,12 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
           </div>
         )}
 
-        {/* Message content */}
-        <div className={`rounded-lg px-4 py-3 ${
+        {/* Message content — hairline block with a colored left accent
+            spine, not a filled rounded bubble. */}
+        <div className={`rounded border border-line border-l-2 px-4 py-3 ${
           isUser
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-800 border border-gray-700 text-gray-200'
+            ? 'border-l-accent-strong bg-gray-850 text-gray-100'
+            : 'border-l-accent bg-gray-800 text-gray-200'
         } ${isTemp ? 'opacity-70' : ''} ${
           isActiveCritique ? 'ring-2 ring-yellow-500/50' : ''
         }`}>
@@ -131,7 +140,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 onChange={e => setEditValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 rows={6}
-                className="w-full min-h-[140px] bg-blue-700 text-white rounded px-3 py-2 text-sm resize-y focus:outline-none"
+                className="w-full min-h-[140px] bg-gray-800 border border-gray-700 text-gray-100 font-mono rounded px-3 py-2 text-sm resize-y focus:outline-none focus:border-accent"
                 autoFocus
               />
               <div className="flex gap-2 mt-2 text-xs">
@@ -140,10 +149,10 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
               </div>
             </div>
           ) : isUser ? (
-            message.content && <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+            message.content && <p className="text-sm whitespace-pre-wrap font-mono">{message.content}</p>
           ) : (
             message.content && (
-              <div className="text-sm prose prose-invert prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+              <div className="prose prose-invert max-w-none text-[15px] leading-relaxed font-serif [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
                 <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                   {message.content}
                 </ReactMarkdown>
@@ -173,6 +182,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
             )}
           </div>
         )}
+        </div>
       </div>
     </div>
   )

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -56,7 +56,19 @@ export default function MessageList({
       onScroll={handleScroll}
       className="flex-1 overflow-auto p-4 space-y-4"
     >
-      <div className="max-w-6xl mx-auto space-y-4">
+      <div className="relative max-w-6xl mx-auto space-y-4">
+        {/* Timeline spine — a hairline rule down the left gutter with
+            faded ends; per-turn tick nodes sit on it (rendered per turn). */}
+        {(messages.length > 0 || streaming) && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-[14px] top-1 bottom-6 w-px"
+            style={{
+              background:
+                'linear-gradient(180deg, transparent, var(--color-line-strong) 4%, var(--color-line-strong) 96%, transparent)',
+            }}
+          ></div>
+        )}
         {messages.map(msg => (
           <MessageBubble
             key={msg.id}
@@ -70,6 +82,15 @@ export default function MessageList({
             artifacts={artifacts[msg.id]}
           />
         ))}
+
+        {/* Streaming assistant turn — one timeline node for the whole
+            in-flight turn, aligned to the shared spine via the gutter. */}
+        {streaming && (
+        <div className="relative pl-8 space-y-4">
+          <span
+            aria-hidden="true"
+            className="absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-gray-850 border border-accent"
+          ></span>
 
         {/* Assistant header + continuous thinking trace — renders ABOVE the
             tool events so the visual order matches the saved view (one
@@ -159,15 +180,15 @@ export default function MessageList({
                 <FormatDriftChip warning={streamingParseWarning} rawContent={streamingContent} />
               )}
               {streamingContent ? (
-                <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700 text-gray-200">
-                  <div className="text-sm prose prose-invert prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-gray-800 text-gray-200">
+                  <div className="prose prose-invert max-w-none text-[15px] leading-relaxed font-serif [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
                     <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                       {streamingContent}
                     </ReactMarkdown>
                   </div>
                 </div>
               ) : !streamingReasoning && toolEvents.length === 0 && pendingToolCalls.length === 0 ? (
-                <div className="rounded-lg px-4 py-3 bg-gray-800 border border-gray-700">
+                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-gray-800">
                   <div className="flex items-center gap-2 text-sm text-gray-400">
                     <span className="relative flex h-2 w-2">
                       <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60"></span>
@@ -199,6 +220,8 @@ export default function MessageList({
               <span>Waiting for model… {heartbeat.elapsed_s.toFixed(1)}s</span>
             </div>
           </div>
+        )}
+        </div>
         )}
 
         {/* Empty state */}


### PR DESCRIPTION
## Phase 3 of issue #29 — Chat visual redesign

Implements §4 (transcript-as-log) in `MessageList.jsx` + `MessageBubble.jsx`. The largest visual change; built on the phase-1 tokens.

### Kept (per §4)
- **Timeline spine** down the left gutter — a hairline rule with faded ends (`linear-gradient` over `--color-line-strong`), rendered once in `MessageList` behind the turns.
- **Per-turn tick node** in the gutter, sitting on the spine: blue `accent` for assistant, deeper `accent-strong` for user. The streaming turn gets one node for the whole in-flight turn.
- Turns as **hairline-bordered blocks with a 2px colored left accent spine** (`border-line` + `border-l-accent` / `border-l-accent-strong`), **not** filled rounded bubbles — applied to persisted messages, the streaming response, and the Thinking/Waiting fallback.
- **Assistant prose in Newsreader serif** (15px / relaxed leading); **user input in IBM Plex Mono** (incl. the edit textarea).
- **Alignment unchanged**: user right-aligned, assistant left-aligned; spine + nodes run down the left gutter — not collapsed to a single left column.

### Dropped (per §4)
- No mono `ROLE · model · seq · time · tok` meta line was present; kept the existing light/minimal role label.

### Palette
- Re-expressed entirely in the blue + semantic palette. No amber/cyan (mock's scheme rejected per §7).

### Verification
- `npm run build` ✓
- Playwright against local `vite preview` of this branch: `/chat` route mounts, phase-1 tokens (`--color-line/accent/accent-strong`, `--font-serif`) compiled into the bundle, Newsreader font-face present, **0 console errors**.
- Note: the local environment has no backend, so a populated transcript can't be rendered end-to-end here; the structural/style change is verified via build + token presence + clean console, with codex review as the second check.

No backend changes.