### PR TITLE
Theme system PR 3/4 — chat + typography cleanup (#5)

### DIFF
--- a/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
+++ b/dashboard/frontend/src/components/chat/ArtifactRenderer.jsx
@@ -47,24 +47,24 @@ export default function ArtifactRenderer({ artifact }) {
   const artType = artifact.type || artifact.artifact_type
 
   return (
-    <div className="rounded-lg border border-blue-500/30 overflow-hidden bg-gray-900/50 my-2">
+    <div className="rounded-lg border border-accent overflow-hidden bg-surface-muted my-2">
       {/* Title bar */}
-      <div className="flex items-center justify-between px-3 py-1.5 bg-blue-500/10 border-b border-blue-500/20">
+      <div className="flex items-center justify-between px-3 py-1.5 bg-accent-subtle border-b border-accent">
         <div className="flex items-center gap-2 text-xs">
           <i className={`fa-solid ${
             artType === 'svg' ? 'fa-image' :
             artType === 'code' ? 'fa-code' :
             artType === 'html' ? 'fa-globe' :
             'fa-file'
-          } text-blue-400 text-[10px]`}></i>
-          <span className="text-blue-300 font-medium">{artifact.title || 'Artifact'}</span>
-          <span className="text-gray-500 text-[10px]">{artType.toUpperCase()}</span>
+          } text-accent-fg text-[10px]`}></i>
+          <span className="text-accent-fg-hover font-medium">{artifact.title || 'Artifact'}</span>
+          <span className="text-fg-subtle text-[10px]">{artType.toUpperCase()}</span>
         </div>
         <div className="flex items-center gap-1">
           {artType === 'html' && (
             <button
               onClick={() => popoutArtifact(artifact)}
-              className="text-gray-500 hover:text-blue-400 px-1.5 py-0.5 rounded hover:bg-blue-500/10"
+              className="text-fg-subtle hover:text-accent-fg px-1.5 py-0.5 rounded hover:bg-accent-subtle"
               title="Pop out to new tab"
             >
               <i className="fa-solid fa-up-right-from-square text-[10px]"></i>
@@ -72,14 +72,14 @@ export default function ArtifactRenderer({ artifact }) {
           )}
           <button
             onClick={() => downloadArtifact(artifact)}
-            className="text-gray-500 hover:text-blue-400 px-1.5 py-0.5 rounded hover:bg-blue-500/10"
+            className="text-fg-subtle hover:text-accent-fg px-1.5 py-0.5 rounded hover:bg-accent-subtle"
             title="Download"
           >
             <i className="fa-solid fa-download text-[10px]"></i>
           </button>
           <button
             onClick={() => setExpanded(!expanded)}
-            className="text-gray-500 hover:text-gray-300 px-1.5 py-0.5 rounded hover:bg-gray-700"
+            className="text-fg-subtle hover:text-fg-muted px-1.5 py-0.5 rounded hover:bg-surface-strong"
           >
             <i className={`fa-solid fa-chevron-${expanded ? 'up' : 'down'} text-[10px]`}></i>
           </button>
@@ -105,7 +105,7 @@ export default function ArtifactRenderer({ artifact }) {
           )}
 
           {artType === 'code' && (
-            <pre className="bg-gray-950 rounded p-3 text-xs text-gray-300 overflow-auto max-h-96">
+            <pre className="bg-app rounded p-3 text-xs text-fg-muted overflow-auto max-h-96">
               <code>{artifact.content}</code>
             </pre>
           )}

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -101,7 +101,7 @@ export default function ChatArea({
   // previously-loaded chat via its stale sendMessage closure (codex iter 2).
   if (awaitingConversation) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-500">
+      <div className="flex-1 flex items-center justify-center text-fg-subtle">
         <div className="text-center">
           <i className="fa-solid fa-spinner fa-spin text-3xl mb-3 block opacity-40"></i>
           <p>Loading conversation…</p>
@@ -114,11 +114,11 @@ export default function ChatArea({
     return (
       <div className="flex-1 flex flex-col items-center justify-center px-4">
         <div className="w-full max-w-2xl flex flex-col items-center">
-          <i className="fa-solid fa-comments text-6xl mb-5 text-blue-500/40"></i>
-          <h2 className="text-2xl font-semibold text-gray-200 mb-2">Start a new conversation</h2>
-          <p className="text-sm text-gray-500 mb-6 text-center">
+          <i className="fa-solid fa-comments text-6xl mb-5 text-accent-fg/40"></i>
+          <h2 className="text-2xl font-semibold text-fg mb-2">Start a new conversation</h2>
+          <p className="text-sm text-fg-subtle mb-6 text-center">
             {defaultModelName
-              ? <>Type a message below — a chat will be created with <span className="text-gray-400">{defaultModelName}</span>.</>
+              ? <>Type a message below — a chat will be created with <span className="text-fg-muted">{defaultModelName}</span>.</>
               : 'No running model services available. Start a model first.'}
           </p>
           <div className="w-full">
@@ -161,7 +161,7 @@ export default function ChatArea({
       {/* Main chat column */}
       <div className="flex-1 flex flex-col min-w-0">
         {/* Header bar */}
-        <div className="border-b border-gray-700 px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
+        <div className="border-b border-border px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
           <div className="flex items-center gap-4 flex-wrap">
             <ModelSelector
               mainService={conversation.main_service}
@@ -180,7 +180,7 @@ export default function ChatArea({
           {streaming && (
             <button
               onClick={onStopStreaming}
-              className="text-xs px-3 py-1 bg-red-600/20 text-red-400 border border-red-600/30 rounded hover:bg-red-600/30"
+              className="text-xs px-3 py-1 bg-danger-subtle text-danger-fg border border-danger rounded hover:bg-danger-subtle"
             >
               <i className="fa-solid fa-stop mr-1"></i>Stop
             </button>
@@ -197,7 +197,7 @@ export default function ChatArea({
 
         {/* Error display */}
         {error && (
-          <div className="mx-4 mt-2 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-xs text-red-400">
+          <div className="mx-4 mt-2 px-3 py-2 bg-danger-subtle border border-danger rounded text-xs text-danger-fg">
             {error}
           </div>
         )}

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -208,7 +208,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
 
   return (
     <div
-      className={`border-t border-gray-700 ${dragOver ? 'bg-accent/5' : ''}`}
+      className={`border-t border-border ${dragOver ? 'bg-accent/5' : ''}`}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -233,13 +233,13 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
           </div>
           <div className="space-y-1">
             {pendingInserts.map((ann, i) => (
-              <div key={i} className="flex items-start gap-2 text-xs bg-gray-850 border border-line border-l-2 border-l-critique rounded px-2 py-1.5">
-                <span className="flex-1 text-gray-300 truncate" title={ann.comment}>
+              <div key={i} className="flex items-start gap-2 text-xs bg-elevated border border-line border-l-2 border-l-critique rounded px-2 py-1.5">
+                <span className="flex-1 text-fg-muted truncate" title={ann.comment}>
                   <span className="font-mono text-critique">{ann.issue_type}:</span> {ann.comment}
                 </span>
                 <button
                   onClick={() => onClearInsert(i)}
-                  className="text-gray-500 hover:text-error flex-shrink-0"
+                  className="text-fg-subtle hover:text-error flex-shrink-0"
                   aria-label="Remove issue"
                 >
                   <i className="fa-solid fa-xmark text-[10px]"></i>
@@ -281,14 +281,14 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
             {attachments.map((att, i) => (
               <div
                 key={i}
-                className="group flex items-center gap-2 text-xs bg-gray-850 border border-line border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
+                className="group flex items-center gap-2 text-xs bg-elevated border border-line border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
               >
                 <i className="fa-solid fa-file-lines text-accent flex-shrink-0"></i>
-                <span className="font-mono text-gray-300 truncate" title={att.name}>{att.name}</span>
-                <span className="font-mono text-gray-500 flex-shrink-0">{formatSize(att.size)}</span>
+                <span className="font-mono text-fg-muted truncate" title={att.name}>{att.name}</span>
+                <span className="font-mono text-fg-subtle flex-shrink-0">{formatSize(att.size)}</span>
                 <button
                   onClick={() => removeAttachment(i)}
-                  className="text-gray-500 hover:text-error flex-shrink-0"
+                  className="text-fg-subtle hover:text-error flex-shrink-0"
                   aria-label="Remove attachment"
                 >
                   <i className="fa-solid fa-xmark text-[10px]"></i>
@@ -316,7 +316,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
             disabled={disabled}
             aria-label="Attach files"
             title="Attach files"
-            className="px-4 py-3 bg-gray-800 border border-gray-700 hover:border-accent text-gray-400 hover:text-accent disabled:opacity-50 rounded-lg text-sm transition-colors"
+            className="px-4 py-3 bg-surface border border-border hover:border-accent text-fg-muted hover:text-accent disabled:opacity-50 rounded-lg text-sm transition-colors"
           >
             <i className="fa-solid fa-paperclip"></i>
           </button>
@@ -329,12 +329,12 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
             placeholder={images.length > 0 ? 'Add a message about the image(s)...' : pendingInserts.length > 0 ? 'Add a message (optional) or send with issues only...' : 'Type a message, paste or drop files...'}
             disabled={disabled}
             rows={1}
-            className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-sm text-gray-100 placeholder-gray-500 resize-none focus:outline-none focus:border-accent disabled:opacity-50"
+            className="flex-1 bg-surface border border-border rounded-lg px-4 py-3 text-sm text-fg placeholder-fg-subtle resize-none focus:outline-none focus:border-accent disabled:opacity-50"
           />
           <button
             type="submit"
             disabled={!canSend}
-            className="px-4 py-3 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded-lg text-sm font-medium transition-colors"
+            className="px-4 py-3 bg-accent-strong hover:bg-accent disabled:bg-surface-strong disabled:text-fg-subtle rounded-lg text-sm font-medium transition-colors"
           >
             <i className="fa-solid fa-paper-plane"></i>
           </button>

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -233,7 +233,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
           </div>
           <div className="space-y-1">
             {pendingInserts.map((ann, i) => (
-              <div key={i} className="flex items-start gap-2 text-xs bg-elevated border border-line border-l-2 border-l-critique rounded px-2 py-1.5">
+              <div key={i} className="flex items-start gap-2 text-xs bg-elevated border border-hairline border-l-2 border-l-critique rounded px-2 py-1.5">
                 <span className="flex-1 text-fg-muted truncate" title={ann.comment}>
                   <span className="font-mono text-critique">{ann.issue_type}:</span> {ann.comment}
                 </span>
@@ -259,7 +259,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
                 <img
                   src={img.dataUrl}
                   alt={img.name}
-                  className="w-20 h-20 object-cover rounded border border-line"
+                  className="w-20 h-20 object-cover rounded border border-hairline"
                 />
                 <button
                   onClick={() => removeImage(i)}
@@ -281,7 +281,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
             {attachments.map((att, i) => (
               <div
                 key={i}
-                className="group flex items-center gap-2 text-xs bg-elevated border border-line border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
+                className="group flex items-center gap-2 text-xs bg-elevated border border-hairline border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
               >
                 <i className="fa-solid fa-file-lines text-accent flex-shrink-0"></i>
                 <span className="font-mono text-fg-muted truncate" title={att.name}>{att.name}</span>
@@ -334,7 +334,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
           <button
             type="submit"
             disabled={!canSend}
-            className="px-4 py-3 bg-accent-strong hover:bg-accent disabled:bg-surface-strong disabled:text-fg-subtle rounded-lg text-sm font-medium transition-colors"
+            className="px-4 py-3 bg-accent-strong hover:bg-accent text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded-lg text-sm font-medium transition-colors"
           >
             <i className="fa-solid fa-paper-plane"></i>
           </button>

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -334,7 +334,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
           <button
             type="submit"
             disabled={!canSend}
-            className="px-4 py-3 bg-accent-strong hover:bg-accent text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded-lg text-sm font-medium transition-colors"
+            className="px-4 py-3 bg-accent-strong hover:bg-accent-hover text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded-lg text-sm font-medium transition-colors"
           >
             <i className="fa-solid fa-paper-plane"></i>
           </button>

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import ThemeSwitcher from '../ThemeSwitcher'
 
 function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggleSelect, confirmDelete, setConfirmDelete, onSelect, onDelete }) {
   const isSpinoff = !!conv.parent_conversation_id
@@ -12,12 +13,12 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
   return (
     <div
       onClick={() => onSelect(conv.id)}
-      className={`group flex items-center gap-2 py-2 cursor-pointer border-b border-gray-800/30 ${
+      className={`group flex items-center gap-2 py-2 cursor-pointer border-b border-border-subtle ${
         selected
-          ? 'bg-blue-900/30 text-white'
+          ? 'bg-accent-subtle text-fg'
           : activeId === conv.id
-            ? 'bg-gray-800 text-white'
-            : 'text-gray-400 hover:bg-gray-800/50'
+            ? 'bg-surface text-fg'
+            : 'text-fg-muted hover:bg-surface-muted'
       }`}
       style={{ paddingLeft: `${12 + depth * 16}px`, paddingRight: 12 }}
     >
@@ -33,7 +34,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => onToggleSelect(conv.id)}
-            className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
+            className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
             title="Select"
           />
         </label>
@@ -46,7 +47,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => onToggleSelect(conv.id)}
-            className={`w-3.5 h-3.5 accent-blue-500 cursor-pointer transition-opacity ${
+            className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${
               checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
             }`}
             title="Select"
@@ -55,7 +56,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       )}
       <div className="flex-1 min-w-0">
         <div className="text-sm truncate">{conv.title}</div>
