### PR TITLE
feat(chat): composer attach affordance + restyled chips — issue #29 phase 4

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -111,15 +111,14 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   }
 
   function handlePaste(e) {
-    const items = e.clipboardData?.items
-    if (!items) return
     if (disabled) return
-    for (const item of items) {
-      if (item.type.startsWith('image/')) {
-        e.preventDefault()
-        const file = item.getAsFile()
-        if (file) addImageFile(file)
-      }
+    // Route pasted files (images and allowlisted non-images, e.g. copied
+    // from the OS file manager) through the same ingest path as the
+    // attach button and drag-and-drop. Text paste falls through.
+    const files = e.clipboardData?.files
+    if (files && files.length > 0) {
+      e.preventDefault()
+      ingestFiles(files)
     }
   }
 

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -1,9 +1,53 @@
 import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 
+// Attach affordance allowlist (issue #29 §5). This is the affordance only —
+// where non-image attachments are stored/used is feature #28.
+const ALLOWED_EXT = new Set([
+  // text / docs
+  'txt', 'md', 'markdown', 'pdf', 'json', 'csv', 'tsv', 'log',
+  // code
+  'js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs', 'java', 'c', 'h',
+  'cpp', 'cc', 'hpp', 'cs', 'php', 'swift', 'kt', 'sh', 'bash', 'zsh',
+  'sql', 'html', 'css', 'scss', 'yml', 'yaml', 'toml', 'ini', 'xml',
+])
+
+function fileExt(name) {
+  const i = name.lastIndexOf('.')
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : ''
+}
+
+function isImage(file) {
+  return file.type.startsWith('image/')
+}
+
+function isAllowed(file) {
+  if (isImage(file)) return true
+  if (
+    file.type.startsWith('text/') ||
+    file.type === 'application/pdf' ||
+    file.type === 'application/json' ||
+    file.type === 'text/csv'
+  ) {
+    return true
+  }
+  return ALLOWED_EXT.has(fileExt(file.name))
+}
+
+function formatSize(bytes) {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert, focusKey }, ref) {
   const [value, setValue] = useState('')
   const [images, setImages] = useState([]) // [{dataUrl, name, size}]
+  const [attachments, setAttachments] = useState([]) // [{name, size, type}] — affordance only (#28)
+  const [dragOver, setDragOver] = useState(false)
   const textareaRef = useRef(null)
+  const fileInputRef = useRef(null)
+  const dragDepth = useRef(0)
 
   // Imperative API for parents that want to inject text from outside the
   // composer (e.g. the text-selection context menu's "Quote in reply" and
@@ -35,30 +79,85 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     }
   }, [value])
 
-  function handlePaste(e) {
-    const items = e.clipboardData?.items
-    if (!items) return
+  function addImageFile(file) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      setImages(prev => [...prev, {
+        dataUrl: reader.result,
+        name: file.name || 'pasted-image',
+        size: file.size,
+      }])
+    }
+    reader.readAsDataURL(file)
+  }
 
