### PR TITLE
Theme system PR 4/4 — canvas/SVG repaint + final cleanup (#5)

### DIFF
--- a/dashboard/frontend/src/components/GaugesRow.jsx
+++ b/dashboard/frontend/src/components/GaugesRow.jsx
@@ -1,5 +1,9 @@
 const CIRCUMFERENCE = 2 * Math.PI * 18
 
+// Categorical threshold hexes stay JS constants (not theme-driven): they
+// must read identically and are asserted by GaugesRow.test (issue #5 §8).
+// Only the non-threshold SVG chrome (track, label text) is themed, via
+// CSS-driven stroke-/fill- utilities that re-resolve on a theme swap.
 const kvColor = (pct) => {
   if (pct < 60) return '#22c55e'
   if (pct <= 85) return '#eab308'
@@ -14,7 +18,7 @@ function DonutGauge({ value, label, colorGetter }) {
   return (
     <div className="flex flex-col items-center gap-1.5">
       <svg width="48" height="48" viewBox="0 0 48 48">
-        <circle cx="24" cy="24" r={18} fill="none" stroke="#374151" strokeWidth={4} strokeDasharray={CIRCUMFERENCE} />
+        <circle className="stroke-chart-grid" cx="24" cy="24" r={18} fill="none" strokeWidth={4} strokeDasharray={CIRCUMFERENCE} />
         {displayPct !== undefined && color && (
           <circle
             cx="24"
@@ -34,14 +38,14 @@ function DonutGauge({ value, label, colorGetter }) {
           y="24"
           dominantBaseline="central"
           textAnchor="middle"
-          fill="#d1d5db"
+          className="fill-chart-axis-label"
           fontSize="9"
           fontWeight="600"
         >
           {displayPct !== undefined ? `${Math.round(displayPct)}%` : '—'}
         </text>
       </svg>
-      <span className="text-gray-400 text-xs">{label}</span>
+      <span className="text-fg-muted text-xs">{label}</span>
     </div>
   )
 }
@@ -52,8 +56,8 @@ export default function GaugesRow({ kvCache, prefixHitRatio, specAcceptRatio }) 
   const specPct = specAcceptRatio !== undefined && specAcceptRatio !== null ? specAcceptRatio * 100 : undefined
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-      <h3 className="text-sm font-medium text-gray-400 mb-3">Utilization</h3>
+    <div className="bg-surface rounded-lg border border-border p-4">
+      <h3 className="text-sm font-medium text-fg-muted mb-3">Utilization</h3>
       <div className="flex justify-around items-center">
         <div title="KV blocks actively used by running/waiting requests (not prefix-cached blocks).">
           <DonutGauge value={kvPct} label="Active KV" colorGetter={kvColor} />

--- a/dashboard/frontend/src/components/GpuGraph.jsx
+++ b/dashboard/frontend/src/components/GpuGraph.jsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef } from 'react'
+import { useTheme } from '../contexts/ThemeContext'
 
 const MAX_POINTS = 20
+
+// Canvas is immediate-mode, so it can't ride the CSS cascade on a theme
+// swap — read the resolved token values at draw time and repaint when the
+// theme changes (issue #5 §8).
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+}
 
 function draw(canvas, memoryHistory, computeHistory) {
   const ctx = canvas.getContext('2d')
@@ -17,7 +25,7 @@ function draw(canvas, memoryHistory, computeHistory) {
   const pad = 2
 
   // Grid lines
-  ctx.strokeStyle = '#374151'
+  ctx.strokeStyle = cssVar('--color-chart-grid')
   ctx.lineWidth = 0.5
   for (let i = 0; i <= 4; i++) {
     const y = pad + (height - 2 * pad) * (i / 4)
@@ -44,30 +52,31 @@ function draw(canvas, memoryHistory, computeHistory) {
     ctx.stroke()
   }
 
-  drawLine(memoryHistory, '#3b82f6')
-  drawLine(computeHistory, '#22c55e')
+  drawLine(memoryHistory, cssVar('--color-chart-memory'))
+  drawLine(computeHistory, cssVar('--color-chart-compute'))
 }
 
 export default function GpuGraph({ memoryHistory, computeHistory }) {
   const canvasRef = useRef(null)
+  const { theme } = useTheme()
 
   useEffect(() => {
     if (canvasRef.current) {
       draw(canvasRef.current, memoryHistory, computeHistory)
     }
-  }, [memoryHistory, computeHistory])
+  }, [memoryHistory, computeHistory, theme])
 
   return (
     <div className="flex-1 min-w-0 pt-1">
       <div className="flex items-center justify-between mb-2">
-        <p className="text-gray-400 text-xs">GPU History (60s)</p>
+        <p className="text-fg-muted text-xs">GPU History (60s)</p>
         <div className="flex gap-3 text-xs">
           <span className="flex items-center gap-1">
-            <span className="inline-block w-3 h-0.5 bg-blue-500 rounded" />
+            <span className="inline-block w-3 h-0.5 bg-chart-memory rounded" />
             Memory
           </span>
           <span className="flex items-center gap-1">
-            <span className="inline-block w-3 h-0.5 bg-green-500 rounded" />
+            <span className="inline-block w-3 h-0.5 bg-chart-compute rounded" />
             Compute
           </span>
         </div>

--- a/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
+++ b/dashboard/frontend/src/components/RotateDefaultKeyModal.jsx
@@ -4,15 +4,15 @@ import { fetchAPI } from '../api'
 function KeyCopy({ value }) {
   const [copied, setCopied] = useState(false)
   return (
-    <div className="flex items-center gap-2 bg-gray-900 border border-gray-700 rounded px-3 py-2">
-      <code className="text-green-300 text-xs break-all flex-1">{value}</code>
+    <div className="flex items-center gap-2 bg-app border border-border rounded px-3 py-2">
+      <code className="text-success-fg text-xs break-all flex-1">{value}</code>
       <button
         onClick={() => {
           navigator.clipboard.writeText(value)
           setCopied(true)
           setTimeout(() => setCopied(false), 1500)
         }}
-        className="text-gray-400 hover:text-gray-200 text-lg leading-none cursor-pointer shrink-0"
+        className="text-fg-muted hover:text-fg text-lg leading-none cursor-pointer shrink-0"
         title="Copy"
       >
         {copied ? '✓' : '⧉'}
@@ -23,7 +23,7 @@ function KeyCopy({ value }) {
 
 function ServiceList({ names }) {
   return (
-    <ul className="mt-1.5 max-h-40 overflow-auto text-xs font-mono text-gray-300 space-y-0.5 pl-1">
+    <ul className="mt-1.5 max-h-40 overflow-auto text-xs font-mono text-fg-muted space-y-0.5 pl-1">
       {names.map(n => <li key={n}>• {n}</li>)}
     </ul>
   )
@@ -59,21 +59,21 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onClose}>
-      <div className="bg-gray-800 rounded-lg border border-gray-700 max-w-xl w-full max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
-        <div className="px-5 py-4 border-b border-gray-700 flex justify-between items-center">
-          <h3 className="text-lg font-semibold text-gray-200">
+      <div className="bg-surface rounded-lg border border-border max-w-xl w-full max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-4 border-b border-border flex justify-between items-center">
+          <h3 className="text-lg font-semibold text-fg">
             {result
               ? (result.success === false
                   ? 'Default API Key Rotated — Action Required'
                   : 'Default API Key Rotated')
               : 'Rotate Default API Key'}
           </h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-200 cursor-pointer" aria-label="Close">✕</button>
+          <button onClick={onClose} className="text-fg-muted hover:text-fg cursor-pointer" aria-label="Close">✕</button>
         </div>
 
-        <div className="px-5 py-4 overflow-auto space-y-4 text-sm text-gray-300">
+        <div className="px-5 py-4 overflow-auto space-y-4 text-sm text-fg-muted">
           {error && (
-            <div className="bg-red-900/40 border border-red-700 text-red-300 rounded px-3 py-2">{error}</div>
+            <div className="bg-danger-subtle border border-danger text-danger-fg rounded px-3 py-2">{error}</div>
           )}
 
           {/* Result view */}
@@ -81,17 +81,17 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
             <>
               <p>{result.message}</p>
               <div>
-                <p className="text-gray-400 mb-1">New default API key (shared by all services):</p>
+                <p className="text-fg-muted mb-1">New default API key (shared by all services):</p>
                 <KeyCopy value={result.new_api_key} />
               </div>
               {result.stopped?.length > 0 && (
                 <div>
-                  <p className="text-gray-400">Stopped containers (restart them when ready):</p>
+                  <p className="text-fg-muted">Stopped containers (restart them when ready):</p>
                   <ServiceList names={result.stopped} />
                 </div>
               )}
               {Object.keys(result.stop_errors || {}).length > 0 && (
-                <div className="bg-red-900/40 border border-red-700 text-red-300 rounded px-3 py-2">
+                <div className="bg-danger-subtle border border-danger text-danger-fg rounded px-3 py-2">
                   <p>Some containers failed to stop:</p>
                   <ul className="mt-1 text-xs font-mono space-y-0.5">
                     {Object.entries(result.stop_errors).map(([n, e]) => <li key={n}>• {n}: {e}</li>)}
@@ -99,7 +99,7 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
                 </div>
               )}
               {result.openwebui_registered?.length > 0 && (
-                <div className="bg-amber-900/30 border border-amber-700/60 text-amber-200 rounded px-3 py-2">
+                <div className="bg-warning-subtle border border-warning text-warning-fg rounded px-3 py-2">
                   <p className="font-medium">⚠ Open WebUI still holds the old key</p>
                   <p className="mt-1 text-xs">
                     Open WebUI keeps its own copy of each connection's API key. Update it in
@@ -113,7 +113,7 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
 
           {/* Confirmation view */}
           {!result && !preview && !error && (
-            <p className="text-gray-500">Loading impact…</p>
+            <p className="text-fg-subtle">Loading impact…</p>
           )}
 
           {!result && preview && (
@@ -121,22 +121,22 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
               <p>
                 This generates a new shared API key, writes it to
                 {' '}<span className="font-mono">.env</span> and applies it to all
-                {' '}<span className="font-semibold text-gray-100">{preview.total_services}</span> service(s)
+                {' '}<span className="font-semibold text-fg">{preview.total_services}</span> service(s)
                 in <span className="font-mono">services.json</span> and the compose file.
               </p>
 
               {preview.running.length > 0 ? (
-                <div className="bg-red-900/30 border border-red-700/60 text-red-200 rounded px-3 py-2">
+                <div className="bg-danger-subtle border border-danger text-danger-fg rounded px-3 py-2">
                   <p className="font-medium">⚠ {preview.running.length} running model(s) will be STOPPED</p>
                   <p className="mt-1 text-xs">They keep serving the revoked key until stopped. Restart them manually afterwards.</p>
                   <ServiceList names={preview.running} />
                 </div>
               ) : (
-                <p className="text-gray-500 text-xs">No running models — nothing will be stopped.</p>
+                <p className="text-fg-subtle text-xs">No running models — nothing will be stopped.</p>
               )}
 
               {preview.openwebui_registered.length > 0 && (
-                <div className="bg-amber-900/30 border border-amber-700/60 text-amber-200 rounded px-3 py-2">
+                <div className="bg-warning-subtle border border-warning text-warning-fg rounded px-3 py-2">
                   <p className="font-medium">⚠ Open WebUI needs a manual update</p>
                   <p className="mt-1 text-xs">
                     These services are registered in Open WebUI, which stores its own copy of the key.
@@ -150,20 +150,20 @@ export default function RotateDefaultKeyModal({ onClose, onDone }) {
           )}
         </div>
 
-        <div className="px-5 py-4 border-t border-gray-700 flex justify-end gap-3">
+        <div className="px-5 py-4 border-t border-border flex justify-end gap-3">
           {result ? (
-            <button onClick={onClose} className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors cursor-pointer">
+            <button onClick={onClose} className="px-4 py-2 bg-surface-strong hover:bg-surface-muted text-fg text-sm rounded transition-colors cursor-pointer">
               Done
             </button>
           ) : (
             <>
-              <button onClick={onClose} disabled={rotating} className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors disabled:opacity-50 cursor-pointer">
+              <button onClick={onClose} disabled={rotating} className="px-4 py-2 bg-surface-strong hover:bg-surface-muted text-fg text-sm rounded transition-colors disabled:opacity-50 cursor-pointer">
                 Cancel
               </button>
               <button
                 onClick={handleRotate}
                 disabled={rotating || !preview}
-                className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white text-sm rounded transition-colors disabled:opacity-50 cursor-pointer"
+                className="px-4 py-2 bg-danger hover:bg-danger text-white text-sm rounded transition-colors disabled:opacity-50 cursor-pointer"
               >
                 {rotating ? 'Rotating…' : 'Rotate key'}
               </button>

--- a/dashboard/frontend/src/components/TokenSparkline.jsx
+++ b/dashboard/frontend/src/components/TokenSparkline.jsx
@@ -1,6 +1,13 @@
 import { useEffect, useRef } from 'react'
+import { useTheme } from '../contexts/ThemeContext'
 
 const MAX_POINTS = 50 // 50 × 200ms = 10s of history
+
+// Canvas is immediate-mode; read resolved token values at draw time so a
+// theme swap repaints with the right colors (issue #5 §8).
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+}
 
 function draw(canvas, history) {
   const ctx = canvas.getContext('2d')
@@ -17,7 +24,7 @@ function draw(canvas, history) {
   const pad = 2
 
   // Grid lines
-  ctx.strokeStyle = '#374151'
+  ctx.strokeStyle = cssVar('--color-chart-grid')
   ctx.lineWidth = 0.5
   for (let i = 0; i <= 4; i++) {
     const y = pad + (height - 2 * pad) * (i / 4)
@@ -32,7 +39,7 @@ function draw(canvas, history) {
   const len = points.length
 
   if (len < 2) {
-    ctx.fillStyle = '#6b7280'
+    ctx.fillStyle = cssVar('--color-fg-subtle')
     ctx.font = '13px sans-serif'
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
@@ -56,16 +63,17 @@ function draw(canvas, history) {
     ctx.stroke()
   }
 
-  drawLine(dp => dp.promptTokensRate || 0, '#3b82f6')
-  drawLine(dp => dp.generationTokensRate || 0, '#22c55e')
+  drawLine(dp => dp.promptTokensRate || 0, cssVar('--color-chart-memory'))
+  drawLine(dp => dp.generationTokensRate || 0, cssVar('--color-chart-compute'))
 }
 
 export default function TokenSparkline({ history }) {
   const canvasRef = useRef(null)
+  const { theme } = useTheme()
 
   useEffect(() => {
     if (canvasRef.current) draw(canvasRef.current, history)
-  }, [history])
+  }, [history, theme])
 
   const latest = history.length > 0 ? history[history.length - 1] : null
   const promptRate = latest?.promptTokensRate
@@ -75,19 +83,19 @@ export default function TokenSparkline({ history }) {
   const genMax = visiblePoints.length >= 2 ? Math.max(1, ...visiblePoints.map(p => p.generationTokensRate || 0)) : null
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+    <div className="bg-surface rounded-lg border border-border p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium text-gray-400">Token Throughput</h3>
+        <h3 className="text-sm font-medium text-fg-muted">Token Throughput</h3>
         <div className="flex items-center gap-4 text-xs">
           <div className="flex items-center gap-1.5">
-            <span className="w-3 h-0.5 bg-blue-500 rounded inline-block" />
-            <span className="text-gray-400">Prompt:</span>
-            {promptMax !== null && <span className="text-gray-500">max {promptMax.toFixed(1)} t/s</span>}
+            <span className="w-3 h-0.5 bg-chart-memory rounded inline-block" />
+            <span className="text-fg-muted">Prompt:</span>
+            {promptMax !== null && <span className="text-fg-subtle">max {promptMax.toFixed(1)} t/s</span>}
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="w-3 h-0.5 bg-green-500 rounded inline-block" />
-            <span className="text-gray-400">Gen:</span>
-            {genMax !== null && <span className="text-gray-500">max {genMax.toFixed(1)} t/s</span>}
+            <span className="w-3 h-0.5 bg-chart-compute rounded inline-block" />
+            <span className="text-fg-muted">Gen:</span>
+            {genMax !== null && <span className="text-fg-subtle">max {genMax.toFixed(1)} t/s</span>}
           </div>
         </div>
       </div>
@@ -97,14 +105,14 @@ export default function TokenSparkline({ history }) {
       {latest && (
         <div className="mt-2 text-xs font-mono flex items-center gap-4">
           <div className="flex items-center gap-1.5">
-            <span className="w-3 h-0.5 bg-blue-500 rounded inline-block" />
-            <span className="text-gray-400">Prompt:</span>
-            <span className="text-gray-300">{promptRate !== undefined ? `${promptRate.toFixed(1)} t/s` : '—'}</span>
+            <span className="w-3 h-0.5 bg-chart-memory rounded inline-block" />
+            <span className="text-fg-muted">Prompt:</span>
+            <span className="text-fg-muted">{promptRate !== undefined ? `${promptRate.toFixed(1)} t/s` : '—'}</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="w-3 h-0.5 bg-green-500 rounded inline-block" />
-            <span className="text-gray-400">Gen:</span>
-            <span className="text-gray-300">{genRate !== undefined ? `${genRate.toFixed(1)} t/s` : '—'}</span>
+            <span className="w-3 h-0.5 bg-chart-compute rounded inline-block" />
+            <span className="text-fg-muted">Gen:</span>
+            <span className="text-fg-muted">{genRate !== undefined ? `${genRate.toFixed(1)} t/s` : '—'}</span>
           </div>
         </div>
       )}

--- a/dashboard/frontend/src/components/tools/RegistryEditor.jsx
+++ b/dashboard/frontend/src/components/tools/RegistryEditor.jsx
@@ -78,43 +78,43 @@ export default function RegistryEditor({ initialContent, configPath, externalErr
   }
 
   return (
-    <div className="border border-gray-700 rounded bg-gray-900">
-      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-700">
-        <div className="text-sm text-gray-300">
-          <i className="fa-solid fa-file-code mr-2 text-gray-500"></i>
+    <div className="border border-border rounded bg-app">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border">
+        <div className="text-sm text-fg-muted">
+          <i className="fa-solid fa-file-code mr-2 text-fg-subtle"></i>
           External registry JSON
           {configPath && (
-            <span className="ml-2 text-xs text-gray-500 font-mono">{configPath}</span>
+            <span className="ml-2 text-xs text-fg-subtle font-mono">{configPath}</span>
           )}
         </div>
         <div className="flex items-center gap-2">
-          {savedNote && <span className="text-xs text-green-400">{savedNote}</span>}
-          {dirty && <span className="text-xs text-yellow-400">Unsaved</span>}
+          {savedNote && <span className="text-xs text-success-fg">{savedNote}</span>}
+          {dirty && <span className="text-xs text-warning-fg">Unsaved</span>}
           <button
             onClick={handleInsertExample}
             disabled={busy}
-            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+            className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
           >
             Insert example
           </button>
           <button
             onClick={handleDiscard}
             disabled={busy || !dirty}
-            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+            className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
           >
             Discard
           </button>
           <button
             onClick={handleReload}
             disabled={busy}
-            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+            className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
           >
             Reload from disk
           </button>
           <button
             onClick={handleSave}
             disabled={busy || !dirty}
-            className="text-xs px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white"
+            className="text-xs px-2 py-1 rounded bg-accent-strong hover:bg-accent-hover disabled:opacity-50 text-white"
           >
             Save
           </button>
@@ -125,26 +125,26 @@ export default function RegistryEditor({ initialContent, configPath, externalErr
         value={content}
         onChange={(e) => onChange(e.target.value)}
         spellCheck={false}
-        className="w-full h-72 bg-gray-950 text-gray-200 font-mono text-xs p-3 focus:outline-none resize-y"
+        className="w-full h-72 bg-surface-muted text-fg font-mono text-xs p-3 focus:outline-none resize-y"
         placeholder='{ "my-tool": { "enabled": true, "name": "...", "command": "/abs/path", "args": [], ... } }'
       />
 
       {(loadError || saveError || (externalErrors && externalErrors.length > 0) || saveEntryErrors.length > 0) && (
-        <div className="px-3 py-2 border-t border-gray-700 text-xs space-y-1">
+        <div className="px-3 py-2 border-t border-border text-xs space-y-1">
           {loadError && (
-            <div className="text-red-400"><i className="fa-solid fa-triangle-exclamation mr-1"></i>Load: {loadError}</div>
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>Load: {loadError}</div>
           )}
           {saveError && (
-            <div className="text-red-400"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{saveError}</div>
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{saveError}</div>
           )}
           {saveEntryErrors.map((err, i) => (
-            <div key={`save-${i}`} className="text-red-300">
-              <span className="font-mono text-gray-500">{err.entry_id || '(top-level)'}:</span> {err.message}
+            <div key={`save-${i}`} className="text-danger-fg">
+              <span className="font-mono text-fg-subtle">{err.entry_id || '(top-level)'}:</span> {err.message}
             </div>
           ))}
           {externalErrors && externalErrors.map((err, i) => (
-            <div key={`ext-${i}`} className="text-yellow-300">
-              <span className="font-mono text-gray-500">{err.entry_id || '(top-level)'}:</span> {err.message}
+            <div key={`ext-${i}`} className="text-warning-fg">
+              <span className="font-mono text-fg-subtle">{err.entry_id || '(top-level)'}:</span> {err.message}
             </div>
           ))}
         </div>

--- a/dashboard/frontend/src/components/tools/ServerTestPanel.jsx
+++ b/dashboard/frontend/src/components/tools/ServerTestPanel.jsx
@@ -34,18 +34,18 @@ function ToolRow({ serverId, tool }) {
   }
 
   return (
-    <div className="border border-gray-700 rounded bg-gray-900 p-3 space-y-2">
+    <div className="border border-border rounded bg-app p-3 space-y-2">
       <div className="flex items-baseline justify-between gap-2">
         <div>
-          <span className="font-mono text-sm text-yellow-300">{tool.name}</span>
+          <span className="font-mono text-sm text-warning-fg">{tool.name}</span>
           {tool.description && (
-            <span className="ml-2 text-xs text-gray-400">{tool.description}</span>
+            <span className="ml-2 text-xs text-fg-muted">{tool.description}</span>
           )}
         </div>
         <button
           onClick={run}
           disabled={busy}
-          className="text-xs px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white"
+          className="text-xs px-2 py-1 rounded bg-accent-strong hover:bg-accent-hover disabled:opacity-50 text-white"
         >
           {busy ? 'Running…' : 'Run'}
         </button>
@@ -55,27 +55,27 @@ function ToolRow({ serverId, tool }) {
         onChange={(e) => setArgs(e.target.value)}
         spellCheck={false}
         rows={3}
-        className="w-full bg-gray-950 text-gray-200 font-mono text-xs p-2 rounded border border-gray-700 focus:outline-none focus:border-gray-500"
+        className="w-full bg-surface-muted text-fg font-mono text-xs p-2 rounded border border-border focus:outline-none focus:border-accent"
         placeholder='{"query": "example"}'
       />
       {error && (
-        <div className="text-xs text-red-400">
+        <div className="text-xs text-danger-fg">
           <i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}
         </div>
       )}
       {result && (
         <div className="text-xs space-y-1">
-          <div className="text-green-400">
+          <div className="text-success-fg">
             <i className="fa-solid fa-check mr-1"></i>Result
           </div>
           {result.artifacts && result.artifacts.length > 0 && (
-            <div className="text-gray-400">
+            <div className="text-fg-muted">
               Artifacts: {result.artifacts.map((a, i) => (
                 <span key={i} className="ml-1 font-mono">[{a.type}{a.content_size ? ` ${a.content_size}b` : ''}]</span>
               ))}
             </div>
           )}
-          <pre className="bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 max-h-72 overflow-auto whitespace-pre-wrap">{result.result_text}</pre>
+          <pre className="bg-surface-muted border border-border rounded p-2 text-fg max-h-72 overflow-auto whitespace-pre-wrap">{result.result_text}</pre>
         </div>
       )}
     </div>
@@ -107,7 +107,7 @@ export default function ServerTestPanel({ server }) {
 
   if (!server.enabled) {
     return (
-      <div className="text-xs text-gray-500 italic">
+      <div className="text-xs text-fg-subtle italic">
         Server is disabled in config. Enable it to test.
       </div>
     )
@@ -119,18 +119,18 @@ export default function ServerTestPanel({ server }) {
         <button
           onClick={discover}
           disabled={busy}
-          className="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-50"
+          className="text-xs px-3 py-1.5 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
         >
           {busy ? 'Discovering…' : 'List tools'}
         </button>
         {tools && (
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-fg-muted">
             {tools.length} tool{tools.length === 1 ? '' : 's'}
           </span>
         )}
       </div>
       {error && (
-        <div className="text-xs text-red-400">
+        <div className="text-xs text-danger-fg">
           <i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}
         </div>
       )}
@@ -142,7 +142,7 @@ export default function ServerTestPanel({ server }) {
         </div>
       )}
       {tools && tools.length === 0 && (
-        <div className="text-xs text-gray-500 italic">Server advertises no tools.</div>
+        <div className="text-xs text-fg-subtle italic">Server advertises no tools.</div>
       )}
     </div>
   )

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -9,21 +9,21 @@ function ServerRow({ server, selected, onSelect }) {
       onClick={() => onSelect(server.id)}
       className={`w-full text-left px-3 py-2 rounded border ${
         selected
-          ? 'bg-gray-800 border-gray-600'
-          : 'bg-gray-900 border-transparent hover:bg-gray-800/70'
+          ? 'bg-surface border-border-strong'
+          : 'bg-app border-transparent hover:bg-surface-muted'
       }`}
     >
       <div className="flex items-center gap-3">
-        <i className={`fa-solid ${server.icon} text-gray-400 w-4 text-center`}></i>
+        <i className={`fa-solid ${server.icon} text-fg-muted w-4 text-center`}></i>
         <div className="flex-1 min-w-0">
-          <div className="text-sm text-gray-200 truncate">{server.name}</div>
-          <div className="text-[11px] text-gray-500 truncate">{server.description}</div>
+          <div className="text-sm text-fg truncate">{server.name}</div>
+          <div className="text-[11px] text-fg-subtle truncate">{server.description}</div>
         </div>
         {!server.enabled && (
-          <span className="text-[10px] uppercase tracking-wide text-gray-500 border border-gray-700 px-1.5 py-0.5 rounded">disabled</span>
+          <span className="text-[10px] uppercase tracking-wide text-fg-subtle border border-border px-1.5 py-0.5 rounded">disabled</span>
         )}
         {server.command_exists === false && (
-          <span className="text-[10px] uppercase tracking-wide text-red-300 border border-red-800 px-1.5 py-0.5 rounded">no command</span>
+          <span className="text-[10px] uppercase tracking-wide text-danger-fg border border-danger px-1.5 py-0.5 rounded">no command</span>
         )}
       </div>
     </button>
@@ -36,41 +36,41 @@ function ServerDetails({ server, registryErrors }) {
     <div className="space-y-3">
       <div>
         <div className="flex items-center gap-3">
-          <i className={`fa-solid ${server.icon} text-gray-400`}></i>
-          <h2 className="text-lg text-gray-100">{server.name}</h2>
+          <i className={`fa-solid ${server.icon} text-fg-muted`}></i>
+          <h2 className="text-lg text-fg">{server.name}</h2>
           <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${
             server.source === 'built-in'
-              ? 'border-blue-700 text-blue-300'
+              ? 'border-accent text-accent-fg-hover'
               : 'border-purple-700 text-purple-300'
           }`}>{server.source}</span>
           {!server.enabled && (
-            <span className="text-[10px] uppercase tracking-wide text-gray-500 border border-gray-700 px-1.5 py-0.5 rounded">disabled</span>
+            <span className="text-[10px] uppercase tracking-wide text-fg-subtle border border-border px-1.5 py-0.5 rounded">disabled</span>
           )}
         </div>
-        <p className="text-sm text-gray-400 mt-1">{server.description}</p>
+        <p className="text-sm text-fg-muted mt-1">{server.description}</p>
       </div>
 
       {server.source === 'built-in' ? (
-        <div className="text-xs text-gray-500 bg-gray-900 border border-gray-800 rounded px-3 py-2">
+        <div className="text-xs text-fg-subtle bg-app border border-border rounded px-3 py-2">
           Built-in server. Defined in <span className="font-mono">dashboard/chat/mcp_registry.py</span>. Edit via code.
         </div>
       ) : (
-        <div className="bg-gray-900 border border-gray-800 rounded px-3 py-2 space-y-1 text-xs">
+        <div className="bg-app border border-border rounded px-3 py-2 space-y-1 text-xs">
           <div>
-            <span className="text-gray-500">command:</span>{' '}
-            <span className="font-mono text-gray-200">{server.command}</span>
+            <span className="text-fg-subtle">command:</span>{' '}
+            <span className="font-mono text-fg">{server.command}</span>
             {server.command_exists === false && (
-              <span className="ml-2 text-red-300">(not found on disk)</span>
+              <span className="ml-2 text-danger-fg">(not found on disk)</span>
             )}
           </div>
           {server.args && server.args.length > 0 && (
             <div>
-              <span className="text-gray-500">args:</span>{' '}
-              <span className="font-mono text-gray-200">{server.args.join(' ')}</span>
+              <span className="text-fg-subtle">args:</span>{' '}
+              <span className="font-mono text-fg">{server.args.join(' ')}</span>
             </div>
           )}
           {server.command_exists === false && (
-            <div className="text-red-300 mt-1">
+            <div className="text-danger-fg mt-1">
               <i className="fa-solid fa-triangle-exclamation mr-1"></i>
               Hidden from chat until the command exists.
             </div>
@@ -79,14 +79,14 @@ function ServerDetails({ server, registryErrors }) {
       )}
 
       {entryError && (
-        <div className="text-xs text-red-400 bg-red-950/30 border border-red-900 rounded px-3 py-2">
+        <div className="text-xs text-danger-fg bg-danger-subtle border border-danger rounded px-3 py-2">
           <i className="fa-solid fa-triangle-exclamation mr-1"></i>
           {entryError.message}
         </div>
       )}
 
-      <div className="pt-2 border-t border-gray-800">
-        <h3 className="text-xs uppercase tracking-wide text-gray-500 mb-2">Test</h3>
+      <div className="pt-2 border-t border-border">
+        <h3 className="text-xs uppercase tracking-wide text-fg-subtle mb-2">Test</h3>
         <ServerTestPanel server={server} />
       </div>
     </div>
@@ -111,14 +111,14 @@ export default function ToolsPage() {
 
   if (loading) {
     return (
-      <div className="p-6 text-gray-400">
+      <div className="p-6 text-fg-muted">
         <i className="fa-solid fa-spinner fa-spin mr-2"></i>Loading registry…
       </div>
     )
   }
   if (error) {
     return (
-      <div className="p-6 text-red-400">
+      <div className="p-6 text-danger-fg">
         <i className="fa-solid fa-triangle-exclamation mr-2"></i>{error}
       </div>
     )
@@ -127,8 +127,8 @@ export default function ToolsPage() {
   return (
     <div className="space-y-4 max-w-6xl">
       <div>
-        <h1 className="text-xl text-gray-100">Tools</h1>
-        <p className="text-sm text-gray-400">
+        <h1 className="text-xl text-fg">Tools</h1>
+        <p className="text-sm text-fg-muted">
           MCP servers available to the chat. Built-in servers ship with the dashboard; external servers are
           declared in a JSON file on disk.
         </p>
@@ -146,7 +146,7 @@ export default function ToolsPage() {
       <div className="grid grid-cols-[280px_1fr] gap-4">
         <div className="space-y-3">
           <div>
-            <div className="text-[11px] uppercase tracking-wide text-gray-500 mb-1 px-1">Built-in</div>
+            <div className="text-[11px] uppercase tracking-wide text-fg-subtle mb-1 px-1">Built-in</div>
             <div className="space-y-1">
               {grouped.builtin.map((s) => (
                 <ServerRow key={s.id} server={s} selected={selected?.id === s.id} onSelect={setSelectedId} />
@@ -154,10 +154,10 @@ export default function ToolsPage() {
             </div>
           </div>
           <div>
-            <div className="text-[11px] uppercase tracking-wide text-gray-500 mb-1 px-1">External</div>
+            <div className="text-[11px] uppercase tracking-wide text-fg-subtle mb-1 px-1">External</div>
             <div className="space-y-1">
               {grouped.external.length === 0 && (
-                <div className="text-xs text-gray-500 italic px-1">None configured. Add some in the editor above.</div>
+                <div className="text-xs text-fg-subtle italic px-1">None configured. Add some in the editor above.</div>
               )}
               {grouped.external.map((s) => (
                 <ServerRow key={s.id} server={s} selected={selected?.id === s.id} onSelect={setSelectedId} />
@@ -166,11 +166,11 @@ export default function ToolsPage() {
           </div>
         </div>
 
-        <div className="bg-gray-900/50 border border-gray-800 rounded p-4">
+        <div className="bg-surface-muted border border-border rounded p-4">
           {selected ? (
             <ServerDetails server={selected} registryErrors={data?.external_errors} />
           ) : (
-            <div className="text-sm text-gray-500">No servers registered.</div>
+            <div className="text-sm text-fg-subtle">No servers registered.</div>
           )}
         </div>
       </div>


### PR DESCRIPTION
Final PR of 4 for the v2 theme system. Tracker: #5. Builds on #35/#36/#37. Completes the theme system app-wide — closes #5.

## Scope (PR 4 — canvas/SVG + remaining cleanup)
- **`GpuGraph`, `TokenSparkline`** (canvas): canvas is immediate-mode and can't ride the CSS cascade. Added a `cssVar()` helper (`getComputedStyle(documentElement)`), read `--color-chart-*` / `--color-fg-subtle` at draw time, and added `theme` (`useTheme`) to the `useEffect` deps so the chart repaints on a swap. DOM chrome migrated; legend swatches use `bg-chart-memory`/`bg-chart-compute` so they match the drawn lines.
- **`GaugesRow`** (SVG): themed chrome via CSS-driven `stroke-chart-grid` / `fill-chart-axis-label` utilities — these re-resolve automatically on a `[data-theme]` flip with **no JS**. Categorical threshold hexes (KV good/warn/bad, prefix, spec) kept as JS constants per issue #5 §8 — they're asserted by `GaugesRow.test` which stays green, unchanged.
- **`RotateDefaultKeyModal` + `tools/` (`ToolsPage`, `RegistryEditor`, `ServerTestPanel`)**: stragglers not in the issue's §7 list (they post-date the issue) but are reachable routes that would render wrong in light. Migrated to semantic tokens so no route is left broken. Filled primary buttons use `bg-accent-strong` + `hover:bg-accent-hover` + explicit inverse text (the AA-contrast pattern established in #37).

## Result
Zero residual raw color utilities remain anywhere in `src` — verified by sweep. Documented-intentional exceptions only: the #29 brand-mark gradient, `bg-white` render/preview canvases, purple spinoff/external-source badges (purple not in the theme palette, consistent with `text-purple-400` left throughout), slate tooltip, `bg-black/<n>` modal scrims.

## Verification
- `npm run build` OK; `npm test` 44/44 (incl. `GaugesRow.test` unchanged & green); no new lint errors (6 pre-existing on `main`).
- Playwright smoke (local `vite preview`, `/v2/tools`): dark + light toggle via Header switcher, `localStorage` persistence, **0** console errors, **0** residual raw color classes in the rendered DOM. Canvas repaint is wired (theme in deps + `getComputedStyle` reads); SVG is CSS-driven/auto-reactive. No local backend so the charts have no data to draw — repaint mechanism verified by construction + build/tests.

## Issue #5 status
With this merged, all four PRs of the owner's sequence are done: #35 foundation+shell, #36 services/GPU, #37 chat+typography, #38 canvas/SVG+cleanup. Dark/light theme works on every route; OS-following is first-load-only; the architecture supports adding a 3rd theme with zero JSX edits (just a `[data-theme="…"]` block + a `META` entry).