-        <div className="text-[10px] text-gray-600">
+        <div className="text-[10px] text-fg-faint">
           {new Date(conv.updated_at).toLocaleDateString()}
         </div>
       </div>
@@ -63,17 +64,17 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
         <div className="flex gap-1 flex-shrink-0">
           <button
             onClick={e => { e.stopPropagation(); onDelete(conv.id); setConfirmDelete(null) }}
-            className="text-[10px] px-1.5 py-0.5 bg-red-600 rounded text-white"
+            className="text-[10px] px-1.5 py-0.5 bg-danger rounded text-white"
           >Yes</button>
           <button
             onClick={e => { e.stopPropagation(); setConfirmDelete(null) }}
-            className="text-[10px] px-1.5 py-0.5 bg-gray-600 rounded text-white"
+            className="text-[10px] px-1.5 py-0.5 bg-border-strong rounded text-white"
           >No</button>
         </div>
       ) : (
         <button
           onClick={e => { e.stopPropagation(); setConfirmDelete(conv.id) }}
-          className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+          className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-danger-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
           title="Delete conversation"
           aria-label="Delete conversation"
         >
@@ -162,12 +163,13 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
   }
 
   return (
-    <div className="w-72 border-r border-gray-800 flex flex-col bg-gray-900 flex-shrink-0">
+    <div className="w-72 border-r border-border flex flex-col bg-app flex-shrink-0">
       {/* Header */}
-      <div className="p-3 border-b border-gray-800">
+      <div className="p-3 border-b border-border">
+        <div className="flex justify-end mb-2"><ThemeSwitcher /></div>
         <button
           onClick={onCreate}
-          className="w-full px-3 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
+          className="w-full px-3 py-2 bg-accent-strong hover:bg-accent rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
         >
           <i className="fa-solid fa-plus"></i>
           New Conversation
@@ -178,19 +180,19 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
           morphs to selection toolbar in select mode. Same outer div / height
           either way so the conversation list never shifts vertically. */}
       <div