-    for (const item of items) {
-      if (item.type.startsWith('image/')) {
-        e.preventDefault()
-        const file = item.getAsFile()
-        if (!file) continue
-        const reader = new FileReader()
-        reader.onload = () => {
-          setImages(prev => [...prev, {
-            dataUrl: reader.result,
-            name: file.name || 'pasted-image',
-            size: file.size,
-          }])
-        }
-        reader.readAsDataURL(file)
+  // Shared ingest path for the attach button, drag-and-drop and paste.
+  // Images flow through the existing image pipeline; other allowlisted
+  // files are shown as attachment chips (affordance only — transport is #28).
+  function ingestFiles(fileList) {
+    for (const file of fileList) {
+      if (!isAllowed(file)) continue
+      if (isImage(file)) {
+        addImageFile(file)
+      } else {
+        setAttachments(prev => [...prev, {
+          name: file.name,
+          size: file.size,
+          type: file.type || fileExt(file.name),
+        }])
       }
     }
   }
 
+  function handlePaste(e) {
+    const items = e.clipboardData?.items
+    if (!items) return
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault()
+        const file = item.getAsFile()
+        if (file) addImageFile(file)
+      }
+    }
+  }
+
+  function handleFilePick(e) {
+    if (e.target.files?.length) ingestFiles(e.target.files)
+    e.target.value = '' // allow re-selecting the same file
+  }
+
+  function handleDragEnter(e) {
+    e.preventDefault()
+    dragDepth.current += 1
+    if (e.dataTransfer?.types?.includes('Files')) setDragOver(true)
+  }
+
+  function handleDragOver(e) {
+    e.preventDefault()
+  }
+
+  function handleDragLeave(e) {
+    e.preventDefault()
+    dragDepth.current -= 1
+    if (dragDepth.current <= 0) {
+      dragDepth.current = 0
+      setDragOver(false)
+    }
+  }
+
+  function handleDrop(e) {
+    e.preventDefault()
+    dragDepth.current = 0
+    setDragOver(false)
+    if (e.dataTransfer?.files?.length) ingestFiles(e.dataTransfer.files)
+  }
+
   function removeImage(idx) {
     setImages(prev => prev.filter((_, i) => i !== idx))
+  }
+
+  function removeAttachment(idx) {
+    setAttachments(prev => prev.filter((_, i) => i !== idx))
   }
 
   function buildMessage() {
@@ -81,6 +180,9 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     onSend(msg, imgDataUrls.length > 0 ? imgDataUrls : undefined)
     setValue('')
     setImages([])
+    // Non-image attachments are an affordance only; their transport is
+    // owned by feature #28. Clear them so the composer resets cleanly.
+    setAttachments([])
   }
 
   function handleKeyDown(e) {
@@ -93,23 +195,40 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   const canSend = !disabled && (value.trim() || images.length > 0 || pendingInserts.length > 0)
 
   return (
-    <div className="border-t border-gray-700">
-      {/* Pending inserts */}
+    <div
+      className={`border-t border-gray-700 ${dragOver ? 'bg-accent/5' : ''}`}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* Drag-and-drop hint */}
+      {dragOver && (
+        <div className="px-4 pt-3 max-w-6xl mx-auto">
+          <div className="rounded border border-dashed border-accent/50 bg-accent/5 px-3 py-2 text-xs font-mono text-accent flex items-center gap-2">
+            <i className="fa-solid fa-paperclip"></i>
+            Drop files to attach (images, text, pdf, json, csv, code)
+          </div>
+        </div>
+      )}
+
+      {/* Pending inserts — refined hairline chips with the critique accent. */}
       {pendingInserts.length > 0 && (
         <div className="px-4 pt-3 max-w-6xl mx-auto">
-          <div className="text-[10px] text-yellow-400 mb-1.5 uppercase tracking-wide">
+          <div className="text-[10px] font-mono text-critique mb-1.5 uppercase tracking-wide">
             <i className="fa-solid fa-arrow-right-to-bracket mr-1"></i>
             Issues to include ({pendingInserts.length})
           </div>
           <div className="space-y-1">
             {pendingInserts.map((ann, i) => (
-              <div key={i} className="flex items-start gap-2 text-xs bg-yellow-500/5 border border-yellow-500/20 rounded px-2 py-1.5">
+              <div key={i} className="flex items-start gap-2 text-xs bg-gray-850 border border-line border-l-2 border-l-critique rounded px-2 py-1.5">
                 <span className="flex-1 text-gray-300 truncate" title={ann.comment}>
-                  <span className="text-yellow-400/70">{ann.issue_type}:</span> {ann.comment}
+                  <span className="font-mono text-critique">{ann.issue_type}:</span> {ann.comment}
                 </span>
                 <button
                   onClick={() => onClearInsert(i)}
-                  className="text-gray-500 hover:text-red-400 flex-shrink-0"
+                  className="text-gray-500 hover:text-error flex-shrink-0"
+                  aria-label="Remove issue"
                 >
                   <i className="fa-solid fa-xmark text-[10px]"></i>
                 </button>
@@ -128,13 +247,39 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
                 <img
                   src={img.dataUrl}
                   alt={img.name}
-                  className="w-20 h-20 object-cover rounded border border-gray-700"
+                  className="w-20 h-20 object-cover rounded border border-line"
                 />
                 <button
                   onClick={() => removeImage(i)}
-                  className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-600 rounded-full flex items-center justify-center text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-error rounded-full flex items-center justify-center text-white text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
+                  aria-label="Remove image"
                 >
                   <i className="fa-solid fa-xmark"></i>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Attachment chips — refined hairline, mono filename/size. */}
+      {attachments.length > 0 && (
+        <div className="px-4 pt-3 max-w-6xl mx-auto">
+          <div className="flex gap-2 flex-wrap">
+            {attachments.map((att, i) => (
+              <div
+                key={i}
+                className="group flex items-center gap-2 text-xs bg-gray-850 border border-line border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
+              >
+                <i className="fa-solid fa-file-lines text-accent flex-shrink-0"></i>
+                <span className="font-mono text-gray-300 truncate" title={att.name}>{att.name}</span>
+                <span className="font-mono text-gray-500 flex-shrink-0">{formatSize(att.size)}</span>
+                <button
+                  onClick={() => removeAttachment(i)}
+                  className="text-gray-500 hover:text-error flex-shrink-0"
+                  aria-label="Remove attachment"
+                >
+                  <i className="fa-solid fa-xmark text-[10px]"></i>
                 </button>
               </div>
             ))}
@@ -145,16 +290,34 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
       {/* Input */}
       <form onSubmit={handleSubmit} className="p-4">
         <div className="flex gap-3 items-end max-w-6xl mx-auto">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/*,text/*,application/pdf,application/json,.md,.csv,.tsv,.log,.js,.jsx,.ts,.tsx,.py,.rb,.go,.rs,.java,.c,.h,.cpp,.cc,.hpp,.cs,.php,.swift,.kt,.sh,.sql,.html,.css,.scss,.yml,.yaml,.toml,.ini,.xml"
+            className="hidden"
+            onChange={handleFilePick}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled}
+            aria-label="Attach files"
+            title="Attach files"
+            className="px-4 py-3 bg-gray-800 border border-gray-700 hover:border-accent text-gray-400 hover:text-accent disabled:opacity-50 rounded-lg text-sm transition-colors"
+          >
+            <i className="fa-solid fa-paperclip"></i>
+          </button>
           <textarea
             ref={textareaRef}
             value={value}
             onChange={e => setValue(e.target.value)}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
-            placeholder={images.length > 0 ? 'Add a message about the image(s)...' : pendingInserts.length > 0 ? 'Add a message (optional) or send with issues only...' : 'Type a message or paste an image...'}
+            placeholder={images.length > 0 ? 'Add a message about the image(s)...' : pendingInserts.length > 0 ? 'Add a message (optional) or send with issues only...' : 'Type a message, paste or drop files...'}
             disabled={disabled}
             rows={1}
-            className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-sm text-gray-100 placeholder-gray-500 resize-none focus:outline-none focus:border-blue-500 disabled:opacity-50"
+            className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-sm text-gray-100 placeholder-gray-500 resize-none focus:outline-none focus:border-accent disabled:opacity-50"
           />
           <button
             type="submit"

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -127,18 +127,27 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     e.target.value = '' // allow re-selecting the same file
   }
 
+  // Only intercept file drags. Non-file drags (e.g. selecting text and
+  // dragging it into the textarea) must fall through so the browser's
+  // native text-drop behavior still works.
+  function isFileDrag(e) {
+    return !!e.dataTransfer?.types?.includes('Files')
+  }
+
   function handleDragEnter(e) {
+    if (disabled || !isFileDrag(e)) return
     e.preventDefault()
-    if (disabled) return
     dragDepth.current += 1
-    if (e.dataTransfer?.types?.includes('Files')) setDragOver(true)
+    setDragOver(true)
   }
 
   function handleDragOver(e) {
+    if (disabled || !isFileDrag(e)) return
     e.preventDefault()
   }
 
   function handleDragLeave(e) {
+    if (disabled || !isFileDrag(e)) return
     e.preventDefault()
     dragDepth.current -= 1
     if (dragDepth.current <= 0) {
@@ -148,10 +157,10 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   }
 
   function handleDrop(e) {
+    if (disabled || !isFileDrag(e)) return
     e.preventDefault()
     dragDepth.current = 0
     setDragOver(false)
-    if (disabled) return
     if (e.dataTransfer?.files?.length) ingestFiles(e.dataTransfer.files)
   }
 

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -95,6 +95,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   // Images flow through the existing image pipeline; other allowlisted
   // files are shown as attachment chips (affordance only — transport is #28).
   function ingestFiles(fileList) {
+    if (disabled) return
     for (const file of fileList) {
       if (!isAllowed(file)) continue
       if (isImage(file)) {
@@ -112,6 +113,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   function handlePaste(e) {
     const items = e.clipboardData?.items
     if (!items) return
+    if (disabled) return
     for (const item of items) {
       if (item.type.startsWith('image/')) {
         e.preventDefault()
@@ -128,6 +130,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
 
   function handleDragEnter(e) {
     e.preventDefault()
+    if (disabled) return
     dragDepth.current += 1
     if (e.dataTransfer?.types?.includes('Files')) setDragOver(true)
   }
@@ -149,6 +152,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     e.preventDefault()
     dragDepth.current = 0
     setDragOver(false)
+    if (disabled) return
     if (e.dataTransfer?.files?.length) ingestFiles(e.dataTransfer.files)
   }
 


### PR DESCRIPTION
## Phase 4 of issue #29 — Chat visual redesign

Implements §5 (composer updates) in `ChatInput.jsx`. Built on the phase-1 tokens.

### Kept (per §5)
- **Attach-files button + drag-and-drop** with allowlist validation (images / text / pdf / json / csv / code). One shared `ingestFiles` path for the button, drop and paste; depth-counted drag enter/leave with a drop hint. Images flow through the existing image pipeline; other allowlisted files become attachment chips. **Affordance only** — transport/storage of non-image attachments is owned by #28, so they are cleared on send.
- **Restyled critique pending-insert chips** to the refined visual language: hairline block + left `critique` accent + mono labels, using the phase-1 semantic tokens.
- New attachment chips share the same refined hairline + mono style.
- **Empty-state composer parity**: `ChatArea` renders the same `<ChatInput>` for both the empty-state (line 125) and active (line 226) composers, so the affordance + restyle apply there automatically — verified in the browser.

### Dropped (per §5)
- No command-console frame (prompt glyph / focus glow / mono hint line).
- No reference-an-existing-artifact picker (deferred to #28).

### Verification
- `npm run build` ✓
- Playwright against local `vite preview`, on the `/chat` empty-state composer:
  - attach button + multi `<input type=file>` present; `accept` includes `application/pdf` and code extensions ✓
  - drag-drop a `.py` + `.csv` + `.exe`: `.py`/`.csv` accepted as chips, `.exe` rejected by the allowlist ✓
  - placeholder updated; **0 console errors** ✓

No backend changes.