### PR TITLE
Theme system PR 2/4 — services / details / GPU components (#5)

### DIFF
--- a/dashboard/frontend/src/components/GpuMonitor.jsx
+++ b/dashboard/frontend/src/components/GpuMonitor.jsx
@@ -31,15 +31,15 @@ export default function GpuMonitor() {
   }, [gpus])
 
   if (error) {
-    return <p className="text-red-400">GPU: {error}</p>
+    return <p className="text-danger-fg">GPU: {error}</p>
   }
 
   if (gpus === null) {
-    return <p className="text-gray-500">Loading GPU info...</p>
+    return <p className="text-fg-subtle">Loading GPU info...</p>
   }
 
   if (!gpus.length) {
-    return <p className="text-gray-400">No GPU detected</p>
+    return <p className="text-fg-muted">No GPU detected</p>
   }
 
   return (

--- a/dashboard/frontend/src/components/GpuStats.jsx
+++ b/dashboard/frontend/src/components/GpuStats.jsx
@@ -2,10 +2,10 @@ export default function GpuStats({ gpu }) {
   const memPct = Math.round((gpu.memory.used / gpu.memory.total) * 100)
 
   return (
-    <div className="w-[500px] shrink-0 bg-gray-800 border border-gray-700 rounded-lg p-4">
+    <div className="w-[500px] shrink-0 bg-surface border border-border rounded-lg p-4">
       {/* GPU Name */}
       <div className="flex items-center gap-2 mb-4">
-        <i className="fa-solid fa-microchip text-green-400" />
+        <i className="fa-solid fa-microchip text-success-fg" />
         <span className="font-bold text-base">{gpu.name}</span>
       </div>
 
@@ -13,29 +13,29 @@ export default function GpuStats({ gpu }) {
       <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
         {/* Memory */}
         <div>
-          <p className="text-gray-400 mb-1">Memory</p>
-          <p className="font-mono text-white">{gpu.memory.used}/{gpu.memory.total} MiB</p>
-          <div className="w-full bg-gray-700 rounded h-1.5 mt-1">
-            <div className="bg-blue-500 h-1.5 rounded" style={{ width: `${memPct}%` }} />
+          <p className="text-fg-muted mb-1">Memory</p>
+          <p className="font-mono text-fg">{gpu.memory.used}/{gpu.memory.total} MiB</p>
+          <div className="w-full bg-surface-strong rounded h-1.5 mt-1">
+            <div className="bg-accent h-1.5 rounded" style={{ width: `${memPct}%` }} />
           </div>
         </div>
 
         {/* Temperature */}
         <div>
-          <p className="text-gray-400 mb-1">Temperature</p>
-          <p className="font-mono text-white">{gpu.temperature.current}°C</p>
+          <p className="text-fg-muted mb-1">Temperature</p>
+          <p className="font-mono text-fg">{gpu.temperature.current}°C</p>
         </div>
 
         {/* GPU Utilization */}
         <div>
-          <p className="text-gray-400 mb-1">GPU Utilization</p>
-          <p className="font-mono text-white">{gpu.utilization.gpu_percent}%</p>
+          <p className="text-fg-muted mb-1">GPU Utilization</p>
+          <p className="font-mono text-fg">{gpu.utilization.gpu_percent}%</p>
         </div>
 
         {/* Power */}
         <div>
-          <p className="text-gray-400 mb-1">Power</p>
-          <p className="font-mono text-white">{gpu.power.draw.toFixed(1)}/{gpu.power.limit.current.toFixed(0)} W</p>
+          <p className="text-fg-muted mb-1">Power</p>
+          <p className="font-mono text-fg">{gpu.power.draw.toFixed(1)}/{gpu.power.limit.current.toFixed(0)} W</p>
         </div>
       </div>
     </div>

--- a/dashboard/frontend/src/components/MetricsPanel.jsx
+++ b/dashboard/frontend/src/components/MetricsPanel.jsx
@@ -30,13 +30,13 @@ export default function MetricsPanel({ serviceName, enabled }) {
 
   if (!enabled) {
     return (
-      <div className="bg-gray-800 rounded-lg border border-gray-700 p-5">
+      <div className="bg-surface rounded-lg border border-border p-5">
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-2 h-2 rounded-full bg-gray-600" />
-          <h3 className="text-base font-semibold text-gray-100">Live Metrics</h3>
-          <span className="text-gray-500 text-sm">(disabled)</span>
+          <div className="w-2 h-2 rounded-full bg-surface-muted" />
+          <h3 className="text-base font-semibold text-fg">Live Metrics</h3>
+          <span className="text-fg-subtle text-sm">(disabled)</span>
         </div>
-        <p className="text-gray-400 text-sm">
+        <p className="text-fg-muted text-sm">
           Metrics are only available for running vLLM services. Start the service to see live metrics.
         </p>
       </div>
@@ -46,38 +46,38 @@ export default function MetricsPanel({ serviceName, enabled }) {
   const hasHistory = history.length > 0
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-5">
+    <div className="bg-surface rounded-lg border border-border p-5">
       <div className="flex items-center gap-3 mb-5">
-        <div className={`w-2 h-2 rounded-full ${error ? 'bg-red-500' : 'bg-green-500 animate-pulse'}`} />
-        <h3 className="text-base font-semibold text-gray-100">Live Metrics</h3>
-        <span className="text-gray-500 text-xs">{loading ? 'Initial fetch...' : timeAgo(lastScraped)}</span>
-        {error && <span className="text-red-400 text-xs ml-auto">{error}</span>}
+        <div className={`w-2 h-2 rounded-full ${error ? 'bg-danger' : 'bg-success animate-pulse'}`} />
+        <h3 className="text-base font-semibold text-fg">Live Metrics</h3>
+        <span className="text-fg-subtle text-xs">{loading ? 'Initial fetch...' : timeAgo(lastScraped)}</span>
+        {error && <span className="text-danger-fg text-xs ml-auto">{error}</span>}
       </div>
 
       {showCumulative && (
         <div className="flex items-center gap-6 mb-4 px-1 text-xs font-mono">
           <div className="flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-blue-500" />
-            <span className="text-gray-400">Prompt:</span>
-            <span className="text-gray-200 font-semibold">{fmt(promptTotal)}</span>
+            <span className="w-2 h-2 rounded-full bg-accent" />
+            <span className="text-fg-muted">Prompt:</span>
+            <span className="text-fg font-semibold">{fmt(promptTotal)}</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-green-500" />
-            <span className="text-gray-400">Gen:</span>
-            <span className="text-gray-200 font-semibold">{fmt(genTotal)}</span>
+            <span className="w-2 h-2 rounded-full bg-success" />
+            <span className="text-fg-muted">Gen:</span>
+            <span className="text-fg font-semibold">{fmt(genTotal)}</span>
           </div>
           <div className="flex items-center gap-1.5 ml-auto">
-            <span className="text-gray-500">Total:</span>
-            <span className="text-gray-100 font-semibold">{fmt((promptTotal || 0) + (genTotal || 0))}</span>
+            <span className="text-fg-subtle">Total:</span>
+            <span className="text-fg font-semibold">{fmt((promptTotal || 0) + (genTotal || 0))}</span>
           </div>
         </div>
       )}
 
       {!hasHistory && !loading && !error ? (
         <div className="flex flex-col items-center justify-center py-12">
-          <i className="fa-solid fa-chart-line text-3xl text-gray-600 mb-3" />
-          <p className="text-gray-400 text-sm mb-1">No metrics available</p>
-          <p className="text-gray-500 text-xs">The vLLM prometheus endpoint returned no data or is unreachable.</p>
+          <i className="fa-solid fa-chart-line text-3xl text-fg-faint mb-3" />
+          <p className="text-fg-muted text-sm mb-1">No metrics available</p>
+          <p className="text-fg-subtle text-xs">The vLLM prometheus endpoint returned no data or is unreachable.</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/dashboard/frontend/src/components/MetricsPanel.test.jsx
+++ b/dashboard/frontend/src/components/MetricsPanel.test.jsx
@@ -65,7 +65,7 @@ describe('MetricsPanel', () => {
       lastScraped: new Date().toISOString()
     })
     const { container } = render(<MetricsPanel serviceName="test" enabled={true} />)
-    const dot = container.querySelector('.bg-green-500')
+    const dot = container.querySelector('.bg-success')
     expect(dot).toBeTruthy()
   })
 
@@ -90,7 +90,7 @@ describe('MetricsPanel', () => {
       lastScraped: null
     })
     const { container } = render(<MetricsPanel serviceName="test" enabled={true} />)
-    expect(container.querySelector('.bg-red-500')).toBeTruthy()
+    expect(container.querySelector('.bg-danger')).toBeTruthy()
     expect(screen.getByText('Connection refused')).toBeTruthy()
   })
 })

--- a/dashboard/frontend/src/components/ParameterReference.jsx
+++ b/dashboard/frontend/src/components/ParameterReference.jsx
@@ -5,7 +5,7 @@ function ParamTooltip({ html, tipRef, tipPos }) {
     <div
       ref={tipRef}
       style={tipPos ? { top: tipPos.top, left: tipPos.left } : undefined}
-      className="fixed w-[280px] bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-xs text-slate-300 leading-relaxed shadow-[0_4px_20px_rgba(0,0,0,0.4)] z-[9999] opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none [&_b]:text-white [&_b]:font-semibold [&_code]:text-blue-300 [&_code]:bg-slate-700 [&_code]:px-1 [&_code]:rounded"
+      className="fixed w-[280px] bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-xs text-slate-300 leading-relaxed shadow-[0_4px_20px_rgba(0,0,0,0.4)] z-[9999] opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none [&_b]:text-white [&_b]:font-semibold [&_code]:text-accent-fg-hover [&_code]:bg-slate-700 [&_code]:px-1 [&_code]:rounded"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   )
@@ -36,18 +36,18 @@ function ParamRow({ f, alreadyAdded, onAddFlag }) {
       className={`group rounded mx-1 px-2 py-1.5 transition-colors ${
         alreadyAdded
           ? 'cursor-default'
-          : 'hover:bg-gray-700/50 cursor-pointer'
+          : 'hover:bg-surface-strong cursor-pointer'
       }`}
       title={!f.tip ? (alreadyAdded ? 'Already in parameters' : `Click to add ${cliFlag}`) : undefined}
     >
       <div className={alreadyAdded ? 'opacity-40' : ''}>
         <div className="flex items-center gap-1.5 text-xs">
-          <span className="text-yellow-400 font-mono font-semibold">{cliFlag}</span>
+          <span className="text-warning-fg font-mono font-semibold">{cliFlag}</span>
           {f.default != null && f.default !== '' && (
-            <span className="text-gray-600 ml-auto whitespace-nowrap">{f.default}</span>
+            <span className="text-fg-faint ml-auto whitespace-nowrap">{f.default}</span>
           )}
         </div>
-        <div className="text-gray-400 text-xs leading-snug mt-0.5">
+        <div className="text-fg-muted text-xs leading-snug mt-0.5">
           {f.description}
         </div>
       </div>
@@ -97,24 +97,24 @@ export default function ParameterReference({ flagMetadata, existingFlags, onAddF
   if (!flagMetadata || Object.keys(flagMetadata).length === 0) return null
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 h-full flex flex-col">
-      <div className="px-3 py-2 border-b border-gray-700 flex items-center gap-2 flex-shrink-0">
-        <i className="fa-solid fa-book text-gray-500 text-xs"></i>
-        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Parameter Reference</span>
+    <div className="bg-surface rounded-lg border border-border h-full flex flex-col">
+      <div className="px-3 py-2 border-b border-border flex items-center gap-2 flex-shrink-0">
+        <i className="fa-solid fa-book text-fg-subtle text-xs"></i>
+        <span className="text-xs font-semibold text-fg-muted uppercase tracking-wider">Parameter Reference</span>
       </div>
-      <div className="px-3 py-2 border-b border-gray-700 flex-shrink-0">
+      <div className="px-3 py-2 border-b border-border flex-shrink-0">
         <div className="relative">
           <input
             type="text"
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Search flags..."
-            className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 pr-7 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            className="w-full bg-surface-strong border border-border-strong rounded px-2 py-1.5 pr-7 text-sm text-fg placeholder-fg-subtle focus:outline-none focus:border-accent"
           />
           {search && (
             <button
               onClick={() => setSearch('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 cursor-pointer"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-fg-muted hover:text-fg cursor-pointer"
               aria-label="Clear search"
             >
               <i className="fa-solid fa-xmark text-xs"></i>
@@ -124,11 +124,11 @@ export default function ParameterReference({ flagMetadata, existingFlags, onAddF
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
         {filtered.length === 0 ? (
-          <p className="text-gray-500 text-xs italic px-3 py-3">No matching flags.</p>
+          <p className="text-fg-subtle text-xs italic px-3 py-3">No matching flags.</p>
         ) : (
           filtered.map(({ category, flags }) => (
             <div key={category}>
-              <div className="text-gray-500 uppercase tracking-wider text-[10px] font-semibold mt-2 mb-1 px-3">
+              <div className="text-fg-subtle uppercase tracking-wider text-[10px] font-semibold mt-2 mb-1 px-3">
                 {category}
               </div>
               {flags.map(f => (

--- a/dashboard/frontend/src/components/RequestStrip.jsx
+++ b/dashboard/frontend/src/components/RequestStrip.jsx
@@ -2,23 +2,23 @@ export default function RequestStrip({ running, waiting, preemptRate }) {
   const fmt = (val) => val !== undefined && val != null ? val : '—'
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-      <h3 className="text-sm font-medium text-gray-400 mb-3">Requests</h3>
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <h3 className="text-sm font-medium text-fg-muted mb-3">Requests</h3>
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
-        <span className="flex items-center gap-1.5 text-gray-300">
-          <i className="fa-solid fa-bolt text-yellow-400 text-xs" />
+        <span className="flex items-center gap-1.5 text-fg-muted">
+          <i className="fa-solid fa-bolt text-warning-fg text-xs" />
           Running: <span className="font-mono font-semibold">{fmt(running)}</span>
         </span>
-        <span className="text-gray-600">|</span>
-        <span className="flex items-center gap-1.5 text-gray-300">
-          <i className="fa-solid fa-clock text-blue-400 text-xs" />
+        <span className="text-fg-faint">|</span>
+        <span className="flex items-center gap-1.5 text-fg-muted">
+          <i className="fa-solid fa-clock text-accent-fg text-xs" />
           Waiting: <span className="font-mono font-semibold">{fmt(waiting)}</span>
         </span>
-        <span className="text-gray-600">|</span>
-        <span className="flex items-center gap-1.5 text-gray-300">
-          <i className="fa-solid fa-arrows-rotate text-red-400 text-xs" />
+        <span className="text-fg-faint">|</span>
+        <span className="flex items-center gap-1.5 text-fg-muted">
+          <i className="fa-solid fa-arrows-rotate text-danger-fg text-xs" />
           Preempt: <span className="font-mono font-semibold">{typeof preemptRate === 'number' ? preemptRate.toFixed(1) : fmt(preemptRate)}</span>
-          {typeof preemptRate === 'number' && <span className="text-gray-500 text-xs">/s</span>}
+          {typeof preemptRate === 'number' && <span className="text-fg-subtle text-xs">/s</span>}
         </span>
       </div>
     </div>

--- a/dashboard/frontend/src/components/ServiceConfigPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceConfigPanel.jsx
@@ -174,12 +174,12 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
   if (!initialized.current && !config) return null
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700">
+    <div className="bg-surface rounded-lg border border-border">
       {/* Header */}
-      <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
-        <h2 className="text-lg font-semibold text-gray-200">Configuration</h2>
+      <div className="px-5 py-4 border-b border-border flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-fg">Configuration</h2>
         {isDirty && (
-          <span className="text-yellow-400 text-sm flex items-center gap-1" role="status" aria-live="polite">
+          <span className="text-warning-fg text-sm flex items-center gap-1" role="status" aria-live="polite">
             <i className="fa-solid fa-circle-exclamation"></i>
             Unsaved changes
           </span>
@@ -190,18 +190,18 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
         {/* Editable fields */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium mb-2 text-gray-300" htmlFor="config-port">Port</label>
+            <label className="block text-sm font-medium mb-2 text-fg-muted" htmlFor="config-port">Port</label>
             <input
               id="config-port"
               type="number"
               value={port}
               onChange={e => setPort(e.target.value)}
               disabled={saving}
-              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              className="w-full bg-surface-strong border border-border-strong rounded px-3 py-2 text-fg focus:outline-none focus:border-accent disabled:opacity-50"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-2 text-gray-300" htmlFor="config-apikey">API Key</label>
+            <label className="block text-sm font-medium mb-2 text-fg-muted" htmlFor="config-apikey">API Key</label>
             <div className="flex gap-2">
               <input
                 id="config-apikey"
@@ -209,12 +209,12 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
                 value={apiKey}
                 onChange={e => setApiKey(e.target.value)}
                 disabled={saving}
-                className="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white font-mono text-sm focus:outline-none focus:border-blue-500 disabled:opacity-50"
+                className="flex-1 bg-surface-strong border border-border-strong rounded px-3 py-2 text-fg font-mono text-sm focus:outline-none focus:border-accent disabled:opacity-50"
               />
               <button
                 onClick={handleUseGlobalKey}
                 disabled={saving || settingGlobalKey}
-                className="px-3 py-2 bg-gray-700 hover:bg-gray-600 border border-gray-600 rounded text-xs text-gray-300 hover:text-white whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                className="px-3 py-2 bg-surface-strong hover:bg-surface-muted border border-border-strong rounded text-xs text-fg-muted hover:text-fg whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                 title="Set API key to the global API key from .env"
               >
                 {settingGlobalKey ? (
@@ -230,13 +230,13 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
         {/* Parameters section */}
         <div>
           <div className="flex items-center justify-between mb-3">
-            <label className="block text-sm font-medium text-gray-300">
+            <label className="block text-sm font-medium text-fg-muted">
               Parameters ({params.filter(p => p.flag || p.value).length})
             </label>
             <button
               onClick={handleParamAdd}
               disabled={saving}
-              className="text-sm text-blue-400 hover:text-blue-300 disabled:opacity-50 cursor-pointer"
+              className="text-sm text-accent-fg hover:text-accent-fg-hover disabled:opacity-50 cursor-pointer"
             >
               <i className="fa-solid fa-plus mr-1"></i>Add parameter
             </button>
@@ -254,7 +254,7 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
                     onChange={e => handleParamFlagChange(id, e.target.value)}
                     disabled={saving}
                     placeholder="-flag"
-                    className={`bg-gray-700 border rounded px-2 py-1 font-mono text-sm w-40 text-white focus:outline-none disabled:opacity-50 ${isDuplicate ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-blue-500'}`}
+                    className={`bg-surface-strong border rounded px-2 py-1 font-mono text-sm w-40 text-fg focus:outline-none disabled:opacity-50 ${isDuplicate ? 'border-danger focus:border-danger' : 'border-border-strong focus:border-accent'}`}
                     title={isDuplicate ? 'Duplicate flag' : tooltip || undefined}
                   />
                   <input
@@ -262,12 +262,12 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
                     onChange={e => handleParamValueChange(id, e.target.value)}
                     disabled={saving}
                     placeholder="value"
-                    className="flex-1 bg-gray-700 border border-gray-600 rounded px-2 py-1 font-mono text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50"
+                    className="flex-1 bg-surface-strong border border-border-strong rounded px-2 py-1 font-mono text-sm text-fg focus:outline-none focus:border-accent disabled:opacity-50"
                   />
                   <button
                     onClick={() => handleParamRemove(id)}
                     disabled={saving || isTrailingEmpty}
-                    className={`disabled:opacity-50 cursor-pointer ${isTrailingEmpty ? 'invisible' : 'text-gray-500 hover:text-red-400'}`}
+                    className={`disabled:opacity-50 cursor-pointer ${isTrailingEmpty ? 'invisible' : 'text-fg-subtle hover:text-danger-fg'}`}
                     aria-label={`Remove parameter ${flag || '(empty)'}`}
                   >
                     <i className="fa-solid fa-xmark"></i>
@@ -276,7 +276,7 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
               )
             })}
             {hasDuplicates && (
-              <p className="text-red-400 text-xs mt-1 px-3">
+              <p className="text-danger-fg text-xs mt-1 px-3">
                 Duplicate flags: {[...duplicateFlags].join(', ')}
               </p>
             )}
@@ -287,31 +287,31 @@ export default function ServiceConfigPanel({ config, serviceName, runtime, onSav
         <div>
           <button
             onClick={() => setCommandPreviewOpen(prev => !prev)}
-            className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-200 cursor-pointer"
+            className="flex items-center gap-2 text-sm text-fg-muted hover:text-fg cursor-pointer"
           >
             <i className={`fa-solid ${commandPreviewOpen ? 'fa-chevron-up' : 'fa-chevron-down'}`}></i>
             Command Preview
           </button>
           {commandPreviewOpen && (
-            <div className="mt-2 bg-gray-900 rounded p-4 font-mono text-xs text-gray-300 whitespace-pre-wrap">
+            <div className="mt-2 bg-app rounded p-4 font-mono text-xs text-fg-muted whitespace-pre-wrap">
               {renderCommandPreview(config, apiKey, params)}
             </div>
           )}
         </div>
 
         {/* Save/Discard buttons */}
-        <div className="flex gap-3 pt-4 border-t border-gray-700">
+        <div className="flex gap-3 pt-4 border-t border-border">
           <button
             onClick={handleDiscard}
             disabled={!isDirty || saving}
-            className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            className="px-4 py-2 bg-surface-muted hover:bg-surface-strong text-fg rounded font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
           >
             Discard
           </button>
           <button
             onClick={handleSave}
             disabled={!isDirty || saving || hasDuplicates}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-accent-strong hover:bg-accent-strong text-white rounded font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
           >
             {saving ? (
               <>

--- a/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
+++ b/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
@@ -13,11 +13,11 @@ function CopyButton({ text, label }) {
   return (
     <button
       onClick={handleCopy}
-      className="text-gray-400 hover:text-gray-200 cursor-pointer"
+      className="text-fg-muted hover:text-fg cursor-pointer"
       aria-label={label}
       title={label}
     >
-      <i className={`fa-solid ${copied ? 'fa-check text-green-400' : 'fa-copy'} text-sm`}></i>
+      <i className={`fa-solid ${copied ? 'fa-check text-success-fg' : 'fa-copy'} text-sm`}></i>
     </button>
   )
 }
@@ -26,24 +26,24 @@ function StatusBadge({ status, transitioning }) {
   let bgClass, textClass, borderClass, label
 
   if (transitioning) {
-    bgClass = 'bg-yellow-500/20'
-    textClass = 'text-yellow-400'
-    borderClass = 'border-yellow-500/30'
+    bgClass = 'bg-warning-subtle'
+    textClass = 'text-warning-fg'
+    borderClass = 'border-warning'
     label = transitioning === 'starting' ? 'Starting...' : transitioning === 'stopping' ? 'Stopping...' : 'Restarting...'
   } else if (status === 'running') {
-    bgClass = 'bg-green-500/20'
-    textClass = 'text-green-400'
-    borderClass = 'border-green-500/30'
+    bgClass = 'bg-success-subtle'
+    textClass = 'text-success-fg'
+    borderClass = 'border-success'
     label = 'Running'
   } else if (status === 'exited') {
-    bgClass = 'bg-red-500/20'
-    textClass = 'text-red-400'
-    borderClass = 'border-red-500/30'
+    bgClass = 'bg-danger-subtle'
+    textClass = 'text-danger-fg'
+    borderClass = 'border-danger'
     label = 'Stopped'
   } else {
-    bgClass = 'bg-gray-500/20'
-    textClass = 'text-gray-400'
-    borderClass = 'border-gray-500/30'
+    bgClass = 'bg-surface-muted'
+    textClass = 'text-fg-muted'
+    borderClass = 'border-border-strong'
     label = 'Not Created'
   }
 
@@ -55,7 +55,7 @@ function StatusBadge({ status, transitioning }) {
       aria-label={`Service status: ${label}`}
     >
       <span className={`w-2 h-2 rounded-full ${transitioning ? 'animate-pulse' : ''} ${
-        transitioning ? 'bg-yellow-400' : status === 'running' ? 'bg-green-400' : status === 'exited' ? 'bg-red-400' : 'bg-gray-400'
+        transitioning ? 'bg-warning' : status === 'running' ? 'bg-success' : status === 'exited' ? 'bg-danger' : 'bg-fg-muted'
       }`} />
       {label}
     </span>
@@ -64,10 +64,10 @@ function StatusBadge({ status, transitioning }) {
 
 function EngineBadge({ templateType }) {
   const engineMap = {
-    llamacpp: { label: 'llama.cpp', classes: 'bg-blue-600/30 text-blue-300' },
-    vllm: { label: 'vLLM', classes: 'bg-purple-600/30 text-purple-300' },
+    llamacpp: { label: 'llama.cpp', classes: 'bg-badge-llamacpp-bg text-badge-llamacpp-fg' },
+    vllm: { label: 'vLLM', classes: 'bg-badge-vllm-bg text-badge-vllm-fg' },
   }
-  const engine = engineMap[templateType] || { label: templateType, classes: 'bg-gray-600/30 text-gray-400' }
+  const engine = engineMap[templateType] || { label: templateType, classes: 'bg-badge-neutral-bg text-badge-neutral-fg' }
 
   return (
     <span className={`px-2 py-0.5 rounded text-xs font-medium ${engine.classes}`}>
@@ -102,13 +102,13 @@ function InlineRename({ serviceName, onRename, onCancel }) {
         value={newName}
         onChange={e => setNewName(e.target.value)}
         disabled={renaming}
-        className="bg-gray-700 border border-gray-600 rounded px-2 py-1 text-xl font-bold text-white focus:outline-none focus:border-blue-500 disabled:opacity-50"
+        className="bg-surface-strong border border-border-strong rounded px-2 py-1 text-xl font-bold text-fg focus:outline-none focus:border-accent disabled:opacity-50"
         onKeyDown={e => e.key === 'Escape' && onCancel()}
       />
       <button
         type="submit"
         disabled={renaming}
-        className="text-green-400 hover:text-green-300 disabled:opacity-50 cursor-pointer"
+        className="text-success-fg hover:text-success-fg disabled:opacity-50 cursor-pointer"
         title="Confirm rename"
       >
         <i className={`fa-solid ${renaming ? 'fa-spinner fa-spin' : 'fa-check'}`}></i>
@@ -117,7 +117,7 @@ function InlineRename({ serviceName, onRename, onCancel }) {
         type="button"
         onClick={onCancel}
         disabled={renaming}
-        className="text-gray-400 hover:text-gray-200 disabled:opacity-50 cursor-pointer"
+        className="text-fg-muted hover:text-fg disabled:opacity-50 cursor-pointer"
         title="Cancel rename"
       >
         <i className="fa-solid fa-xmark"></i>
@@ -135,18 +135,18 @@ function YamlPreviewModal({ yaml, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onClose}>
-      <div className="bg-gray-800 rounded-lg border border-gray-700 max-w-3xl w-full max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
-        <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
-          <h3 className="text-lg font-semibold text-gray-200">Docker Compose YAML</h3>
+      <div className="bg-surface rounded-lg border border-border max-w-3xl w-full max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-4 border-b border-border flex justify-between items-center">
+          <h3 className="text-lg font-semibold text-fg">Docker Compose YAML</h3>
           <div className="flex items-center gap-3">
             <CopyButton text={yaml} label="Copy YAML" />
-            <button onClick={onClose} className="text-gray-400 hover:text-gray-200 cursor-pointer" aria-label="Close">
+            <button onClick={onClose} className="text-fg-muted hover:text-fg cursor-pointer" aria-label="Close">
               <i className="fa-solid fa-xmark"></i>
             </button>
           </div>
         </div>
         <div className="flex-1 overflow-auto p-5">
-          <pre className="font-mono text-sm text-gray-300 whitespace-pre-wrap">{yaml}</pre>
+          <pre className="font-mono text-sm text-fg-muted whitespace-pre-wrap">{yaml}</pre>
         </div>
       </div>
     </div>
@@ -164,10 +164,10 @@ function MetadataRow({ config, runtime }) {
   const isRegistered = runtime?.openwebui_registered
 
   return (
-    <div className="flex items-center gap-4 flex-wrap pt-3 mt-3 border-t border-gray-700">
+    <div className="flex items-center gap-4 flex-wrap pt-3 mt-3 border-t border-border">
       {/* Port */}
       <div className="flex items-center gap-1.5">
-        <span className="text-xs text-gray-400">Port:</span>
+        <span className="text-xs text-fg-muted">Port:</span>
         {port ? (
           <>
             {isRunning ? (
@@ -175,31 +175,31 @@ function MetadataRow({ config, runtime }) {
                 href={`http://${window.location.hostname}:${port}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs font-mono text-blue-400 hover:text-blue-300"
+                className="text-xs font-mono text-accent-fg hover:text-accent-fg-hover"
               >
                 {port}
               </a>
             ) : (
-              <span className="text-xs font-mono text-white">{port}</span>
+              <span className="text-xs font-mono text-fg">{port}</span>
             )}
             {isPublicPort && (
-              <span className="text-green-400" title="Public port (3301)">
+              <span className="text-success-fg" title="Public port (3301)">
                 <i className="fa-solid fa-globe text-xs"></i>
               </span>
             )}
           </>
         ) : (
-          <span className="text-xs text-gray-500">N/A</span>
+          <span className="text-xs text-fg-subtle">N/A</span>
         )}
       </div>
 
       {/* API Key */}
       {apiKey && (
         <>
-          <div className="w-px h-4 bg-gray-700" />
+          <div className="w-px h-4 bg-surface-strong" />
           <div className="flex items-center gap-1.5">
-            <span className="text-xs text-gray-400">API Key:</span>
-            <span className="text-xs font-mono text-white">{apiKey.slice(0, 16)}...</span>
+            <span className="text-xs text-fg-muted">API Key:</span>
+            <span className="text-xs font-mono text-fg">{apiKey.slice(0, 16)}...</span>
             <CopyButton text={apiKey} label="Copy API key" />
           </div>
         </>
@@ -208,10 +208,10 @@ function MetadataRow({ config, runtime }) {
       {/* Container ID */}
       {containerId && (
         <>
-          <div className="w-px h-4 bg-gray-700" />
+          <div className="w-px h-4 bg-surface-strong" />
           <div className="flex items-center gap-1.5">
-            <span className="text-xs text-gray-400">Container:</span>
-            <span className="text-xs font-mono text-white">{containerId.slice(0, 7)}</span>
+            <span className="text-xs text-fg-muted">Container:</span>
+            <span className="text-xs font-mono text-fg">{containerId.slice(0, 7)}</span>
             <CopyButton text={containerId} label="Copy container ID" />
           </div>
         </>
@@ -219,13 +219,13 @@ function MetadataRow({ config, runtime }) {
 
       {/* Open WebUI status */}
       <>
-        <div className="w-px h-4 bg-gray-700" />
+        <div className="w-px h-4 bg-surface-strong" />
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-gray-400">WebUI:</span>
+          <span className="text-xs text-fg-muted">WebUI:</span>
           {isRegistered ? (
-            <span className="text-xs text-green-400">Registered</span>
+            <span className="text-xs text-success-fg">Registered</span>
           ) : (
-            <span className="text-xs text-gray-500">Not registered</span>
+            <span className="text-xs text-fg-subtle">Not registered</span>
           )}
         </div>
       </>
@@ -233,10 +233,10 @@ function MetadataRow({ config, runtime }) {
       {/* Exit code */}
       {status === 'exited' && runtime?.exit_code != null && (
         <>
-          <div className="w-px h-4 bg-gray-700" />
+          <div className="w-px h-4 bg-surface-strong" />
           <div className="flex items-center gap-1.5">
-            <span className="text-xs text-gray-400">Exit code:</span>
-            <span className="text-xs text-white">{runtime.exit_code}</span>
+            <span className="text-xs text-fg-muted">Exit code:</span>
+            <span className="text-xs text-fg">{runtime.exit_code}</span>
           </div>
         </>
       )}
@@ -311,14 +311,14 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
 
   return (
     <>
-      <div className="flex items-center gap-2 flex-wrap mt-3 pt-3 border-t border-gray-700">
+      <div className="flex items-center gap-2 flex-wrap mt-3 pt-3 border-t border-border">
         {/* Group 1: Lifecycle */}
         {isRunning ? (
           <>
             <button
               onClick={() => handleLifecycleAction(actions.stop)}
               disabled={disabled}
-              className={`${toolbarBtnBase} bg-red-600 hover:bg-red-700 text-white`}
+              className={`${toolbarBtnBase} bg-danger hover:bg-danger text-white`}
             >
               {transitioning === 'stopping' ? (
                 <i className="fa-solid fa-spinner fa-spin"></i>
@@ -330,7 +330,7 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
             <button
               onClick={() => handleLifecycleAction(actions.restart)}
               disabled={disabled}
-              className={`${toolbarBtnBase} bg-yellow-600 hover:bg-yellow-700 text-white`}
+              className={`${toolbarBtnBase} bg-warning hover:bg-warning text-white`}
             >
               {transitioning === 'restarting' ? (
                 <i className="fa-solid fa-spinner fa-spin"></i>
@@ -344,7 +344,7 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
           <button
             onClick={() => handleLifecycleAction(actions.start)}
             disabled={disabled}
-            className={`${toolbarBtnBase} bg-green-600 hover:bg-green-700 text-white`}
+            className={`${toolbarBtnBase} bg-success hover:bg-success text-white`}
           >
             {transitioning === 'starting' ? (
               <i className="fa-solid fa-spinner fa-spin"></i>
@@ -356,14 +356,14 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
         )}
 
         {/* Divider between groups */}
-        <div className="w-px h-5 bg-gray-600 mx-1" />
+        <div className="w-px h-5 bg-surface-muted mx-1" />
 
         {/* Group 2: Actions */}
         {!isPublicPort ? (
           <button
             onClick={handleSetPublicPort}
             disabled={settingPublicPort}
-            className={`${toolbarBtnBase} bg-gray-600 hover:bg-gray-700 text-white`}
+            className={`${toolbarBtnBase} bg-surface-muted hover:bg-surface-strong text-fg`}
           >
             {settingPublicPort ? (
               <i className="fa-solid fa-spinner fa-spin"></i>
@@ -373,7 +373,7 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
             {settingPublicPort ? 'Setting...' : 'Set as Public'}
           </button>
         ) : (
-          <span className="px-3 py-1.5 rounded text-xs font-medium inline-flex items-center gap-1.5 bg-green-600/20 text-green-400 border border-green-600/30">
+          <span className="px-3 py-1.5 rounded text-xs font-medium inline-flex items-center gap-1.5 bg-success-subtle text-success-fg border border-success">
             <i className="fa-solid fa-globe"></i>
             Public (3301)
           </span>
@@ -381,7 +381,7 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
 
         <button
           onClick={handleViewYaml}
-          className={`${toolbarBtnBase} bg-gray-600 hover:bg-gray-700 text-white`}
+          className={`${toolbarBtnBase} bg-surface-muted hover:bg-surface-strong text-fg`}
         >
           <i className="fa-solid fa-code"></i>
           View YAML
@@ -390,7 +390,7 @@ function ToolbarRow({ config, runtime, transitioning, actions, onSuccess, onErro
         <button
           onClick={handleToggleWebUI}
           disabled={togglingWebUI}
-          className={`${toolbarBtnBase} bg-gray-600 hover:bg-gray-700 text-white`}
+          className={`${toolbarBtnBase} bg-surface-muted hover:bg-surface-strong text-fg`}
         >
           {togglingWebUI ? (
             <i className="fa-solid fa-spinner fa-spin"></i>
@@ -428,19 +428,19 @@ export default function ServiceDetailsHeader({ serviceName, config, runtime, tra
   }, [onRename, navigate, onError])
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 px-6 py-4 -mx-6 -mt-6 mb-6">
+    <div className="bg-surface border-b border-border px-6 py-4 -mx-6 -mt-6 mb-6">
       {/* Row 1: Identity */}
       <div className="flex items-center gap-4 flex-wrap">
         <button
           onClick={() => navigate('/')}
-          className="flex items-center gap-2 text-gray-400 hover:text-gray-200 cursor-pointer"
+          className="flex items-center gap-2 text-fg-muted hover:text-fg cursor-pointer"
           aria-label="Back to services list"
         >
           <i className="fa-solid fa-arrow-left"></i>
           <span className="text-sm">Back to Services</span>
         </button>
 
-        <div className="w-px h-6 bg-gray-700" />
+        <div className="w-px h-6 bg-surface-strong" />
 
         {editing ? (
           <InlineRename
@@ -450,12 +450,12 @@ export default function ServiceDetailsHeader({ serviceName, config, runtime, tra
           />
         ) : (
           <>
-            <h1 className="text-2xl font-bold text-white">{serviceName}</h1>
+            <h1 className="text-2xl font-bold text-fg">{serviceName}</h1>
             <CopyButton text={serviceName} label="Copy service name" />
             <button
               onClick={() => setEditing(true)}
               disabled={!canRename}
-              className="text-gray-400 hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+              className="text-fg-muted hover:text-fg disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
               title={canRename ? 'Rename service' : 'Stop service to rename'}
             >
               <i className="fa-solid fa-pen text-sm"></i>
@@ -468,11 +468,11 @@ export default function ServiceDetailsHeader({ serviceName, config, runtime, tra
         {templateType && <EngineBadge templateType={templateType} />}
 
         {config?.model_size_str && (
-          <span className="text-xs text-gray-400">{config.model_size_str}</span>
+          <span className="text-xs text-fg-muted">{config.model_size_str}</span>
         )}
 
         {(config?.model_path || config?.model_name) && (
-          <span className="text-xs text-gray-500 font-mono break-all">
+          <span className="text-xs text-fg-subtle font-mono break-all">
             {config.model_path || config.model_name}
           </span>
         )}

--- a/dashboard/frontend/src/components/ServiceDetailsPage.jsx
+++ b/dashboard/frontend/src/components/ServiceDetailsPage.jsx
@@ -14,7 +14,7 @@ function Toast({ message, type, onDone }) {
     return () => clearTimeout(t)
   }, [onDone])
 
-  const bgColor = type === 'success' ? 'bg-green-600' : 'bg-red-600'
+  const bgColor = type === 'success' ? 'bg-success' : 'bg-danger'
 
   return (
     <div className={`fixed bottom-6 right-6 ${bgColor} text-white px-4 py-2 rounded shadow-lg text-sm z-50`} role="alert">
@@ -31,10 +31,10 @@ function TabBar({ serviceName, isLogsRoute, isMetricsRoute }) {
     return false
   }
 
-  const tabClass = (route) => `pb-3 text-sm font-medium cursor-pointer ${isActive(route) ? 'border-b-2 border-blue-500 text-white' : 'text-gray-400 hover:text-gray-200'}`
+  const tabClass = (route) => `pb-3 text-sm font-medium cursor-pointer ${isActive(route) ? 'border-b-2 border-accent text-fg' : 'text-fg-muted hover:text-fg'}`
 
   return (
-    <div className="flex gap-6 border-b border-gray-700 mb-6">
+    <div className="flex gap-6 border-b border-border mb-6">
       <Link to={`/services/${serviceName}`} className={tabClass('config')}>Configuration</Link>
       <Link to={`/services/${serviceName}/logs`} className={tabClass('logs')}>Logs</Link>
       <Link to={`/services/${serviceName}/metrics`} className={tabClass('metrics')}>Metrics</Link>
@@ -47,38 +47,38 @@ const SKELETON_WIDTHS = [68, 85, 73, 91, 78, 64, 82, 96]
 function LoadingSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="bg-gray-800 border-b border-gray-700 px-6 py-4 -mx-6 -mt-6 mb-6">
+      <div className="bg-surface border-b border-border px-6 py-4 -mx-6 -mt-6 mb-6">
         <div className="flex items-center gap-4">
-          <div className="h-5 w-32 bg-gray-700/50 rounded" />
-          <div className="w-px h-6 bg-gray-700" />
-          <div className="h-7 w-48 bg-gray-700/50 rounded" />
-          <div className="h-6 w-20 bg-gray-700/50 rounded-full" />
-          <div className="h-5 w-16 bg-gray-700/50 rounded" />
+          <div className="h-5 w-32 bg-surface-strong rounded" />
+          <div className="w-px h-6 bg-surface-strong" />
+          <div className="h-7 w-48 bg-surface-strong rounded" />
+          <div className="h-6 w-20 bg-surface-strong rounded-full" />
+          <div className="h-5 w-16 bg-surface-strong rounded" />
         </div>
       </div>
       {/* Tab bar skeleton */}
-      <div className="flex gap-6 border-b border-gray-700 mb-6">
-        <div className="h-4 w-24 bg-gray-700/50 rounded mb-3" />
-        <div className="h-4 w-12 bg-gray-700/50 rounded mb-3" />
+      <div className="flex gap-6 border-b border-border mb-6">
+        <div className="h-4 w-24 bg-surface-strong rounded mb-3" />
+        <div className="h-4 w-12 bg-surface-strong rounded mb-3" />
       </div>
       {/* Config + Reference skeleton */}
       <div className="grid grid-cols-1 xl:grid-cols-[60%_1fr] gap-6">
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-5">
-          <div className="h-4 w-24 bg-gray-700/50 rounded mb-4" />
+        <div className="bg-surface rounded-lg border border-border p-5">
+          <div className="h-4 w-24 bg-surface-strong rounded mb-4" />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {[...Array(4)].map((_, i) => (
               <div key={i}>
-                <div className="h-3 w-16 bg-gray-700/50 rounded mb-2" />
-                <div className="h-5 w-32 bg-gray-700/50 rounded" />
+                <div className="h-3 w-16 bg-surface-strong rounded mb-2" />
+                <div className="h-5 w-32 bg-surface-strong rounded" />
               </div>
             ))}
           </div>
         </div>
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-5">
-          <div className="h-4 w-32 bg-gray-700/50 rounded mb-4" />
+        <div className="bg-surface rounded-lg border border-border p-5">
+          <div className="h-4 w-32 bg-surface-strong rounded mb-4" />
           <div className="space-y-2">
             {[...Array(8)].map((_, i) => (
-              <div key={i} className="h-4 bg-gray-700/50 rounded" style={{ width: `${SKELETON_WIDTHS[i]}%` }} />
+              <div key={i} className="h-4 bg-surface-strong rounded" style={{ width: `${SKELETON_WIDTHS[i]}%` }} />
             ))}
           </div>
         </div>
@@ -91,14 +91,14 @@ function NotFoundError({ serviceName }) {
   const navigate = useNavigate()
   return (
     <div className="flex flex-col items-center justify-center py-20">
-      <i className="fa-solid fa-circle-exclamation text-4xl text-gray-500 mb-4"></i>
-      <h2 className="text-xl font-semibold text-white mb-2">Service not found</h2>
-      <p className="text-gray-400 mb-6">
+      <i className="fa-solid fa-circle-exclamation text-4xl text-fg-subtle mb-4"></i>
+      <h2 className="text-xl font-semibold text-fg mb-2">Service not found</h2>
+      <p className="text-fg-muted mb-6">
         The service "{serviceName}" does not exist or has been deleted.
       </p>
       <button
         onClick={() => navigate('/')}
-        className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-medium cursor-pointer"
+        className="px-4 py-2 bg-accent-strong hover:bg-accent-strong text-white rounded font-medium cursor-pointer"
       >
         Back to Services
       </button>
@@ -157,7 +157,7 @@ export default function ServiceDetailsPage() {
   if (error === 'not-found') return <NotFoundError serviceName={serviceName} />
   if (error) {
     return (
-      <div className="text-red-400 py-10 text-center">
+      <div className="text-danger-fg py-10 text-center">
         <i className="fa-solid fa-triangle-exclamation mr-2"></i>
         Failed to load service: {error}
       </div>

--- a/dashboard/frontend/src/components/ServiceLogsPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceLogsPanel.jsx
@@ -89,29 +89,29 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
   }
 
   return (
-    <div className="h-full bg-gray-800 rounded-lg border border-gray-700 flex flex-col">
+    <div className="h-full bg-surface rounded-lg border border-border flex flex-col">
       {/* Header */}
-      <div className="px-5 py-3 border-b border-gray-700 flex justify-between items-center">
+      <div className="px-5 py-3 border-b border-border flex justify-between items-center">
         <div className="flex items-center gap-3">
-          <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
+          <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wider">
             Container Logs
           </h2>
           {hasContainer && !paused && connected && (
-            <span className="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse" />
+            <span className="w-2.5 h-2.5 rounded-full bg-success animate-pulse" />
           )}
           {hasContainer && !paused && !connected && !streamEnded && (
-            <span className="w-2.5 h-2.5 rounded-full bg-yellow-500 animate-pulse" />
+            <span className="w-2.5 h-2.5 rounded-full bg-warning animate-pulse" />
           )}
           {streamEnded && (
-            <span className="text-xs text-gray-500 italic">stopped</span>
+            <span className="text-xs text-fg-subtle italic">stopped</span>
           )}
         </div>
         <div className="flex items-center gap-2">
-          <div className="flex items-center text-gray-400" title="Log font size">
+          <div className="flex items-center text-fg-muted" title="Log font size">
             <button
               onClick={() => bumpFontSize(-FONT_SIZE_STEP)}
               disabled={fontSize <= FONT_SIZE_MIN}
-              className="p-1.5 hover:text-gray-200 disabled:opacity-40 cursor-pointer"
+              className="p-1.5 hover:text-fg disabled:opacity-40 cursor-pointer"
               title="Smaller text"
               aria-label="Decrease log font size"
             >
@@ -121,7 +121,7 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
             <button
               onClick={() => bumpFontSize(FONT_SIZE_STEP)}
               disabled={fontSize >= FONT_SIZE_MAX}
-              className="p-1.5 hover:text-gray-200 disabled:opacity-40 cursor-pointer"
+              className="p-1.5 hover:text-fg disabled:opacity-40 cursor-pointer"
               title="Larger text"
               aria-label="Increase log font size"
             >
@@ -131,7 +131,7 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           <button
             onClick={handleRefresh}
             disabled={!hasContainer || paused}
-            className="p-1.5 text-gray-400 hover:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            className="p-1.5 text-fg-muted hover:text-fg disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             title={paused ? 'Resume to refresh' : 'Refresh logs'}
           >
             <i className="fa-solid fa-rotate-right text-sm"></i>
@@ -139,7 +139,7 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
           <button
             onClick={() => setPaused(prev => !prev)}
             disabled={!hasContainer}
-            className="p-1.5 text-gray-400 hover:text-gray-200 disabled:opacity-50 cursor-pointer"
+            className="p-1.5 text-fg-muted hover:text-fg disabled:opacity-50 cursor-pointer"
             title={paused ? 'Resume' : 'Pause'}
           >
             <i className={`fa-solid ${paused ? 'fa-play' : 'fa-pause'} text-sm`}></i>
@@ -150,13 +150,13 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
       {/* Log content */}
       {!hasContainer ? (
         <div className="flex-1 flex items-center justify-center">
-          <p className="text-gray-500 italic text-sm">
+          <p className="text-fg-subtle italic text-sm">
             Service has not been started. Start the service to see logs.
           </p>
         </div>
       ) : error ? (
         <div className="flex-1 flex items-center justify-center">
-          <p className="text-red-400 text-sm">Failed to load logs: {error}</p>
+          <p className="text-danger-fg text-sm">Failed to load logs: {error}</p>
         </div>
       ) : (
         <div
@@ -166,21 +166,21 @@ export default function ServiceLogsPanel({ serviceName, runtime }) {
         >
           {lines.length > 0 ? (
             <pre
-              className="font-mono text-gray-300 whitespace-pre-wrap leading-relaxed select-text"
+              className="font-mono text-fg-muted whitespace-pre-wrap leading-relaxed select-text"
               style={{ fontSize: `${fontSize}px` }}
             >
               {lines.join('\n')}
             </pre>
           ) : loading ? (
-            <p className="text-gray-500 italic text-sm">Loading logs…</p>
+            <p className="text-fg-subtle italic text-sm">Loading logs…</p>
           ) : (
-            <p className="text-gray-500 italic text-sm">No log output yet.</p>
+            <p className="text-fg-subtle italic text-sm">No log output yet.</p>
           )}
         </div>
       )}
 
       {/* Footer */}
-      <div className="px-5 py-2 border-t border-gray-700 text-xs text-gray-500 flex justify-between">
+      <div className="px-5 py-2 border-t border-border text-xs text-fg-subtle flex justify-between">
         <span>Last updated: {formatTime(lastUpdated)} | {lines.length} lines</span>
         <span>{footerStatus()}</span>
       </div>

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -18,29 +18,29 @@ function isInfra(name) {
 
 function StatusDot({ status }) {
   const color = status === 'running'
-    ? 'bg-green-400'
+    ? 'bg-success'
     : status === 'exited'
-      ? 'bg-red-400'
-      : 'bg-gray-500'
+      ? 'bg-danger'
+      : 'bg-fg-subtle'
   return <span className={`inline-block w-2.5 h-2.5 rounded-full ${color}`} />
 }
 
 function StatusLabel({ service }) {
   const s = service.status
-  if (s === 'running') return <span className="text-green-400">Running</span>
+  if (s === 'running') return <span className="text-success-fg">Running</span>
   if (s === 'exited') {
     const exitInfo = service.exit_code != null ? ` (exit ${service.exit_code})` : ''
-    return <span className="text-red-400">Stopped{exitInfo}</span>
+    return <span className="text-danger-fg">Stopped{exitInfo}</span>
   }
-  return <span className="text-gray-500">Not Created</span>
+  return <span className="text-fg-subtle">Not Created</span>
 }
 
 function EngineBadge({ engine }) {
   const colors = {
-    'llama.cpp': 'bg-blue-600/30 text-blue-300',
-    'vLLM': 'bg-purple-600/30 text-purple-300',
-    'WebUI': 'bg-emerald-600/30 text-emerald-300',
-    'Unknown': 'bg-gray-600/30 text-gray-400'
+    'llama.cpp': 'bg-badge-llamacpp-bg text-badge-llamacpp-fg',
+    'vLLM': 'bg-badge-vllm-bg text-badge-vllm-fg',
+    'WebUI': 'bg-badge-webui-bg text-badge-webui-fg',
+    'Unknown': 'bg-badge-neutral-bg text-badge-neutral-fg'
   }
   return (
     <span className={`px-2 py-0.5 rounded text-xs font-medium ${colors[engine] || colors.Unknown}`}>
@@ -62,7 +62,7 @@ function CopyButton({ text }) {
   return (
     <button
       onClick={handleCopy}
-      className="ml-2 text-gray-400 hover:text-gray-200 text-lg leading-none cursor-pointer"
+      className="ml-2 text-fg-muted hover:text-fg text-lg leading-none cursor-pointer"
       title="Copy"
     >
       {copied ? '✓' : '⧉'}
@@ -85,7 +85,7 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
             target="_blank"
             rel="noopener noreferrer"
             onClick={e => e.stopPropagation()}
-            className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-gray-200 cursor-pointer"
+            className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-fg cursor-pointer"
             title="Open"
           >
             ↗
@@ -94,7 +94,7 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
         <button
           onClick={e => { e.stopPropagation(); onRestart(service.name) }}
           disabled={!!isTransitioning}
-          className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-yellow-300 disabled:opacity-50 cursor-pointer"
+          className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-warning-fg disabled:opacity-50 cursor-pointer"
           title="Restart"
         >
           ↻
@@ -109,7 +109,7 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
         <button
           onClick={e => { e.stopPropagation(); onStop(service.name) }}
           disabled={!!isTransitioning}
-          className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-red-400 disabled:opacity-50 cursor-pointer"
+          className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-danger-fg disabled:opacity-50 cursor-pointer"
           title="Stop"
         >
           {isTransitioning === 'stopping' ? '...' : '■'}
@@ -118,7 +118,7 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
         <button
           onClick={e => { e.stopPropagation(); onStart(service.name) }}
           disabled={!!isTransitioning}
-          className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-green-400 disabled:opacity-50 cursor-pointer"
+          className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-success-fg disabled:opacity-50 cursor-pointer"
           title="Start"
         >
           {isTransitioning === 'starting' ? '...' : '▶'}
@@ -126,14 +126,14 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
       )}
       <button
         onClick={e => { e.stopPropagation(); onEdit(service.name) }}
-        className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-blue-400 cursor-pointer"
+        className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-accent-fg cursor-pointer"
         title="Edit"
       >
         ✎
       </button>
       <button
         onClick={e => { e.stopPropagation(); onViewLogs(service.name) }}
-        className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-purple-400 cursor-pointer"
+        className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-purple-400 cursor-pointer"
         title="View logs"
       >
         <i className="fa-solid fa-terminal text-sm"></i>
@@ -141,7 +141,7 @@ function ActionButtons({ service, transitioning, onStart, onStop, onRestart, onD
       <button
         onClick={e => { e.stopPropagation(); onDelete(service.name) }}
         disabled={!!isTransitioning}
-        className="p-1.5 text-lg leading-none rounded hover:bg-gray-600 text-gray-400 hover:text-red-400 disabled:opacity-50 cursor-pointer"
+        className="p-1.5 text-lg leading-none rounded hover:bg-surface-muted text-fg-muted hover:text-danger-fg disabled:opacity-50 cursor-pointer"
         title="Delete"
       >
         ✕
@@ -157,7 +157,7 @@ function Toast({ message, onDone }) {
   }, [onDone])
 
   return (
-    <div className="fixed bottom-6 right-6 bg-red-600 text-white px-4 py-2 rounded shadow-lg text-sm z-50">
+    <div className="fixed bottom-6 right-6 bg-danger text-white px-4 py-2 rounded shadow-lg text-sm z-50">
       {message}
     </div>
   )
@@ -224,11 +224,11 @@ export default function ServicesTable() {
   }, [])
 
   if (error) {
-    return <p className="text-red-400 mt-6">Services: {error}</p>
+    return <p className="text-danger-fg mt-6">Services: {error}</p>
   }
 
   if (services === null) {
-    return <p className="text-gray-500 mt-6">Loading services...</p>
+    return <p className="text-fg-subtle mt-6">Loading services...</p>
   }
 
   const term = search.trim().toLowerCase()
@@ -240,17 +240,17 @@ export default function ServicesTable() {
 
     if (error) {
       if (error.includes('reconnecting') && !error.includes('Authentication')) {
-        color = 'bg-yellow-400'
+        color = 'bg-warning'
         label = 'Reconnecting...'
       } else {
-        color = 'bg-red-400'
+        color = 'bg-danger'
         label = error
       }
     } else if (connected) {
-      color = 'bg-green-400'
+      color = 'bg-success'
       label = 'Connected'
     } else {
-      color = 'bg-gray-500'
+      color = 'bg-fg-subtle'
       label = 'Disconnected'
     }
 
@@ -266,7 +266,7 @@ export default function ServicesTable() {
     <div className="mt-6">
       <div className="flex items-center justify-between mb-3 gap-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold text-gray-200">Services</h2>
+          <h2 className="text-lg font-semibold text-fg">Services</h2>
           <ConnectionDot connected={connected} error={error} />
         </div>
         <div className="flex items-center gap-3">
@@ -276,12 +276,12 @@ export default function ServicesTable() {
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Filter by name..."
-              className="w-48 bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500 transition-colors"
+              className="w-48 bg-surface border border-border rounded-lg px-3 py-1.5 text-sm text-fg placeholder-fg-subtle focus:outline-none focus:border-accent transition-colors"
             />
             {search && (
               <button
                 onClick={() => setSearch('')}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 text-xs cursor-pointer"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-fg-subtle hover:text-fg-muted text-xs cursor-pointer"
               >
                 ✕
               </button>
@@ -289,7 +289,7 @@ export default function ServicesTable() {
           </div>
           <button
             onClick={() => setShowRotateKey(true)}
-            className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors flex items-center gap-1.5"
+            className="px-3 py-1.5 bg-surface-strong hover:bg-surface-muted text-fg text-sm rounded transition-colors flex items-center gap-1.5"
             title="Generate a new shared API key for all services"
           >
             <i className="fa-solid fa-key text-xs"></i>
@@ -297,15 +297,15 @@ export default function ServicesTable() {
           </button>
           <button
             onClick={() => navigate('/services/new')}
-            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition-colors"
+            className="px-3 py-1.5 bg-accent-strong hover:bg-accent text-white text-sm rounded transition-colors"
           >
             + New Service
           </button>
         </div>
       </div>
-      <div className="overflow-x-auto rounded-lg border border-gray-700">
+      <div className="overflow-x-auto rounded-lg border border-border">
         <table className="w-full text-sm text-left">
-          <thead className="bg-gray-800 text-gray-400 uppercase text-xs">
+          <thead className="bg-surface text-fg-muted uppercase text-xs">
             <tr>
               <th className="px-6 py-3">Service</th>
               <th className="px-6 py-3">Status</th>
@@ -321,7 +321,7 @@ export default function ServicesTable() {
               <tr>
                 <td
                   colSpan={7}
-                  className="px-6 py-8 text-center text-gray-400"
+                  className="px-6 py-8 text-center text-fg-muted"
                 >
                   {services.length === 0
                     ? 'No services configured'
@@ -365,7 +365,7 @@ function PortCell({ service, onSetPublicPort }) {
   const isLlamaCpp = engine === 'llama.cpp'
   const isPublicPort = port === 3301
 
-  if (!port) return <td className="px-6 py-3 font-mono text-gray-500">N/A</td>
+  if (!port) return <td className="px-6 py-3 font-mono text-fg-subtle">N/A</td>
 
   return (
     <td className="px-6 py-3">
@@ -376,22 +376,22 @@ function PortCell({ service, onSetPublicPort }) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={e => e.stopPropagation()}
-            className="font-mono text-blue-400 hover:text-blue-300"
+            className="font-mono text-accent-fg hover:text-accent-fg-hover"
           >
             {port}
           </a>
         ) : (
-          <span className="font-mono text-gray-300">{port}</span>
+          <span className="font-mono text-fg-muted">{port}</span>
         )}
         {!infra && (isPublicPort ? (
-          <svg className="w-4 h-4 text-green-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" title="Public port (3301)">
+          <svg className="w-4 h-4 text-success-fg" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" title="Public port (3301)">
             <circle cx="12" cy="12" r="10" />
             <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
           </svg>
         ) : (
           <button
             onClick={e => { e.stopPropagation(); onSetPublicPort(service.name) }}
-            className="text-gray-500 hover:text-blue-400 text-lg leading-none cursor-pointer"
+            className="text-fg-subtle hover:text-accent-fg text-lg leading-none cursor-pointer"
             title="Set to public port (3301)"
           >
             ◎
@@ -407,14 +407,14 @@ function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetP
   const infra = isInfra(service.name)
 
   return (
-    <tr className={`border-b border-gray-700 transition-colors ${service.status === 'running' ? 'bg-green-900/40 hover:bg-green-900/50' : 'bg-gray-800/50 hover:bg-gray-700/50'}`}>
+    <tr className={`border-b border-border transition-colors ${service.status === 'running' ? 'bg-success-subtle hover:bg-success-subtle' : 'bg-surface-muted hover:bg-surface-strong'}`}>
       <td className="px-6 py-3">
         <div className="flex flex-col">
-          <div className="flex items-center font-medium text-gray-200">
+          <div className="flex items-center font-medium text-fg">
             {!infra ? (
               <button
                 onClick={() => onEdit(service.name)}
-                className="text-blue-400 hover:text-blue-300 hover:underline cursor-pointer text-left"
+                className="text-accent-fg hover:text-accent-fg-hover hover:underline cursor-pointer text-left"
               >
                 {service.name}
               </button>
@@ -424,7 +424,7 @@ function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetP
             <CopyButton text={service.name} />
           </div>
           {service.api_key && (
-            <p className="text-gray-400 font-mono text-xs mt-1">
+            <p className="text-fg-muted font-mono text-xs mt-1">
               {service.api_key.slice(0, 12)}...
               <CopyButton text={service.api_key} />
             </p>
@@ -439,16 +439,16 @@ function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetP
       </td>
       <PortCell service={service} onSetPublicPort={onSetPublicPort} />
       <td className="px-6 py-3"><EngineBadge engine={engine} /></td>
-      <td className="px-6 py-3 text-gray-300 text-xs">
+      <td className="px-6 py-3 text-fg-muted text-xs">
         {service.model_size_str || '—'}
       </td>
       <td className="px-6 py-3">
         {infra ? (
-          <span className="text-gray-600">—</span>
+          <span className="text-fg-faint">—</span>
         ) : service.openwebui_registered ? (
-          <span className="text-green-400 text-xs">✓ Registered</span>
+          <span className="text-success-fg text-xs">✓ Registered</span>
         ) : (
-          <span className="text-gray-500 text-xs">Not registered</span>
+          <span className="text-fg-subtle text-xs">Not registered</span>
         )}
       </td>
       <td className="px-6 py-3">

--- a/dashboard/frontend/src/components/SpecDecodeBar.jsx
+++ b/dashboard/frontend/src/components/SpecDecodeBar.jsx
@@ -13,19 +13,19 @@ export default function SpecDecodeBar({ specPerPos }) {
   if (entries.length === 0) return null
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-      <h3 className="text-sm font-medium text-gray-400 mb-3">Spec Decode per Position</h3>
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <h3 className="text-sm font-medium text-fg-muted mb-3">Spec Decode per Position</h3>
       <div className="space-y-2">
         {entries.map(([key, val]) => {
           const pct = (val / maxVal) * 100
           const label = key.replace('position_', 'Pos ')
           return (
             <div key={key} className="flex items-center gap-2">
-              <span className="text-gray-400 text-xs w-10 text-right">{label}</span>
-              <div className="flex-1 bg-gray-700 rounded h-4 overflow-hidden">
-                <div className="h-full bg-amber-500 rounded" style={{ width: `${pct}%` }} />
+              <span className="text-fg-muted text-xs w-10 text-right">{label}</span>
+              <div className="flex-1 bg-surface-strong rounded h-4 overflow-hidden">
+                <div className="h-full bg-warning rounded" style={{ width: `${pct}%` }} />
               </div>
-              <span className="text-gray-300 text-xs w-8 text-right">{Math.round(val)}</span>
+              <span className="text-fg-muted text-xs w-8 text-right">{Math.round(val)}</span>
             </div>
           )
         })}

--- a/dashboard/frontend/src/components/SpecDecodeBar.test.jsx
+++ b/dashboard/frontend/src/components/SpecDecodeBar.test.jsx
@@ -23,7 +23,7 @@ describe('SpecDecodeBar', () => {
 
   it('normalizes bar width to max value', () => {
     const { container } = render(<SpecDecodeBar specPerPos={{ position_0: 200, position_1: 100 }} />)
-    const bars = container.querySelectorAll('.bg-amber-500')
+    const bars = container.querySelectorAll('.bg-warning')
     expect(bars.length).toBe(2)
     expect(bars[0].style.width).toBe('100%')
     expect(bars[1].style.width).toBe('50%')


### PR DESCRIPTION
Second of 4 PRs for the v2 theme system. Tracker: #5. Builds on #35 (foundation + shell).

## Scope (PR 2 — services / monitor)
Migrate 11 components from hard-coded `gray/blue/green/red/yellow` Tailwind utilities to the semantic theme tokens introduced in PR 1, per the issue #5 §2 mapping table:

`ServicesTable`, `ServiceDetailsPage`, `ServiceDetailsHeader`, `ServiceConfigPanel`, `ServiceLogsPanel`, `ParameterReference`, `GpuMonitor`, `GpuStats`, `MetricsPanel`, `RequestStrip`, `SpecDecodeBar`.

- Surfaces/fg/border → `app/surface/surface-strong/surface-muted/elevated`, `fg/fg-muted/fg-subtle/fg-faint`, `border/border-strong/border-subtle`.
- Engine badges → `badge-llamacpp/vllm/webui/neutral-*`.
- Status dots/indicators → `success/danger/warning/info` (semantic, meaning preserved: running=green, stopped=red).
- Accent → `accent-strong/accent/accent-fg/accent-subtle`. `text-white` kept on accent buttons (intentional inverse).

## Deferred (PR 4, intentionally not here)
`GpuGraph`, `TokenSparkline`, `GaugesRow` — canvas/SVG. PR 4 owns them fully so the `getComputedStyle` variable reads + theme-dependent repaint land together. `prose prose-invert` (PR 3).

## Tests
Updated 3 assertions that targeted renamed status-indicator classes (`.bg-green-500`→`.bg-success`, `.bg-red-500`→`.bg-danger`, `.bg-amber-500`→`.bg-warning`). They assert a status dot is present; it now uses the semantic token. No behavioral test changes.

## Judgment calls
- vLLM engine badge was purple → `badge-vllm-*` (purple is the vLLM brand; token exists).
- Neutral/"Not Created"/disconnected dots: no neutral-dot token → `bg-fg-subtle`/`bg-fg-muted` to match the muted text of the same states.
- Opacity-suffixed fills (`bg-*-900/40` + `hover:.../50`) collapse to the single `*-subtle` token (mapping has no -300/-700 variants) — minor loss of a hover delta, acceptable per the issue's token taxonomy.
- `text-purple-400` (view-logs hover), `slate-*` (param tooltip), `bg-black/60` (modal scrim): not in the §2 mapping → left untouched.

## Verification
- `npm run build` OK; `npm test` 44/44; no new lint errors (the 6 errors pre-exist on `main`).
- Playwright smoke (local `vite preview`): dark parity — **0** leftover raw gray/blue/green/red/yellow utilities in the migrated (non-shell) area; light toggle + `localStorage` persistence on the services route; **0** console errors. No local backend, so service rows render the (migrated) not-authenticated state — documented limitation of the smoke env.