-        className={`h-9 px-3 border-b border-gray-800 flex items-center justify-between text-xs ${
-          selectionCount > 0 ? 'bg-gray-800/60' : ''
+        className={`h-9 px-3 border-b border-border flex items-center justify-between text-xs ${
+          selectionCount > 0 ? 'bg-surface-muted' : ''
         }`}
       >
         {selectionCount === 0 ? (
           <>
-            <span className="text-gray-500">
+            <span className="text-fg-subtle">
               {conversations.length} {conversations.length === 1 ? 'chat' : 'chats'}
             </span>
             {tree.roots.length > 0 && (
               <button
                 onClick={toggleSelectAllRoots}
-                className="text-[11px] text-gray-500 hover:text-gray-300"
+                className="text-[11px] text-fg-subtle hover:text-fg-muted"
                 title="Selects only top-level conversations; spin-offs follow their parent"
               >
                 {allRootsSelected ? 'Deselect all' : 'Select all'}
@@ -199,31 +201,31 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
           </>
         ) : (
           <>
-            <span className="text-gray-300">{selectionCount} selected</span>
+            <span className="text-fg-muted">{selectionCount} selected</span>
             <div className="flex items-center gap-2">
               {confirmBulk ? (
                 <>
                   <button
                     onClick={handleBulkDelete}
-                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white"
+                    className="px-2 py-1 bg-danger hover:bg-danger rounded text-white"
                   >Delete {selectionCount}</button>
                   <button
                     onClick={() => setConfirmBulk(false)}
-                    className="px-2 py-1 bg-gray-600 hover:bg-gray-500 rounded text-white"
+                    className="px-2 py-1 bg-border-strong hover:bg-border-strong rounded text-white"
                   >Cancel</button>
                 </>
               ) : (
                 <>
                   <button
                     onClick={() => setConfirmBulk(true)}
-                    className="px-2 py-1 text-red-400 hover:text-red-300 hover:bg-red-900/30 rounded"
+                    className="px-2 py-1 text-danger-fg hover:text-danger-fg hover:bg-danger-subtle rounded"
                     title="Delete selected"
                   >
                     <i className="fa-solid fa-trash"></i>
                   </button>
                   <button
                     onClick={clearSelection}
-                    className="px-2 py-1 text-gray-400 hover:text-gray-200"
+                    className="px-2 py-1 text-fg-muted hover:text-fg"
                     title="Clear selection"
                   >Clear</button>
                 </>
@@ -236,7 +238,7 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
       {/* Conversation tree */}
       <div className="flex-1 overflow-auto">
         {conversations.length === 0 && (
-          <div className="p-4 text-center text-xs text-gray-500">
+          <div className="p-4 text-center text-xs text-fg-subtle">
             No conversations yet
           </div>
         )}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -169,7 +169,7 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
         <div className="flex justify-end mb-2"><ThemeSwitcher /></div>
         <button
           onClick={onCreate}
-          className="w-full px-3 py-2 bg-accent-strong hover:bg-accent text-fg-inverse rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
+          className="w-full px-3 py-2 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
         >
           <i className="fa-solid fa-plus"></i>
           New Conversation

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -68,7 +68,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
           >Yes</button>
           <button
             onClick={e => { e.stopPropagation(); setConfirmDelete(null) }}
-            className="text-[10px] px-1.5 py-0.5 bg-border-strong rounded text-white"
+            className="text-[10px] px-1.5 py-0.5 bg-surface-strong rounded text-fg"
           >No</button>
         </div>
       ) : (
@@ -169,7 +169,7 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
         <div className="flex justify-end mb-2"><ThemeSwitcher /></div>
         <button
           onClick={onCreate}
-          className="w-full px-3 py-2 bg-accent-strong hover:bg-accent rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
+          className="w-full px-3 py-2 bg-accent-strong hover:bg-accent text-fg-inverse rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
         >
           <i className="fa-solid fa-plus"></i>
           New Conversation
@@ -211,7 +211,7 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
                   >Delete {selectionCount}</button>
                   <button
                     onClick={() => setConfirmBulk(false)}
-                    className="px-2 py-1 bg-border-strong hover:bg-border-strong rounded text-white"
+                    className="px-2 py-1 bg-surface-strong hover:bg-surface-strong rounded text-fg"
                   >Cancel</button>
                 </>
               ) : (

--- a/dashboard/frontend/src/components/chat/CopyablePre.jsx
+++ b/dashboard/frontend/src/components/chat/CopyablePre.jsx
@@ -53,7 +53,7 @@ export default function CopyablePre({ children, ...rest }) {
       <button
         type="button"
         onClick={handleCopy}
-        className="absolute top-1.5 right-1.5 z-10 px-2 py-1 text-[10px] font-medium rounded bg-gray-700/80 text-gray-300 hover:bg-gray-600 hover:text-white opacity-0 group-hover/code:opacity-100 focus:opacity-100 transition-opacity"
+        className="absolute top-1.5 right-1.5 z-10 px-2 py-1 text-[10px] font-medium rounded bg-surface-strong text-fg-muted hover:bg-surface-muted hover:text-fg opacity-0 group-hover/code:opacity-100 focus:opacity-100 transition-opacity"
         title={copied ? 'Copied' : 'Copy code'}
         aria-label={copied ? 'Code copied' : 'Copy code'}
       >

--- a/dashboard/frontend/src/components/chat/CritiqueButton.jsx
+++ b/dashboard/frontend/src/components/chat/CritiqueButton.jsx
@@ -5,8 +5,8 @@ export default function CritiqueButton({ messageId, hasCritique, loading, onClic
       disabled={loading}
       className={`text-xs px-2 py-1 rounded transition-colors ${
         hasCritique
-          ? 'text-yellow-400 hover:text-yellow-300'
-          : 'text-gray-500 hover:text-gray-400'
+          ? 'text-warning-fg hover:text-warning-fg'
+          : 'text-fg-subtle hover:text-fg-muted'
       } ${loading ? 'opacity-50 cursor-wait' : ''}`}
       title={hasCritique ? 'View / refresh critique' : 'Request critique'}
     >

--- a/dashboard/frontend/src/components/chat/CritiqueOverlay.jsx
+++ b/dashboard/frontend/src/components/chat/CritiqueOverlay.jsx
@@ -1,13 +1,13 @@
 const VERDICT_STYLES = {
-  pass: 'text-green-400 bg-green-500/10 border-green-500/30',
-  minor_issues: 'text-yellow-400 bg-yellow-500/10 border-yellow-500/30',
-  major_issues: 'text-red-400 bg-red-500/10 border-red-500/30',
+  pass: 'text-success-fg bg-success-subtle border-success',
+  minor_issues: 'text-warning-fg bg-warning-subtle border-warning',
+  major_issues: 'text-danger-fg bg-danger-subtle border-danger',
 }
 
 const SEVERITY_COLORS = {
-  error: { badge: 'bg-red-500/20 text-red-300', border: 'border-red-500/30', icon: 'text-red-400' },
-  warning: { badge: 'bg-yellow-500/20 text-yellow-300', border: 'border-yellow-500/30', icon: 'text-yellow-400' },
-  info: { badge: 'bg-blue-500/20 text-blue-300', border: 'border-blue-500/30', icon: 'text-blue-400' },
+  error: { badge: 'bg-danger-subtle text-danger-fg', border: 'border-danger', icon: 'text-danger-fg' },
+  warning: { badge: 'bg-warning-subtle text-warning-fg', border: 'border-warning', icon: 'text-warning-fg' },
+  info: { badge: 'bg-accent-subtle text-accent-fg', border: 'border-accent', icon: 'text-accent-fg' },
 }
 
 function AnnotationCard({ annotation, index, onInsert }) {
@@ -15,21 +15,21 @@ function AnnotationCard({ annotation, index, onInsert }) {
   const colors = SEVERITY_COLORS[severity] || SEVERITY_COLORS.info
 
   return (
-    <div className={`rounded border ${colors.border} bg-gray-900/50 overflow-hidden`}>
+    <div className={`rounded border ${colors.border} bg-surface-muted overflow-hidden`}>
       {/* Header */}
-      <div className="px-3 py-1.5 flex items-center gap-2 border-b border-gray-800/50">
+      <div className="px-3 py-1.5 flex items-center gap-2 border-b border-border-subtle">
         <span className={`text-[10px] font-bold uppercase ${colors.icon}`}>
           {severity === 'error' ? '!' : severity === 'warning' ? '?' : 'i'}
         </span>
-        <span className="text-[10px] text-gray-400 uppercase tracking-wide">{annotation.issue_type}</span>
+        <span className="text-[10px] text-fg-muted uppercase tracking-wide">{annotation.issue_type}</span>
         <span className={`text-[10px] px-1.5 py-0.5 rounded ${colors.badge}`}>{severity}</span>
       </div>
 
       {/* Quoted span */}
       {annotation.span_text && (
-        <div className="px-3 py-2 border-b border-gray-800/50">
-          <div className="text-[10px] text-gray-500 mb-1">Referenced text:</div>
-          <div className={`text-xs text-gray-300 italic border-l-2 ${colors.border} pl-2`}>
+        <div className="px-3 py-2 border-b border-border-subtle">
+          <div className="text-[10px] text-fg-subtle mb-1">Referenced text:</div>
+          <div className={`text-xs text-fg-muted italic border-l-2 ${colors.border} pl-2`}>
             "{annotation.span_text}"
           </div>
         </div>
@@ -37,10 +37,10 @@ function AnnotationCard({ annotation, index, onInsert }) {
 
       {/* Comment + Insert button */}
       <div className="px-3 py-2 flex items-start gap-2">
-        <p className="text-xs text-gray-300 leading-relaxed flex-1">{annotation.comment}</p>
+        <p className="text-xs text-fg-muted leading-relaxed flex-1">{annotation.comment}</p>
         <button
           onClick={() => onInsert(annotation)}
-          className="flex-shrink-0 text-[10px] px-2 py-1 rounded bg-blue-600/20 text-blue-400 border border-blue-600/30 hover:bg-blue-600/30 transition-colors"
+          className="flex-shrink-0 text-[10px] px-2 py-1 rounded bg-accent-subtle text-accent-fg border border-accent hover:bg-accent-subtle transition-colors"
           title="Insert into next message"
         >
           <i className="fa-solid fa-arrow-right-to-bracket mr-1"></i>Insert
@@ -70,7 +70,7 @@ export default function CritiqueOverlay({ critique, originalContent, onInsertAnn
       {/* Annotation cards */}
       {annotations.length > 0 && (
         <div className="space-y-2">
-          <div className="text-[10px] text-gray-500 uppercase tracking-wide">
+          <div className="text-[10px] text-fg-subtle uppercase tracking-wide">
             {annotations.length} issue{annotations.length !== 1 ? 's' : ''} found
           </div>
           {annotations.map((ann, i) => (
@@ -80,8 +80,8 @@ export default function CritiqueOverlay({ critique, originalContent, onInsertAnn
       )}
 
       {annotations.length === 0 && verdict === 'pass' && (
-        <div className="text-xs text-gray-500 text-center py-4">
-          <i className="fa-solid fa-check-circle text-green-500 text-lg mb-2 block"></i>
+        <div className="text-xs text-fg-subtle text-center py-4">
+          <i className="fa-solid fa-check-circle text-success-fg text-lg mb-2 block"></i>
           No issues found
         </div>
       )}

--- a/dashboard/frontend/src/components/chat/CritiquePanel.jsx
+++ b/dashboard/frontend/src/components/chat/CritiquePanel.jsx
@@ -10,33 +10,32 @@ export default function CritiquePanel({ messageId, originalContent, critique, lo
   }
 
   return (
-    <div className="w-96 border-l border-gray-700 flex flex-col bg-gray-850 flex-shrink-0 overflow-hidden"
-         style={{ backgroundColor: '#1a1d23' }}>
+    <div className="w-96 border-l border-border flex flex-col bg-elevated flex-shrink-0 overflow-hidden">
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-700 flex items-center justify-between">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm font-medium">
-          <i className="fa-solid fa-magnifying-glass text-yellow-400"></i>
+          <i className="fa-solid fa-magnifying-glass text-warning-fg"></i>
           <span>Critique</span>
         </div>
-        <button onClick={onClose} className="text-gray-500 hover:text-gray-300">
+        <button onClick={onClose} className="text-fg-subtle hover:text-fg-muted">
           <i className="fa-solid fa-xmark"></i>
         </button>
       </div>
 
       {/* Instructions input */}
-      <form onSubmit={handleSubmit} className="px-4 py-3 border-b border-gray-700">
-        <label className="text-xs text-gray-400 mb-1.5 block">Extra instructions for the critic</label>
+      <form onSubmit={handleSubmit} className="px-4 py-3 border-b border-border">
+        <label className="text-xs text-fg-muted mb-1.5 block">Extra instructions for the critic</label>
         <textarea
           value={instructions}
           onChange={e => setInstructions(e.target.value)}
           placeholder="e.g. Focus on factual accuracy, check the math, verify the code..."
           rows={2}
-          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-xs text-gray-200 resize-none focus:outline-none focus:border-yellow-500/50 placeholder-gray-600"
+          className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-warning placeholder-fg-faint"
         />
         <button
           type="submit"
           disabled={loading}
-          className="mt-2 w-full px-3 py-1.5 bg-yellow-600/20 text-yellow-400 border border-yellow-600/30 rounded text-xs font-medium hover:bg-yellow-600/30 disabled:opacity-50 transition-colors"
+          className="mt-2 w-full px-3 py-1.5 bg-warning-subtle text-warning-fg border border-warning rounded text-xs font-medium hover:bg-warning-subtle disabled:opacity-50 transition-colors"
         >
           {loading ? (
             <><i className="fa-solid fa-spinner fa-spin mr-1.5"></i>Critiquing...</>
@@ -51,7 +50,7 @@ export default function CritiquePanel({ messageId, originalContent, critique, lo
       {/* Results */}
       <div className="flex-1 overflow-auto px-4 py-3">
         {loading && !critique && (
-          <div className="text-center text-gray-500 py-8">
+          <div className="text-center text-fg-subtle py-8">
             <i className="fa-solid fa-spinner fa-spin text-xl mb-3 block"></i>
             <p className="text-xs">Critic is reviewing...</p>
           </div>
@@ -62,7 +61,7 @@ export default function CritiquePanel({ messageId, originalContent, critique, lo
         )}
 
         {!critique && !loading && (
-          <div className="text-center text-gray-600 py-8 text-xs">
+          <div className="text-center text-fg-faint py-8 text-xs">
             Click "Run Critique" to have the critic review this response
           </div>
         )}

--- a/dashboard/frontend/src/components/chat/FormatDriftChip.jsx
+++ b/dashboard/frontend/src/components/chat/FormatDriftChip.jsx
@@ -11,7 +11,7 @@ export default function FormatDriftChip({ warning, rawContent }) {
       <button
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="inline-flex items-center gap-1.5 rounded border border-yellow-600/40 bg-yellow-900/20 px-2 py-0.5 text-[11px] text-yellow-300 hover:bg-yellow-900/40"
+        className="inline-flex items-center gap-1.5 rounded border border-warning bg-warning-subtle px-2 py-0.5 text-[11px] text-warning-fg hover:bg-warning-subtle"
         title="Click to inspect"
       >
         <i className={`fa-solid fa-triangle-exclamation`}></i>
@@ -19,20 +19,20 @@ export default function FormatDriftChip({ warning, rawContent }) {
         <i className={`fa-solid ${open ? 'fa-chevron-up' : 'fa-chevron-down'} text-[9px] opacity-70`}></i>
       </button>
       {open && (
-        <div className="mt-1 rounded border border-yellow-600/30 bg-gray-900/60 p-2 text-[11px] text-gray-300 space-y-2 font-mono">
+        <div className="mt-1 rounded border border-warning bg-surface-muted p-2 text-[11px] text-fg-muted space-y-2 font-mono">
           {warning.description && (
-            <div className="text-yellow-300/90 font-sans">{warning.description}</div>
+            <div className="text-warning-fg font-sans">{warning.description}</div>
           )}
           {warning.snippet && (
             <div>
-              <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-0.5 font-sans">snippet</div>
-              <pre className="whitespace-pre-wrap break-words text-yellow-100/90">{warning.snippet}</pre>
+              <div className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5 font-sans">snippet</div>
+              <pre className="whitespace-pre-wrap break-words text-warning-fg">{warning.snippet}</pre>
             </div>
           )}
           {hasRaw && (
             <div>
-              <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-0.5 font-sans">raw content ({rawContent.length} chars)</div>
-              <pre className="whitespace-pre-wrap break-words max-h-64 overflow-auto text-gray-200">{rawContent}</pre>
+              <div className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5 font-sans">raw content ({rawContent.length} chars)</div>
+              <pre className="whitespace-pre-wrap break-words max-h-64 overflow-auto text-fg">{rawContent}</pre>
             </div>
           )}
         </div>

--- a/dashboard/frontend/src/components/chat/McpToggle.jsx
+++ b/dashboard/frontend/src/components/chat/McpToggle.jsx
@@ -33,14 +33,14 @@ export default function McpToggle({ conversationId, enabledServers, onUpdate, di
             disabled={disabled}
             className={`flex items-center gap-1.5 px-2 py-1 rounded text-[11px] border transition-colors ${
               isOn
-                ? 'bg-green-600/20 text-green-400 border-green-600/40 hover:bg-green-600/30'
-                : 'bg-gray-800 text-gray-500 border-gray-700 hover:bg-gray-700 hover:text-gray-400'
+                ? 'bg-success-subtle text-success-fg border-success hover:bg-success-subtle'
+                : 'bg-surface text-fg-subtle border-border hover:bg-surface-strong hover:text-fg-muted'
             } disabled:opacity-50`}
             title={server.description}
           >
             <i className={`fa-solid ${server.icon} text-[10px]`}></i>
             <span>{server.name}</span>
-            <span className={`text-[9px] ${isOn ? 'text-green-500' : 'text-gray-600'}`}>
+            <span className={`text-[9px] ${isOn ? 'text-success-fg' : 'text-fg-faint'}`}>
               {isOn ? 'ON' : 'OFF'}
             </span>
           </button>

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -112,7 +112,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
 
         {/* Message content — hairline block with a colored left accent
             spine, not a filled rounded bubble. */}
-        <div className={`rounded border border-line border-l-2 px-4 py-3 ${
+        <div className={`rounded border border-hairline border-l-2 px-4 py-3 ${
           isUser
             ? 'border-l-accent-strong bg-elevated text-fg'
             : 'border-l-accent bg-surface text-fg'
@@ -146,7 +146,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 autoFocus
               />
               <div className="flex gap-2 mt-2 text-xs">
-                <button onClick={handleEditSubmit} className="px-2 py-1 bg-accent rounded hover:bg-accent">Save</button>
+                <button onClick={handleEditSubmit} className="px-2 py-1 bg-accent text-fg-inverse rounded hover:bg-accent">Save</button>
                 <button onClick={() => { setEditing(false); setEditValue(message.content) }} className="px-2 py-1 bg-border-strong rounded hover:bg-border-strong">Cancel</button>
               </div>
             </div>

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -13,12 +13,14 @@ import { formatArgValue } from './toolCallUtils'
 import ToolResultBlock from './ToolResultBlock'
 import FormatDriftChip from './FormatDriftChip'
 import { detectFormatDrift } from './formatDrift'
+import useProseClass from '../../hooks/useProseClass'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function MessageBubble({ message, critique, critiqueLoading, hasSidekick, onCritique, onEdit, isActiveCritique, artifacts }) {
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(message.content)
+  const proseClass = useProseClass('max-w-none', 'text-[15px]', 'leading-relaxed', 'font-serif', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')
   const isUser = message.role === 'user'
   const isTemp = message.id?.startsWith('temp-')
   const messageImages = message.images || []
@@ -50,14 +52,14 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
       {/* Timeline tick node — sits in the left gutter on the shared spine. */}
       <span
         aria-hidden="true"
-        className={`absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-gray-850 border ${
+        className={`absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-elevated border ${
           isUser ? 'border-accent-strong' : 'border-accent'
         }`}
       ></span>
       <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
         <div className={`max-w-[90%] ${isUser ? 'order-1' : ''}`}>
           {/* Role label — light/minimal, no mono meta line */}
-          <div className={`text-[10px] text-gray-500 mb-1 ${isUser ? 'text-right' : ''}`}>
+          <div className={`text-[10px] text-fg-subtle mb-1 ${isUser ? 'text-right' : ''}`}>
             {isUser ? 'You' : message.model_service || 'Assistant'}
           </div>
 
@@ -77,15 +79,15 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
         {!isUser && message.tool_calls && message.tool_calls.length > 0 && (
           <div className="mb-2 space-y-1.5">
             {message.tool_calls.map((tc, i) => (
-              <div key={i} className="rounded px-3 py-2 text-xs border bg-gray-800/50 border-gray-700/50 space-y-1">
-                <div className="text-yellow-400">
+              <div key={i} className="rounded px-3 py-2 text-xs border bg-surface-muted border-border space-y-1">
+                <div className="text-warning-fg">
                   <i className="fa-solid fa-wrench mr-1.5"></i>
                   <span className="font-mono">{tc.name}</span>
                 </div>
                 {tc.arguments && Object.keys(tc.arguments).length > 0 && (
-                  <div className="text-gray-400 font-mono pl-5">
+                  <div className="text-fg-muted font-mono pl-5">
                     {Object.entries(tc.arguments).map(([k, v]) => (
-                      <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
+                      <div key={k} className="truncate"><span className="text-fg-subtle">{k}:</span> {formatArgValue(v)}</div>
                     ))}
                   </div>
                 )}
@@ -112,10 +114,10 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
             spine, not a filled rounded bubble. */}
         <div className={`rounded border border-line border-l-2 px-4 py-3 ${
           isUser
-            ? 'border-l-accent-strong bg-gray-850 text-gray-100'
-            : 'border-l-accent bg-gray-800 text-gray-200'
+            ? 'border-l-accent-strong bg-elevated text-fg'
+            : 'border-l-accent bg-surface text-fg'
         } ${isTemp ? 'opacity-70' : ''} ${
-          isActiveCritique ? 'ring-2 ring-yellow-500/50' : ''
+          isActiveCritique ? 'ring-2 ring-warning/50' : ''
         }`}>
           {/* Images */}
           {messageImages.length > 0 && (
@@ -125,7 +127,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                   <img
                     src={src}
                     alt={`Image ${i + 1}`}
-                    className="max-w-[300px] max-h-[200px] rounded border border-gray-600 hover:border-gray-400 transition-colors cursor-pointer"
+                    className="max-w-[300px] max-h-[200px] rounded border border-border-strong hover:border-fg-muted transition-colors cursor-pointer"
                   />
                 </a>
               ))}
@@ -140,19 +142,19 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 onChange={e => setEditValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 rows={6}
-                className="w-full min-h-[140px] bg-gray-800 border border-gray-700 text-gray-100 font-mono rounded px-3 py-2 text-sm resize-y focus:outline-none focus:border-accent"
+                className="w-full min-h-[140px] bg-surface border border-border text-fg font-mono rounded px-3 py-2 text-sm resize-y focus:outline-none focus:border-accent"
                 autoFocus
               />
               <div className="flex gap-2 mt-2 text-xs">
-                <button onClick={handleEditSubmit} className="px-2 py-1 bg-blue-500 rounded hover:bg-blue-400">Save</button>
-                <button onClick={() => { setEditing(false); setEditValue(message.content) }} className="px-2 py-1 bg-gray-600 rounded hover:bg-gray-500">Cancel</button>
+                <button onClick={handleEditSubmit} className="px-2 py-1 bg-accent rounded hover:bg-accent">Save</button>
+                <button onClick={() => { setEditing(false); setEditValue(message.content) }} className="px-2 py-1 bg-border-strong rounded hover:bg-border-strong">Cancel</button>
               </div>
             </div>
           ) : isUser ? (
             message.content && <p className="text-sm whitespace-pre-wrap font-mono">{message.content}</p>
           ) : (
             message.content && (
-              <div className="prose prose-invert max-w-none text-[15px] leading-relaxed font-serif [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+              <div className={proseClass}>
                 <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                   {message.content}
                 </ReactMarkdown>
@@ -167,7 +169,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
             {isUser && !editing && (
               <button
                 onClick={() => setEditing(true)}
-                className="text-xs text-gray-500 hover:text-gray-400"
+                className="text-xs text-fg-subtle hover:text-fg-muted"
               >
                 <i className="fa-solid fa-pen-to-square mr-1"></i>Edit
               </button>

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -146,7 +146,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 autoFocus
               />
               <div className="flex gap-2 mt-2 text-xs">
-                <button onClick={handleEditSubmit} className="px-2 py-1 bg-accent text-fg-inverse rounded hover:bg-accent">Save</button>
+                <button onClick={handleEditSubmit} className="px-2 py-1 bg-accent-strong text-fg-inverse rounded hover:bg-accent-hover">Save</button>
                 <button onClick={() => { setEditing(false); setEditValue(message.content) }} className="px-2 py-1 bg-border-strong rounded hover:bg-border-strong">Cancel</button>
               </div>
             </div>

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -67,7 +67,7 @@ export default function MessageList({
             className="pointer-events-none absolute left-[14px] top-1 bottom-6 w-px"
             style={{
               background:
-                'linear-gradient(180deg, transparent, var(--color-line-strong) 4%, var(--color-line-strong) 96%, transparent)',
+                'linear-gradient(180deg, transparent, var(--color-hairline-strong) 4%, var(--color-hairline-strong) 96%, transparent)',
             }}
           ></div>
         )}
@@ -182,7 +182,7 @@ export default function MessageList({
                 <FormatDriftChip warning={streamingParseWarning} rawContent={streamingContent} />
               )}
               {streamingContent ? (
-                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-surface text-fg">
+                <div className="rounded border border-hairline border-l-2 border-l-accent px-4 py-3 bg-surface text-fg">
                   <div className={proseClass}>
                     <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                       {streamingContent}
@@ -190,7 +190,7 @@ export default function MessageList({
                   </div>
                 </div>
               ) : !streamingReasoning && toolEvents.length === 0 && pendingToolCalls.length === 0 ? (
-                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-surface">
+                <div className="rounded border border-hairline border-l-2 border-l-accent px-4 py-3 bg-surface">
                   <div className="flex items-center gap-2 text-sm text-fg-muted">
                     <span className="relative flex h-2 w-2">
                       <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-60"></span>

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -11,6 +11,7 @@ import CopyablePre from './CopyablePre'
 import { formatArgValue } from './toolCallUtils'
 import ToolResultBlock from './ToolResultBlock'
 import FormatDriftChip from './FormatDriftChip'
+import useProseClass from '../../hooks/useProseClass'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
@@ -35,6 +36,7 @@ export default function MessageList({
   const bottomRef = useRef(null)
   const containerRef = useRef(null)
   const userScrolledRef = useRef(false)
+  const proseClass = useProseClass('max-w-none', 'text-[15px]', 'leading-relaxed', 'font-serif', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')
 
   // Auto-scroll on new content
   useEffect(() => {
@@ -89,7 +91,7 @@ export default function MessageList({
         <div className="relative pl-8 space-y-4">
           <span
             aria-hidden="true"
-            className="absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-gray-850 border border-accent"
+            className="absolute left-[10px] top-[7px] w-[9px] h-[9px] rounded-full bg-elevated border border-accent"
           ></span>
 
         {/* Assistant header + continuous thinking trace — renders ABOVE the
@@ -99,7 +101,7 @@ export default function MessageList({
         {streaming && (toolEvents.length > 0 || streamingReasoning) && (
           <div className="flex justify-start">
             <div className="max-w-[90%]">
-              <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
+              <div className="text-[10px] text-fg-subtle mb-1">Assistant</div>
               {streamingReasoning && (
                 <ThinkingBlock content={streamingReasoning} />
               )}
@@ -113,18 +115,18 @@ export default function MessageList({
             {toolEvents.map((evt, i) => (
               <div key={i} className="flex justify-start">
                 <div className="max-w-[90%]">
-                  <div className="rounded px-3 py-2 text-xs border bg-gray-800/50 border-gray-700/50 space-y-1">
-                    <div className={'result' in evt ? 'text-green-400' : 'text-yellow-400'}>
+                  <div className="rounded px-3 py-2 text-xs border bg-surface-muted border-border space-y-1">
+                    <div className={'result' in evt ? 'text-success-fg' : 'text-warning-fg'}>
                       <i className={`fa-solid ${'result' in evt ? 'fa-check' : 'fa-wrench fa-fade'} mr-1.5`}></i>
                       <span className="font-mono">{evt.name}</span>
                       {!('result' in evt) && (
-                        <span className="ml-2 text-[10px] uppercase tracking-wide text-gray-500">running…</span>
+                        <span className="ml-2 text-[10px] uppercase tracking-wide text-fg-subtle">running…</span>
                       )}
                     </div>
                     {evt.arguments && Object.keys(evt.arguments).length > 0 && (
-                      <div className="text-gray-400 font-mono pl-5">
+                      <div className="text-fg-muted font-mono pl-5">
                         {Object.entries(evt.arguments).map(([k, v]) => (
-                          <div key={k} className="truncate"><span className="text-gray-500">{k}:</span> {formatArgValue(v)}</div>
+                          <div key={k} className="truncate"><span className="text-fg-subtle">{k}:</span> {formatArgValue(v)}</div>
                         ))}
                       </div>
                     )}
@@ -157,10 +159,10 @@ export default function MessageList({
             {pendingToolCalls.map((p) => (
               <div key={p.index} className="flex justify-start">
                 <div className="max-w-[90%]">
-                  <div className="rounded px-3 py-2 text-xs border bg-gray-800/30 border-gray-700/50 border-dashed flex items-center gap-2 text-yellow-400/80">
+                  <div className="rounded px-3 py-2 text-xs border bg-surface-muted border-border border-dashed flex items-center gap-2 text-warning-fg">
                     <i className="fa-solid fa-wrench fa-fade"></i>
                     <span className="font-mono">{p.name || 'tool'}</span>
-                    <span className="text-gray-500">assembling call…</span>
+                    <span className="text-fg-subtle">assembling call…</span>
                   </div>
                 </div>
               </div>
@@ -174,25 +176,25 @@ export default function MessageList({
           <div className="flex justify-start">
             <div className="max-w-[90%]">
               {!toolEvents.length && !streamingReasoning && (
-                <div className="text-[10px] text-gray-500 mb-1">Assistant</div>
+                <div className="text-[10px] text-fg-subtle mb-1">Assistant</div>
               )}
               {streamingParseWarning && (
                 <FormatDriftChip warning={streamingParseWarning} rawContent={streamingContent} />
               )}
               {streamingContent ? (
-                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-gray-800 text-gray-200">
-                  <div className="prose prose-invert max-w-none text-[15px] leading-relaxed font-serif [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-surface text-fg">
+                  <div className={proseClass}>
                     <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                       {streamingContent}
                     </ReactMarkdown>
                   </div>
                 </div>
               ) : !streamingReasoning && toolEvents.length === 0 && pendingToolCalls.length === 0 ? (
-                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-gray-800">
-                  <div className="flex items-center gap-2 text-sm text-gray-400">
+                <div className="rounded border border-line border-l-2 border-l-accent px-4 py-3 bg-surface">
+                  <div className="flex items-center gap-2 text-sm text-fg-muted">
                     <span className="relative flex h-2 w-2">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60"></span>
-                      <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-60"></span>
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-accent"></span>
                     </span>
                     <span>
                       {heartbeat
@@ -212,10 +214,10 @@ export default function MessageList({
             Covers between-tool-round gaps and reasoning-without-content phases. */}
         {streaming && heartbeat && (streamingContent || streamingReasoning || toolEvents.length > 0 || pendingToolCalls.length > 0) && (
           <div className="flex justify-start">
-            <div className="text-[11px] text-gray-500 flex items-center gap-2 pl-1">
+            <div className="text-[11px] text-fg-subtle flex items-center gap-2 pl-1">
               <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60"></span>
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500"></span>
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-60"></span>
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-accent"></span>
               </span>
               <span>Waiting for model… {heartbeat.elapsed_s.toFixed(1)}s</span>
             </div>
@@ -226,7 +228,7 @@ export default function MessageList({
 
         {/* Empty state */}
         {messages.length === 0 && !streaming && (
-          <div className="text-center text-gray-500 py-20">
+          <div className="text-center text-fg-subtle py-20">
             <i className="fa-solid fa-comments text-4xl mb-4 block opacity-30"></i>
             <p>Start a conversation</p>
           </div>

--- a/dashboard/frontend/src/components/chat/ModelSelector.jsx
+++ b/dashboard/frontend/src/components/chat/ModelSelector.jsx
@@ -4,18 +4,18 @@ export default function ModelSelector({ mainService, sidekickService, onChangeMa
   const { services, loading } = useRunningServices()
 
   if (loading) {
-    return <div className="text-xs text-gray-500">Loading services...</div>
+    return <div className="text-xs text-fg-subtle">Loading services...</div>
   }
 
   return (
     <div className="flex gap-4 items-center flex-wrap">
       <div className="flex items-center gap-2">
-        <label className="text-xs text-gray-400 whitespace-nowrap">Main:</label>
+        <label className="text-xs text-fg-muted whitespace-nowrap">Main:</label>
         <select
           value={mainService}
           onChange={e => onChangeMain(e.target.value)}
           disabled={disabled}
-          className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 disabled:opacity-50"
+          className="bg-surface border border-border rounded px-2 py-1 text-xs text-fg disabled:opacity-50"
         >
           <option value="">Select model...</option>
           {services.map(s => (
@@ -24,12 +24,12 @@ export default function ModelSelector({ mainService, sidekickService, onChangeMa
         </select>
       </div>
       <div className="flex items-center gap-2">
-        <label className="text-xs text-gray-400 whitespace-nowrap">Critic:</label>
+        <label className="text-xs text-fg-muted whitespace-nowrap">Critic:</label>
         <select
           value={sidekickService || ''}
           onChange={e => onChangeSidekick(e.target.value || null)}
           disabled={disabled}
-          className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 disabled:opacity-50"
+          className="bg-surface border border-border rounded px-2 py-1 text-xs text-fg disabled:opacity-50"
         >
           <option value="">None</option>
           {services.map(s => (

--- a/dashboard/frontend/src/components/chat/SpinoffTaskbar.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffTaskbar.jsx
@@ -3,18 +3,18 @@ export default function SpinoffTaskbar({ windows, onRestore, onClose }) {
   if (minimized.length === 0) return null
 
   return (
-    <div className="fixed bottom-0 left-56 right-0 z-40 bg-gray-900 border-t border-gray-700 px-2 py-1 flex gap-1 overflow-x-auto">
+    <div className="fixed bottom-0 left-56 right-0 z-40 bg-app border-t border-border px-2 py-1 flex gap-1 overflow-x-auto">
       {minimized.map(w => (
         <div
           key={w.id}
-          className="flex items-center gap-1.5 bg-gray-800 border border-gray-700 rounded px-2.5 py-1.5 text-xs text-gray-300 hover:bg-gray-700 cursor-pointer group max-w-[200px]"
+          className="flex items-center gap-1.5 bg-surface border border-border rounded px-2.5 py-1.5 text-xs text-fg-muted hover:bg-surface-strong cursor-pointer group max-w-[200px]"
           onClick={() => onRestore(w.id)}
         >
           <i className="fa-solid fa-code-branch text-purple-400 text-[10px] flex-shrink-0"></i>
           <span className="truncate">{w.text.length > 25 ? w.text.slice(0, 25) + '...' : w.text}</span>
           <button
             onClick={e => { e.stopPropagation(); onClose(w.id) }}
-            className="text-gray-600 hover:text-red-400 flex-shrink-0 opacity-0 group-hover:opacity-100"
+            className="text-fg-faint hover:text-danger-fg flex-shrink-0 opacity-0 group-hover:opacity-100"
           >
             <i className="fa-solid fa-xmark text-[10px]"></i>
           </button>

--- a/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
@@ -7,10 +7,12 @@ import rehypeKatex from 'rehype-katex'
 import { streamChat } from '../../services/sse'
 import { createConversation, getConversation } from '../../services/chat'
 import CopyablePre from './CopyablePre'
+import useProseClass from '../../hooks/useProseClass'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function SpinoffWindow({ id, conversationId: initialConvId, selectedText, serviceName, parentConversationId, position, onClose, onMinimize, onFocus, onConversationCreated, zIndex }) {
+  const proseClass = useProseClass('prose-xs', 'max-w-none', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')
   const [convId, setConvId] = useState(initialConvId || null)
   const [messages, setMessages] = useState([])
   const [input, setInput] = useState('')
@@ -181,32 +183,31 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
   return (
     <div
       onClick={onFocus}
-      className="fixed shadow-2xl rounded-xl border border-gray-600 flex flex-col overflow-hidden"
-      style={{ left: pos.x, top: pos.y, width: size.w, height: size.h, zIndex, backgroundColor: '#111318' }}
+      className="fixed shadow-2xl rounded-xl border border-border-strong flex flex-col overflow-hidden bg-elevated"
+      style={{ left: pos.x, top: pos.y, width: size.w, height: size.h, zIndex }}
     >
       {/* Title bar */}
       <div
         onMouseDown={handleMouseDown}
-        className={`px-3 py-2 border-b border-gray-700 flex items-center justify-between flex-shrink-0 select-none ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
-        style={{ backgroundColor: '#191c22' }}
+        className={`px-3 py-2 border-b border-border bg-surface flex items-center justify-between flex-shrink-0 select-none ${dragging ? 'cursor-grabbing' : 'cursor-grab'}`}
       >
         <div className="flex items-center gap-2 text-xs font-medium min-w-0">
           <i className="fa-solid fa-code-branch text-purple-400 text-[10px]"></i>
-          <span className="truncate text-gray-300" title={title}>{title}</span>
+          <span className="truncate text-fg-muted" title={title}>{title}</span>
         </div>
         <div className="flex items-center gap-1 flex-shrink-0 ml-2">
-          <button onClick={e => { e.stopPropagation(); onMinimize() }} className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-yellow-400 hover:bg-gray-700 rounded" title="Minimize">
+          <button onClick={e => { e.stopPropagation(); onMinimize() }} className="w-6 h-6 flex items-center justify-center text-fg-subtle hover:text-warning-fg hover:bg-surface-strong rounded" title="Minimize">
             <i className="fa-solid fa-minus text-[10px]"></i>
           </button>
-          <button onClick={e => { e.stopPropagation(); onClose() }} className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-red-400 hover:bg-gray-700 rounded" title="Close">
+          <button onClick={e => { e.stopPropagation(); onClose() }} className="w-6 h-6 flex items-center justify-center text-fg-subtle hover:text-danger-fg hover:bg-surface-strong rounded" title="Close">
             <i className="fa-solid fa-xmark text-[10px]"></i>
           </button>
         </div>
       </div>
 
       {/* Context */}
-      <div className="px-3 py-1.5 border-b border-gray-800/50 bg-gray-800/20 flex-shrink-0">
-        <div className="text-[10px] text-gray-500 italic max-h-10 overflow-auto leading-tight">
+      <div className="px-3 py-1.5 border-b border-border-subtle bg-surface-muted flex-shrink-0">
+        <div className="text-[10px] text-fg-subtle italic max-h-10 overflow-auto leading-tight">
           "{selectedText.length > 200 ? selectedText.slice(0, 200) + '...' : selectedText}"
         </div>
       </div>
@@ -216,10 +217,10 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
         {messages.map((msg, i) => (
           <div key={msg.id || i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
             <div className={`max-w-[85%] rounded-lg px-3 py-2 text-xs ${
-              msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-800 border border-gray-700 text-gray-200'
+              msg.role === 'user' ? 'bg-accent-strong text-white' : 'bg-surface border border-border text-fg'
             }`}>
               {msg.role === 'assistant' ? (
-                <div className="prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                <div className={proseClass}>
                   <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                     {msg.content}
                   </ReactMarkdown>
@@ -233,8 +234,8 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
 
         {streaming && streamingContent && (
           <div className="flex justify-start">
-            <div className="max-w-[85%] rounded-lg px-3 py-2 text-xs bg-gray-800 border border-gray-700 text-gray-200">
-              <div className="prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+            <div className="max-w-[85%] rounded-lg px-3 py-2 text-xs bg-surface border border-border text-fg">
+              <div className={proseClass}>
                 <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
                   {streamingContent}
                 </ReactMarkdown>
@@ -245,20 +246,20 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
 
         {streaming && !streamingContent && (
           <div className="flex justify-start">
-            <div className="rounded-lg px-3 py-2 bg-gray-800 border border-gray-700 text-xs text-gray-400">
+            <div className="rounded-lg px-3 py-2 bg-surface border border-border text-xs text-fg-muted">
               <i className="fa-solid fa-spinner fa-spin mr-1"></i>Thinking...
             </div>
           </div>
         )}
 
         {messages.length === 0 && !streaming && (
-          <div className="text-center text-gray-600 py-4 text-[10px]">Ask about the selected text</div>
+          <div className="text-center text-fg-faint py-4 text-[10px]">Ask about the selected text</div>
         )}
         <div ref={bottomRef} />
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="border-t border-gray-700 p-2 flex gap-1.5 flex-shrink-0">
+      <form onSubmit={handleSubmit} className="border-t border-border p-2 flex gap-1.5 flex-shrink-0">
         <input
           ref={inputRef}
           value={input}
@@ -266,9 +267,9 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
           onKeyDown={handleKeyDown}
           placeholder="Ask about this..."
           disabled={streaming}
-          className="flex-1 bg-gray-800 border border-gray-700 rounded px-2.5 py-1.5 text-xs text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+          className="flex-1 bg-surface border border-border rounded px-2.5 py-1.5 text-xs text-fg placeholder-fg-subtle focus:outline-none focus:border-accent disabled:opacity-50"
         />
-        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-xs transition-colors">
+        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-accent-strong hover:bg-accent disabled:bg-surface-strong disabled:text-fg-subtle rounded text-xs transition-colors">
           <i className="fa-solid fa-paper-plane"></i>
         </button>
       </form>

--- a/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
@@ -269,7 +269,7 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
           disabled={streaming}
           className="flex-1 bg-surface border border-border rounded px-2.5 py-1.5 text-xs text-fg placeholder-fg-subtle focus:outline-none focus:border-accent disabled:opacity-50"
         />
-        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-accent-strong hover:bg-accent disabled:bg-surface-strong disabled:text-fg-subtle rounded text-xs transition-colors">
+        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-accent-strong hover:bg-accent text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded text-xs transition-colors">
           <i className="fa-solid fa-paper-plane"></i>
         </button>
       </form>

--- a/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
@@ -269,7 +269,7 @@ export default function SpinoffWindow({ id, conversationId: initialConvId, selec
           disabled={streaming}
           className="flex-1 bg-surface border border-border rounded px-2.5 py-1.5 text-xs text-fg placeholder-fg-subtle focus:outline-none focus:border-accent disabled:opacity-50"
         />
-        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-accent-strong hover:bg-accent text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded text-xs transition-colors">
+        <button type="submit" disabled={streaming || !input.trim()} className="px-2.5 py-1.5 bg-accent-strong hover:bg-accent-hover text-fg-inverse disabled:bg-surface-strong disabled:text-fg-subtle rounded text-xs transition-colors">
           <i className="fa-solid fa-paper-plane"></i>
         </button>
       </form>

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
@@ -4,10 +4,10 @@ export default function SystemPromptEditor({ mainPrompt, sidekickPrompt, onChang
   const [open, setOpen] = useState(false)
 
   return (
-    <div className="border-b border-gray-700">
+    <div className="border-b border-border">
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 px-4 py-2 text-xs text-gray-500 hover:text-gray-400 w-full text-left"
+        className="flex items-center gap-2 px-4 py-2 text-xs text-fg-subtle hover:text-fg-muted w-full text-left"
       >
         <i className={`fa-solid fa-chevron-${open ? 'down' : 'right'} text-[10px]`}></i>
         <i className="fa-solid fa-sliders"></i>
@@ -16,21 +16,21 @@ export default function SystemPromptEditor({ mainPrompt, sidekickPrompt, onChang
       {open && (
         <div className="px-4 pb-3 space-y-3">
           <div>
-            <label className="text-xs text-gray-400 mb-1 block">Main Model</label>
+            <label className="text-xs text-fg-muted mb-1 block">Main Model</label>
             <textarea
               value={mainPrompt}
               onChange={e => onChangeMain(e.target.value)}
               rows={3}
-              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-xs text-gray-200 resize-none focus:outline-none focus:border-blue-500"
+              className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"
             />
           </div>
           <div>
-            <label className="text-xs text-gray-400 mb-1 block">Critic Model</label>
+            <label className="text-xs text-fg-muted mb-1 block">Critic Model</label>
             <textarea
               value={sidekickPrompt}
               onChange={e => onChangeSidekick(e.target.value)}
               rows={3}
-              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-xs text-gray-200 resize-none focus:outline-none focus:border-blue-500"
+              className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"
             />
           </div>
         </div>

--- a/dashboard/frontend/src/components/chat/TextContextMenu.jsx
+++ b/dashboard/frontend/src/components/chat/TextContextMenu.jsx
@@ -54,7 +54,7 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
 
   return (
     <div
-      className="fixed z-50 bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
+      className="fixed z-50 bg-surface border border-border-strong rounded-lg shadow-xl py-1 min-w-[160px]"
       style={{ left: menu.x, top: menu.y }}
       onClick={e => e.stopPropagation()}
     >
@@ -63,7 +63,7 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
           onSpinoff(menu.text)
           setMenu(null)
         }}
-        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+        className="w-full text-left px-3 py-2 text-sm text-fg hover:bg-surface-strong flex items-center gap-2"
       >
         <i className="fa-solid fa-code-branch text-purple-400 text-xs"></i>
         Spin-off...
@@ -73,9 +73,9 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
           await copyToClipboard(menu.text)
           setMenu(null)
         }}
-        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+        className="w-full text-left px-3 py-2 text-sm text-fg hover:bg-surface-strong flex items-center gap-2"
       >
-        <i className="fa-solid fa-copy text-gray-400 text-xs"></i>
+        <i className="fa-solid fa-copy text-fg-muted text-xs"></i>
         Copy
       </button>
       <button
@@ -83,9 +83,9 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
           onQuote?.(menu.text)
           setMenu(null)
         }}
-        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+        className="w-full text-left px-3 py-2 text-sm text-fg hover:bg-surface-strong flex items-center gap-2"
       >
-        <i className="fa-solid fa-quote-right text-blue-400 text-xs"></i>
+        <i className="fa-solid fa-quote-right text-accent-fg text-xs"></i>
         Quote in reply
       </button>
       <button
@@ -93,9 +93,9 @@ export default function TextContextMenu({ onSpinoff, onQuote, onCritique }) {
           onCritique?.(menu.text)
           setMenu(null)
         }}
-        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+        className="w-full text-left px-3 py-2 text-sm text-fg hover:bg-surface-strong flex items-center gap-2"
       >
-        <i className="fa-solid fa-magnifying-glass text-amber-400 text-xs"></i>
+        <i className="fa-solid fa-magnifying-glass text-warning-fg text-xs"></i>
         Critique this
       </button>
     </div>

--- a/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
+++ b/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
@@ -5,11 +5,13 @@ import remarkMath from 'remark-math'
 import rehypeRaw from 'rehype-raw'
 import rehypeKatex from 'rehype-katex'
 import CopyablePre from './CopyablePre'
+import useProseClass from '../../hooks/useProseClass'
 
 const MD_COMPONENTS = { pre: CopyablePre }
 
 export default function ThinkingBlock({ content }) {
   const [open, setOpen] = useState(false)
+  const proseClass = useProseClass('prose-xs', 'max-w-none', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')
 
   if (!content) return null
 
@@ -17,14 +19,14 @@ export default function ThinkingBlock({ content }) {
     <div className="mb-2">
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-400"
+        className="flex items-center gap-2 text-xs text-fg-subtle hover:text-fg-muted"
       >
         <i className={`fa-solid fa-chevron-${open ? 'down' : 'right'} text-[10px]`}></i>
         <i className="fa-solid fa-brain"></i>
         <span>Thinking ({content.length} chars)</span>
       </button>
       {open && (
-        <div className="mt-1 p-3 bg-gray-900/50 border border-gray-700 rounded text-xs text-gray-400 max-h-60 overflow-auto prose prose-invert prose-xs max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+        <div className={`mt-1 p-3 bg-surface-muted border border-border rounded text-xs text-fg-muted max-h-60 overflow-auto ${proseClass}`}>
           <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, rehypeKatex]} components={MD_COMPONENTS}>
             {content}
           </ReactMarkdown>

--- a/dashboard/frontend/src/components/chat/ToolResultBlock.jsx
+++ b/dashboard/frontend/src/components/chat/ToolResultBlock.jsx
@@ -8,18 +8,18 @@ export default function ToolResultBlock({ text }) {
   const long = s.length > PREVIEW_CHARS
   const preview = long ? s.slice(0, PREVIEW_CHARS).replace(/\s+$/, '') + '…' : s
   return (
-    <div className="text-gray-300 inline">
-      <span className="text-green-400 mr-1">→</span>
+    <div className="text-fg-muted inline">
+      <span className="text-success-fg mr-1">→</span>
       {open || !long ? (
-        <pre className="font-mono whitespace-pre-wrap break-words bg-gray-950/60 border border-gray-800 rounded px-2 py-1 mt-1 max-h-80 overflow-auto text-[11px] text-gray-300">{s}</pre>
+        <pre className="font-mono whitespace-pre-wrap break-words bg-surface-muted border border-border rounded px-2 py-1 mt-1 max-h-80 overflow-auto text-[11px] text-fg-muted">{s}</pre>
       ) : (
-        <span className="font-mono text-gray-400">{preview}</span>
+        <span className="font-mono text-fg-muted">{preview}</span>
       )}
       {long && (
         <button
           type="button"
           onClick={() => setOpen(o => !o)}
-          className="ml-2 text-[10px] uppercase tracking-wide text-gray-500 hover:text-gray-300"
+          className="ml-2 text-[10px] uppercase tracking-wide text-fg-subtle hover:text-fg-muted"
         >
           {open ? 'collapse' : `show all (${s.length.toLocaleString()} chars)`}
         </button>

--- a/dashboard/frontend/src/hooks/useProseClass.js
+++ b/dashboard/frontend/src/hooks/useProseClass.js
@@ -1,0 +1,22 @@
+import { useTheme } from '../contexts/ThemeContext'
+
+/**
+ * Shared markdown/prose class helper (issue #5, owner note 6).
+ *
+ * `prose-invert` is the Tailwind Typography dark-on-light inversion and is
+ * only correct in the dark theme. Rather than repeating
+ * `theme === 'light' ? ... : ...` in every chat component that renders
+ * markdown, call this hook: it returns the base `prose` class plus
+ * `prose-invert` only in dark, with any extra modifiers appended.
+ *
+ *   const proseClass = useProseClass('prose-xs', 'max-w-none')
+ *   <div className={proseClass}> … </div>
+ */
+export default function useProseClass(...extra) {
+  const { theme } = useTheme()
+  return [
+    'prose',
+    theme === 'light' ? null : 'prose-invert',
+    ...extra,
+  ].filter(Boolean).join(' ')
+}

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -71,6 +71,12 @@
   --color-border-strong: #36404f;
   --color-border-subtle: #161c27;
 
+  /* Themed hairline / timeline-spine. Semantic counterpart to the
+     brand-fixed #29 --color-line; translucent so it reads on any
+     surface, and overridden for light below (issue #5 §8). */
+  --color-hairline:        rgba(148, 163, 184, 0.10);
+  --color-hairline-strong: rgba(148, 163, 184, 0.20);
+
   /* Accent (reuses #29's accent pair; adds fg/subtle roles). */
   --color-accent-hover:    #3b82f6;
   --color-accent-fg:       #60a5fa;
@@ -164,11 +170,12 @@
   --color-chart-grid:       #cbd5e1;
   --color-chart-axis-label: #475569;
 
-  /* #29 hairline/timeline-spine tokens: the dark slate-alpha values are
-     near-invisible on a light surface. Darken for light (issue #5 §8 —
-     hairlines must stay visible across themes; chat consumes these). */
-  --color-line:        rgba(15, 23, 42, 0.10);
-  --color-line-strong: rgba(15, 23, 42, 0.18);
+  /* Semantic hairline: the dark slate-alpha is near-invisible on a light
+     surface, so darken for light (issue #5 §8 — hairlines must stay
+     visible across themes). The brand-fixed #29 --color-line tokens are
+     intentionally NOT overridden. */
+  --color-hairline:        rgba(15, 23, 42, 0.10);
+  --color-hairline-strong: rgba(15, 23, 42, 0.18);
 }
 
 [data-theme="dark"] {

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -77,8 +77,11 @@
   --color-hairline:        rgba(148, 163, 184, 0.10);
   --color-hairline-strong: rgba(148, 163, 184, 0.20);
 
-  /* Accent (reuses #29's accent pair; adds fg/subtle roles). */
-  --color-accent-hover:    #3b82f6;
+  /* Accent (reuses #29's accent pair; adds fg/subtle roles).
+     accent-hover is the *darker* filled-button hover — it must keep
+     white text >= AA, so it stays at/below accent-strong (#2563eb).
+     #3b82f6 (the lighter accent) drops white text to ~3.7:1. */
+  --color-accent-hover:    #1d4ed8;
   --color-accent-fg:       #60a5fa;
   --color-accent-fg-hover: #93c5fd;
   --color-accent-subtle:   rgb(37 99 235 / 0.25);

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -163,6 +163,12 @@
 
   --color-chart-grid:       #cbd5e1;
   --color-chart-axis-label: #475569;
+
+  /* #29 hairline/timeline-spine tokens: the dark slate-alpha values are
+     near-invisible on a light surface. Darken for light (issue #5 §8 —
+     hairlines must stay visible across themes; chat consumes these). */
+  --color-line:        rgba(15, 23, 42, 0.10);
+  --color-line-strong: rgba(15, 23, 42, 0.18);
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
Third of 4 PRs for the v2 theme system. Tracker: #5. Builds on #35 (foundation) + #36 (services).

## Scope (PR 3 — chat + typography)
- **All `chat/` components** migrated from hard-coded `gray/blue/green/red/yellow` utilities to the semantic theme tokens (issue #5 §2). The #29 brand/hairline tokens (`accent`, `critique`, `mcp`, `spinoff`, `error`, `line`, `line-strong`) are intentionally kept brand-fixed.
- **Shared prose helper** (owner note 6): new `src/hooks/useProseClass.js`. Replaces all 5 hand-rolled `prose prose-invert …` sites (`MessageBubble`, `MessageList`, `ThinkingBlock`, `SpinoffWindow` ×2). `prose-invert` is applied only in dark; computed once at component top level — hooks-rules-safe even where the prose div is inside a `.map()` (closed over, not called in the loop).
- **Inline `backgroundColor` removed** (issue #5 §5): `CritiquePanel` `#1a1d23` → `bg-elevated`; `SpinoffWindow` `#111318` → `bg-elevated`, `#191c22` → `bg-surface`. Layout inline styles (`left/top/width/height/zIndex`) preserved.
- **`ChatSidebar` gets its own `ThemeSwitcher`** — the chat route renders the app `Sidebar` but not `Header`, so the switcher is placed in the ChatSidebar header (issue #5 §5).
- **`index.css`**: light-theme overrides for the #29 `--color-line`/`--color-line-strong` hairline tokens (the dark slate-alpha values are near-invisible on a white surface; chat consumes them for the transcript spine — issue #5 §8 "hairlines must stay visible across themes").
- Also migrated `ToolResultBlock`, `CopyablePre`, `FormatDriftChip` — chat-surface components added post-#29, not in the original §7 list but required for light correctness.

## Deferred (PR 4)
Canvas/SVG repaint: `GpuGraph`, `TokenSparkline`, `GaugesRow` — `getComputedStyle` variable reads + theme-dependent redraw.

## Verification
- `npm run build` OK; `npm test` 44/44; no new lint errors (6 pre-existing on `main`).
- Playwright smoke (local `vite preview`, `/v2/chat`): dark parity; light toggle + `localStorage` persistence via the ChatSidebar switcher; **0** console errors (prose hook + all chat components render clean); **0** residual raw color utilities in `chat/`; light screenshot reviewed (white surfaces, dark text, visible hairlines, themed empty-state/composer). No local backend → composer renders the migrated disabled/empty state (documented smoke-env limitation).