### PR TITLE
feat(chat): vocabulary pass — issue #29 phase 5

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -191,7 +191,7 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
               <button
                 onClick={toggleSelectAllRoots}
                 className="text-[11px] text-gray-500 hover:text-gray-300"
-                title="Selects only top-level conversations; spinoffs follow their parent"
+                title="Selects only top-level conversations; spin-offs follow their parent"
               >
                 {allRootsSelected ? 'Deselect all' : 'Select all'}
               </button>

--- a/dashboard/frontend/src/components/chat/CritiquePanel.jsx
+++ b/dashboard/frontend/src/components/chat/CritiquePanel.jsx
@@ -53,7 +53,7 @@ export default function CritiquePanel({ messageId, originalContent, critique, lo
         {loading && !critique && (
           <div className="text-center text-gray-500 py-8">
             <i className="fa-solid fa-spinner fa-spin text-xl mb-3 block"></i>
-            <p className="text-xs">Sidekick is reviewing...</p>
+            <p className="text-xs">Critic is reviewing...</p>
           </div>
         )}
 
@@ -63,7 +63,7 @@ export default function CritiquePanel({ messageId, originalContent, critique, lo
 
         {!critique && !loading && (
           <div className="text-center text-gray-600 py-8 text-xs">
-            Click "Run Critique" to have the sidekick review this response
+            Click "Run Critique" to have the critic review this response
           </div>
         )}
       </div>

--- a/dashboard/frontend/src/components/chat/ModelSelector.jsx
+++ b/dashboard/frontend/src/components/chat/ModelSelector.jsx
@@ -24,7 +24,7 @@ export default function ModelSelector({ mainService, sidekickService, onChangeMa
         </select>
       </div>
       <div className="flex items-center gap-2">
-        <label className="text-xs text-gray-400 whitespace-nowrap">Sidekick:</label>
+        <label className="text-xs text-gray-400 whitespace-nowrap">Critic:</label>
         <select
           value={sidekickService || ''}
           onChange={e => onChangeSidekick(e.target.value || null)}

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
@@ -25,7 +25,7 @@ export default function SystemPromptEditor({ mainPrompt, sidekickPrompt, onChang
             />
           </div>
           <div>
-            <label className="text-xs text-gray-400 mb-1 block">Sidekick Model</label>
+            <label className="text-xs text-gray-400 mb-1 block">Critic Model</label>
             <textarea
               value={sidekickPrompt}
               onChange={e => onChangeSidekick(e.target.value)}

--- a/dashboard/frontend/src/components/chat/TextContextMenu.jsx
+++ b/dashboard/frontend/src/components/chat/TextContextMenu.jsx
@@ -66,7 +66,7 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
         className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
       >
         <i className="fa-solid fa-code-branch text-purple-400 text-xs"></i>
-        Spin off...
+        Spin-off...
       </button>
       <button
         onClick={async () => {


### PR DESCRIPTION
## Phase 5 of issue #29 — Chat visual redesign

Implements §1: conventional terms only. **Copy-only**, no visual change, low risk.

### Changes
The codebase already used conventional terms for Conversation / Critique / Composer / You. The remaining jargon was "Sidekick" for the critic model, plus an unhyphenated "Spin off":
- `ModelSelector`: `Sidekick:` → `Critic:`
- `SystemPromptEditor`: `Sidekick Model` → `Critic Model`
- `CritiquePanel`: `Sidekick is reviewing...` → `Critic is reviewing...`; `have the sidekick review this response` → `have the critic review this response`
- `TextContextMenu`: `Spin off...` → `Spin-off...`
- `ChatSidebar`: tooltip `spinoffs follow their parent` → `spin-offs follow their parent`

Code identifiers and internal comments are intentionally left unchanged — the issue scopes this to user-facing labels/copy.

### Verification
- `npm run build` ✓
- Playwright against local `vite preview`: no "sidekick" string anywhere in the rendered DOM; 0 console errors. (`Critic:` / `Critic Model` live in the model selector / settings, not shown in the offline empty state, but verified by the diff + build.)

No backend changes.