### PR TITLE
Theme system PR 1/4 — foundation + shell parity (#5)

### DIFF
--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -9,6 +9,22 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:ital,wght@0,400;0,500;0,600;1,400&display=swap">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LLM-Dock</title>
+    <script>
+      // Anti-FOUC: set the theme before the stylesheet/React so first paint
+      // is correct. Must run before the module bundle (issue #5 §4).
+      (function () {
+        try {
+          var KEY = 'dashboard_theme';
+          var stored = localStorage.getItem(KEY);
+          var theme = (stored === 'dark' || stored === 'light') ? stored
+            : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+          document.documentElement.dataset.theme = theme;
+          document.documentElement.style.colorScheme = theme;
+        } catch (e) {
+          document.documentElement.dataset.theme = 'dark';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -20,7 +20,7 @@ function DefaultLayout({ children }) {
 
 function App() {
   return (
-    <div className="flex h-screen bg-gray-900 text-gray-100">
+    <div className="flex h-screen bg-app text-fg">
       <Sidebar />
       <main className="flex-1 flex flex-col overflow-hidden">
         <Routes>

--- a/dashboard/frontend/src/components/Header.jsx
+++ b/dashboard/frontend/src/components/Header.jsx
@@ -1,9 +1,12 @@
+import ThemeSwitcher from './ThemeSwitcher'
+
 function Header() {
   return (
-    <header className="h-16 bg-gray-900/80 border-b border-gray-800 px-4 flex items-center justify-end">
+    <header className="h-16 bg-app/80 border-b border-border-subtle px-4 flex items-center justify-end gap-3">
+      <ThemeSwitcher />
       <a
         href="/"
-        className="text-xs text-gray-500 hover:text-gray-300 flex items-center gap-1.5"
+        className="text-xs text-fg-subtle hover:text-fg-muted flex items-center gap-1.5 transition-colors"
         title="Switch to the legacy dashboard"
       >
         <i className="fa-solid fa-arrow-left text-[10px]"></i>

--- a/dashboard/frontend/src/components/Sidebar.jsx
+++ b/dashboard/frontend/src/components/Sidebar.jsx
@@ -34,11 +34,11 @@ function Sidebar() {
     <aside
       className={`hidden md:flex ${
         collapsed ? 'w-16' : 'w-56'
-      } bg-gray-900 border-r border-gray-800 flex-col flex-shrink-0 transition-[width] duration-200 ease-in-out`}
+      } bg-app border-r border-border-subtle flex-col flex-shrink-0 transition-[width] duration-200 ease-in-out`}
     >
       {/* Logo + collapse toggle */}
       <div
-        className={`h-16 border-b border-gray-800 flex items-center ${
+        className={`h-16 border-b border-border-subtle flex items-center ${
           collapsed ? 'justify-center px-0' : 'justify-between px-4'
         }`}
       >
@@ -48,8 +48,8 @@ function Sidebar() {
               <i className="fa-solid fa-cube text-white text-sm"></i>
             </div>
             <div className="min-w-0">
-              <h1 className="font-bold text-lg truncate">LLM-Dock</h1>
-              <p className="text-xs text-gray-500">v1.0.0</p>
+              <h1 className="font-bold text-lg truncate text-fg">LLM-Dock</h1>
+              <p className="text-xs text-fg-subtle">v1.0.0</p>
             </div>
           </div>
         )}
@@ -59,7 +59,7 @@ function Sidebar() {
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           aria-expanded={!collapsed}
           title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-white hover:bg-gray-800/60 transition-colors"
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors"
         >
           <i
             className={`fa-solid ${
@@ -82,8 +82,8 @@ function Sidebar() {
                 collapsed ? 'justify-center px-0' : 'px-4'
               } ${
                 isActive
-                  ? 'text-white bg-gray-800/70'
-                  : 'text-gray-400 hover:bg-gray-800/50'
+                  ? 'text-fg bg-surface-strong/70'
+                  : 'text-fg-muted hover:bg-surface/50'
               }`
             }
           >
@@ -92,7 +92,7 @@ function Sidebar() {
             {collapsed && (
               <span
                 role="tooltip"
-                className="pointer-events-none absolute left-full ml-2 z-20 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-gray-100 border border-gray-700 opacity-0 shadow-lg transition-opacity duration-150 group-hover/nav:opacity-100"
+                className="pointer-events-none absolute left-full ml-2 z-20 whitespace-nowrap rounded-md bg-surface px-2 py-1 text-xs text-fg border border-border opacity-0 shadow-lg transition-opacity duration-150 group-hover/nav:opacity-100"
               >
                 {label}
               </span>
@@ -103,7 +103,7 @@ function Sidebar() {
 
       {/* User section */}
       <div
-        className={`border-t border-gray-800 ${
+        className={`border-t border-border-subtle ${
           collapsed ? 'p-2' : 'p-4'
         }`}
       >
@@ -113,18 +113,18 @@ function Sidebar() {
           }`}
         >
           <div
-            className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center flex-shrink-0"
+            className="w-8 h-8 bg-surface-strong rounded-full flex items-center justify-center flex-shrink-0"
             title={collapsed ? 'Admin' : undefined}
           >
-            <i className="fa-solid fa-user text-gray-400 text-sm"></i>
+            <i className="fa-solid fa-user text-fg-muted text-sm"></i>
           </div>
           {!collapsed && (
             <>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">Admin</p>
+                <p className="text-sm font-medium truncate text-fg">Admin</p>
               </div>
               <button
-                className="text-gray-500 hover:text-gray-300"
+                className="text-fg-subtle hover:text-fg-muted"
                 aria-label="Log out"
                 title="Log out"
               >

--- a/dashboard/frontend/src/components/ThemeSwitcher.jsx
+++ b/dashboard/frontend/src/components/ThemeSwitcher.jsx
@@ -1,0 +1,40 @@
+import { useTheme } from '../contexts/ThemeContext'
+
+const META = {
+  dark:  { icon: 'fa-moon', label: 'Dark' },
+  light: { icon: 'fa-sun',  label: 'Light' },
+}
+
+// Generic over the themes array: cycles for ≤2, renders a <select> for 3+.
+// Adding a third theme needs zero JSX edits here.
+export default function ThemeSwitcher() {
+  const { theme, setTheme, themes } = useTheme()
+
+  if (themes.length <= 2) {
+    const next = themes[(themes.indexOf(theme) + 1) % themes.length]
+    return (
+      <button
+        type="button"
+        onClick={() => setTheme(next)}
+        className="text-fg-subtle hover:text-fg-muted px-2 py-1 rounded transition-colors"
+        title={`Switch to ${META[next]?.label || next} theme`}
+        aria-label={`Switch to ${META[next]?.label || next} theme`}
+      >
+        <i className={`fa-solid ${META[theme]?.icon || 'fa-circle-half-stroke'} text-xs`}></i>
+      </button>
+    )
+  }
+
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value)}
+      className="bg-surface border border-border text-fg text-xs rounded px-2 py-1"
+      aria-label="Theme"
+    >
+      {themes.map((t) => (
+        <option key={t} value={t}>{META[t]?.label || t}</option>
+      ))}
+    </select>
+  )
+}

--- a/dashboard/frontend/src/contexts/ThemeContext.jsx
+++ b/dashboard/frontend/src/contexts/ThemeContext.jsx
@@ -85,19 +85,11 @@ export function ThemeProvider({ children }) {
     })
   }, [])
 
-  // Follow the OS only while the user has NOT chosen explicitly.
-  useEffect(() => {
-    if (readUserOverride()) return
-    const mql = window.matchMedia('(prefers-color-scheme: light)')
-    const handler = (e) => {
-      if (readUserOverride()) return
-      const next = e.matches ? 'light' : 'dark'
-      applyThemeToDom(next)
-      setThemeState(next)
-    }
-    mql.addEventListener('change', handler)
-    return () => mql.removeEventListener('change', handler)
-  }, [])
+  // OS-following is first-load-only (owner decision): prefers-color-scheme
+  // is sampled once during initial resolution (resolveInitial + the inline
+  // anti-FOUC script), never live. Intentionally no matchMedia change
+  // listener — a mid-session OS flip must not silently change the theme
+  // when there is no visible "system" mode to explain it.
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme, cycleTheme, themes: AVAILABLE_THEMES }}>

--- a/dashboard/frontend/src/contexts/ThemeContext.jsx
+++ b/dashboard/frontend/src/contexts/ThemeContext.jsx
@@ -1,0 +1,111 @@
+/* eslint-disable react-refresh/only-export-components --
+   Context module intentionally co-exports the provider component, the
+   useTheme hook, and AVAILABLE_THEMES. Splitting them would scatter the
+   theme API; the rule only affects dev-time Fast Refresh granularity. */
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'dashboard_theme'
+export const AVAILABLE_THEMES = ['dark', 'light']
+const DEFAULT_THEME = 'dark'
+
+// OS following is FIRST-LOAD-ONLY (issue #5, owner decision): prefers-color-
+// scheme picks the initial theme only when the user has no stored override.
+// Once the user picks a theme explicitly it is persisted and the OS is no
+// longer followed. There is intentionally no "system" entry in
+// AVAILABLE_THEMES; clearing localStorage restores OS-following on next load.
+function osTheme() {
+  try {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  } catch {
+    return DEFAULT_THEME
+  }
+}
+
+function readUserOverride() {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return AVAILABLE_THEMES.includes(v) ? v : null
+  } catch {
+    return null
+  }
+}
+
+function resolveInitial() {
+  const override = readUserOverride()
+  if (override) return override
+  if (typeof document !== 'undefined') {
+    const fromDom = document.documentElement.dataset.theme
+    if (fromDom && AVAILABLE_THEMES.includes(fromDom)) return fromDom
+  }
+  return osTheme()
+}
+
+const ThemeContext = createContext({
+  theme: DEFAULT_THEME,
+  setTheme: () => {},
+  cycleTheme: () => {},
+  themes: AVAILABLE_THEMES,
+})
+
+function applyThemeToDom(next) {
+  const root = document.documentElement
+  root.classList.add('theme-swap-no-transitions')
+  root.dataset.theme = next
+  root.style.colorScheme = next
+  void root.offsetHeight // force reflow so the no-transition frame takes effect
+  requestAnimationFrame(() => {
+    root.classList.remove('theme-swap-no-transitions')
+  })
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(resolveInitial)
+
+  // Authoritative on mount: re-assert the resolved theme even if the
+  // inline anti-FOUC script failed or was changed (owner note 4).
+  useEffect(() => {
+    applyThemeToDom(theme)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const setTheme = useCallback((next) => {
+    if (!AVAILABLE_THEMES.includes(next)) return
+    try { localStorage.setItem(STORAGE_KEY, next) } catch { /* ignore */ }
+    applyThemeToDom(next)
+    setThemeState(next)
+  }, [])
+
+  const cycleTheme = useCallback(() => {
+    setThemeState((cur) => {
+      const i = AVAILABLE_THEMES.indexOf(cur)
+      const next = AVAILABLE_THEMES[(i + 1) % AVAILABLE_THEMES.length]
+      try { localStorage.setItem(STORAGE_KEY, next) } catch { /* ignore */ }
+      applyThemeToDom(next)
+      return next
+    })
+  }, [])
+
+  // Follow the OS only while the user has NOT chosen explicitly.
+  useEffect(() => {
+    if (readUserOverride()) return
+    const mql = window.matchMedia('(prefers-color-scheme: light)')
+    const handler = (e) => {
+      if (readUserOverride()) return
+      const next = e.matches ? 'light' : 'dark'
+      applyThemeToDom(next)
+      setThemeState(next)
+    }
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, cycleTheme, themes: AVAILABLE_THEMES }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -7,17 +7,23 @@
  * These tokens are the foundation later phases (nav, transcript, composer)
  * build on. Families/values are swappable later; the role structure is the
  * decision.
+ *
+ * Issue #5 — theme system. The `--color-<name>` semantic tokens below
+ * (surfaces / fg / border / state / badge / chart) are the themed layer:
+ * dark is the @theme default; [data-theme="light"] overrides only the
+ * variables. The #29 fixed palette (gray ramp + accent/critique/mcp/
+ * spinoff/error) stays brand-fixed across themes — semantic tokens are
+ * what components migrate onto (issue #5 §2 mapping) over PRs 2–4.
+ * `static` keeps every token in the built CSS even when not yet
+ * referenced, so later-PR consumers can read them as runtime `var(--...)`.
  */
 @theme static {
-  /* §6 — distinctive trio. Replaces the previous undeclared system-sans.
-     `static` keeps every token in the built CSS even when not yet
-     referenced — later phases consume these as runtime `var(--...)`. */
+  /* §6 — distinctive trio. Replaces the previous undeclared system-sans. */
   --font-sans: "Archivo", ui-sans-serif, system-ui, sans-serif;        /* UI chrome */
   --font-serif: "Newsreader", Georgia, Cambria, "Times New Roman", serif; /* assistant prose */
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace; /* user input, code, labels */
 
-  /* §7 — refine, don't reinvent. Deepen / de-muddy the gray surfaces and
-     tighten contrast. Keeps blue as primary; rejects the mock's amber/cyan. */
+  /* §7 — #29 fixed gray ramp (brand-fixed; not themed). */
   --color-gray-950: #07090d;
   --color-gray-900: #0b0f15; /* app background */
   --color-gray-850: #11161f; /* raised panels (also makes bg-gray-850 real) */
@@ -25,8 +31,8 @@
   --color-gray-700: #232b38; /* hairline borders */
   --color-gray-600: #36404f; /* strong borders */
 
-  /* Established semantic colors (kept): blue=primary, yellow=critique,
-     green=MCP-on, purple=spin-off, red=error. Available as bg-/text-/border-. */
+  /* #29 brand/semantic colors (brand-fixed; not themed): blue=primary,
+     yellow=critique, green=MCP-on, purple=spin-off, red=error. */
   --color-accent: #3b82f6;
   --color-accent-strong: #2563eb;
   --color-critique: #eab308;
@@ -34,18 +40,158 @@
   --color-spinoff: #a855f7;
   --color-error: #ef4444;
 
-  /* Hairline rules + timeline spine — re-expressed in the neutral/blue palette
-     (consumed by the transcript-as-log work, §4). */
+  /* #29 hairline rules + timeline spine. */
   --color-line: rgba(148, 163, 184, 0.10);
   --color-line-strong: rgba(148, 163, 184, 0.20);
+
+  /* -----------------------------------------------------------------
+   * Issue #5 — semantic theming tokens. Dark = default (values chosen
+   * to preserve pixel parity with the post-#29 look). [data-theme=
+   * "light"] below overrides only what differs. Names map to issue #5
+   * §2: bg-app/surface/..., text-fg/..., border-border/..., etc.
+   * ----------------------------------------------------------------- */
+
+  /* Surfaces */
+  --color-app:            #0b0f15;
+  --color-surface:        #161c27;
+  --color-surface-strong: #232b38;
+  --color-surface-muted:  #11161f;
+  --color-overlay:        #07090d;
+  --color-elevated:       #11161f;
+
+  /* Foreground / text */
+  --color-fg:        #f3f4f6;
+  --color-fg-muted:  #9ca3af;
+  --color-fg-subtle: #6b7280;
+  --color-fg-faint:  #4b5563;
+  --color-fg-inverse:#ffffff;
+
+  /* Borders */
+  --color-border:        #232b38;
+  --color-border-strong: #36404f;
+  --color-border-subtle: #161c27;
+
+  /* Accent (reuses #29's accent pair; adds fg/subtle roles). */
+  --color-accent-hover:    #3b82f6;
+  --color-accent-fg:       #60a5fa;
+  --color-accent-fg-hover: #93c5fd;
+  --color-accent-subtle:   rgb(37 99 235 / 0.25);
+
+  /* State (semantic, not literal) */
+  --color-success:        #22c55e;
+  --color-success-fg:     #4ade80;
+  --color-success-subtle: rgb(20 83 45 / 0.40);
+  --color-danger:         #dc2626;
+  --color-danger-fg:      #f87171;
+  --color-danger-subtle:  rgb(127 29 29 / 0.30);
+  --color-warning:        #facc15;
+  --color-warning-fg:     #fde047;
+  --color-warning-subtle: rgb(120 53 15 / 0.30);
+  --color-info:           #38bdf8;
+  --color-info-fg:        #7dd3fc;
+
+  /* Engine badges (categorical, themed) */
+  --color-badge-llamacpp-bg: rgb(37 99 235 / 0.30);
+  --color-badge-llamacpp-fg: #93c5fd;
+  --color-badge-vllm-bg:     rgb(147 51 234 / 0.30);
+  --color-badge-vllm-fg:     #d8b4fe;
+  --color-badge-webui-bg:    rgb(5 150 105 / 0.30);
+  --color-badge-webui-fg:    #6ee7b7;
+  --color-badge-neutral-bg:  rgb(75 85 99 / 0.30);
+  --color-badge-neutral-fg:  #9ca3af;
+
+  /* Charts (read by canvas/SVG via getComputedStyle; also utilities) */
+  --color-chart-memory:     #3b82f6;
+  --color-chart-compute:    #22c55e;
+  --color-chart-grid:       #232b38;
+  --color-chart-axis-label: #d1d5db;
+  --color-gauge-prefix:     #3b82f6;
+  --color-gauge-spec:       #a855f7;
+  --color-gauge-good:       #22c55e;
+  --color-gauge-warn:       #eab308;
+  --color-gauge-bad:        #ef4444;
+}
+
+/* -------------------------------------------------------------------
+ * Light theme — overrides only. State/brand hues keep their meaning
+ * (running=green, stopped=red, link=blue), using light-friendly
+ * variants rather than inverted lightness (issue #5 §8).
+ * ------------------------------------------------------------------- */
+[data-theme="light"] {
+  --color-app:            #f8fafc;
+  --color-surface:        #ffffff;
+  --color-surface-strong: #f1f5f9;
+  --color-surface-muted:  #e2e8f0;
+  --color-overlay:        #ffffff;
+  --color-elevated:       #ffffff;
+
+  --color-fg:        #0f172a;
+  --color-fg-muted:  #475569;
+  --color-fg-subtle: #64748b;
+  --color-fg-faint:  #94a3b8;
+  --color-fg-inverse:#ffffff;
+
+  --color-border:        #e2e8f0;
+  --color-border-strong: #cbd5e1;
+  --color-border-subtle: #f1f5f9;
+
+  --color-accent-hover:    #1d4ed8;
+  --color-accent-fg:       #2563eb;
+  --color-accent-fg-hover: #1d4ed8;
+  --color-accent-subtle:   rgb(37 99 235 / 0.10);
+
+  --color-success:        #16a34a;
+  --color-success-fg:     #15803d;
+  --color-success-subtle: rgb(34 197 94 / 0.10);
+  --color-danger:         #dc2626;
+  --color-danger-fg:      #b91c1c;
+  --color-danger-subtle:  rgb(220 38 38 / 0.08);
+  --color-warning:        #d97706;
+  --color-warning-fg:     #b45309;
+  --color-warning-subtle: rgb(217 119 6 / 0.10);
+  --color-info:           #0284c7;
+  --color-info-fg:        #0369a1;
+
+  --color-badge-llamacpp-bg: rgb(37 99 235 / 0.12);
+  --color-badge-llamacpp-fg: #1d4ed8;
+  --color-badge-vllm-bg:     rgb(147 51 234 / 0.12);
+  --color-badge-vllm-fg:     #7e22ce;
+  --color-badge-webui-bg:    rgb(5 150 105 / 0.12);
+  --color-badge-webui-fg:    #047857;
+  --color-badge-neutral-bg:  rgb(100 116 139 / 0.12);
+  --color-badge-neutral-fg:  #475569;
+
+  --color-chart-grid:       #cbd5e1;
+  --color-chart-axis-label: #475569;
+}
+
+[data-theme="dark"] {
+  /* intentionally empty — @theme covers dark; selector kept for symmetry */
 }
 
 @layer base {
+  /* Variable-backed so first paint is correct before Tailwind's
+     content-scanned utilities or React mount (issue #5 §8, owner note 3). */
+  html {
+    background-color: var(--color-app);
+    color: var(--color-fg);
+  }
   body {
     font-family: var(--font-sans);
-    background-color: var(--color-gray-900);
-    color: #c7d0db;
+    background-color: var(--color-app);
+    color: var(--color-fg);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+}
+
+/* -------------------------------------------------------------------
+ * Anti-transition-flash helper. ThemeProvider toggles this on <html>
+ * for one frame around a swap so transition-colors elements snap
+ * instead of animating through intermediate colors (issue #5 §8).
+ * ------------------------------------------------------------------- */
+.theme-swap-no-transitions *,
+.theme-swap-no-transitions *::before,
+.theme-swap-no-transitions *::after {
+  transition: none !important;
 }

--- a/dashboard/frontend/src/main.jsx
+++ b/dashboard/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import { ThemeProvider } from './contexts/ThemeContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter basename="/v2">
-      <App />
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter basename="/v2">
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
First of 4 PRs for the v2 theme system. Tracker: #5. Follows the owner-comment PR sequence.

## Scope (PR 1 — wiring + shell only)
- **`index.css`**: issue #5 semantic theming tokens (surfaces / fg / border / state / badge / chart) added inside the existing `@theme static` block (so they survive Tailwind v4 tree-shaking, the lesson from #29). Dark values chosen to **preserve pixel parity** with the post-#29 palette. New `[data-theme="light"]` override block. `html`/`body` made variable-backed for correct first paint (owner note 3). `.theme-swap-no-transitions` helper.
- **`index.html`**: anti-FOUC inline script before the module bundle.
- **`ThemeContext.jsx`** (new): `ThemeProvider` authoritative on mount (owner note 4); `localStorage` persistence; **OS-following is first-load-only**, documented in-code — no `system` entry in `AVAILABLE_THEMES` (owner decision on issue-comment point 2).
- **`ThemeSwitcher.jsx`** (new): generic over the `themes` array (cycles for ≤2, `<select>` for 3+ — zero JSX edits to add a 3rd theme). Rendered in `Header`.
- **Shell migrated** to semantic tokens: `App`, `Header`, `Sidebar`.

## Reconciliation note
Issue #5's draft predates the #29 chat redesign (which already redefined the gray ramp, added `--color-accent`/`critique`/`mcp`/`spinoff`/`error`, and rewrote `Sidebar` as collapsible). The #29 fixed palette + brand colors are kept brand-fixed; issue #5's semantic tokens are layered on top as the themed layer that components migrate onto over PRs 2–4. Dark token values mirror the #29 palette so dark stays pixel-identical.

## Out of scope (later PRs)
Everything outside the shell still uses the fixed gray ramp and looks correct in dark but not yet in light — migrated in PR 2 (services/GPU), PR 3 (chat + prose helper), PR 4 (canvas/SVG + inline-color cleanup).

## Verification
- `npm run build` OK; `npm test` 44/44; no new lint errors (the 6 remaining errors pre-exist on `main` in `useChat.js`/`useCritique.js`).
- Playwright smoke (local `vite preview`): dark parity (`--color-app` `#0b0f15`), light toggle + `localStorage` persistence across reload, first-load OS-following, **0 console errors**.
- `dist/assets/*.css` contains both default tokens and the `[data-theme=light]` override (Lightning CSS strips the attribute-value quotes — valid).