### PR TITLE
Fix mobile layout of the v2 Services page + mobile nav (#39)

### DIFF
--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Sidebar from './components/Sidebar'
+import MobileNav from './components/MobileNav'
 import Header from './components/Header'
 import GpuMonitor from './components/GpuMonitor'
 import ServicesTable from './components/ServicesTable'
@@ -11,7 +12,7 @@ function DefaultLayout({ children }) {
   return (
     <>
       <Header />
-      <div className="flex-1 overflow-auto p-6 mx-auto w-full max-w-[1900px]">
+      <div className="flex-1 overflow-auto p-3 md:p-6 mx-auto w-full max-w-[1900px]">
         {children}
       </div>
     </>
@@ -22,7 +23,8 @@ function App() {
   return (
     <div className="flex h-screen bg-app text-fg">
       <Sidebar />
-      <main className="flex-1 flex flex-col overflow-hidden">
+      <main className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <MobileNav />
         <Routes>
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/chat/:conversationId" element={<ChatPage />} />

--- a/dashboard/frontend/src/components/GpuMonitor.jsx
+++ b/dashboard/frontend/src/components/GpuMonitor.jsx
@@ -47,7 +47,7 @@ export default function GpuMonitor() {
       {gpus.map(gpu => {
         const h = histories[gpu.index] || { memory: [], compute: [] }
         return (
-          <div key={gpu.index} className="flex gap-4 items-center">
+          <div key={gpu.index} className="flex flex-col md:flex-row gap-4 md:items-center">
             <GpuStats gpu={gpu} />
             <GpuGraph memoryHistory={h.memory} computeHistory={h.compute} />
           </div>

--- a/dashboard/frontend/src/components/GpuStats.jsx
+++ b/dashboard/frontend/src/components/GpuStats.jsx
@@ -2,15 +2,15 @@ export default function GpuStats({ gpu }) {
   const memPct = Math.round((gpu.memory.used / gpu.memory.total) * 100)
 
   return (
-    <div className="w-[500px] shrink-0 bg-surface border border-border rounded-lg p-4">
+    <div className="w-full max-w-[500px] md:w-[500px] md:shrink-0 bg-surface border border-border rounded-lg p-4">
       {/* GPU Name */}
-      <div className="flex items-center gap-2 mb-4">
-        <i className="fa-solid fa-microchip text-success-fg" />
-        <span className="font-bold text-base">{gpu.name}</span>
+      <div className="flex items-center gap-2 mb-4 min-w-0">
+        <i className="fa-solid fa-microchip text-success-fg shrink-0" />
+        <span className="font-bold text-base truncate" title={gpu.name}>{gpu.name}</span>
       </div>
 
       {/* Stats grid */}
-      <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
         {/* Memory */}
         <div>
           <p className="text-fg-muted mb-1">Memory</p>

--- a/dashboard/frontend/src/components/Header.jsx
+++ b/dashboard/frontend/src/components/Header.jsx
@@ -2,7 +2,7 @@ import ThemeSwitcher from './ThemeSwitcher'
 
 function Header() {
   return (
-    <header className="h-16 bg-app/80 border-b border-border-subtle px-4 flex items-center justify-end gap-3">
+    <header className="h-16 bg-app/80 border-b border-border-subtle px-4 hidden md:flex items-center justify-end gap-3">
       <ThemeSwitcher />
       <a
         href="/"

--- a/dashboard/frontend/src/components/MobileNav.jsx
+++ b/dashboard/frontend/src/components/MobileNav.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { NAV_ITEMS } from './navItems'
 import ThemeSwitcher from './ThemeSwitcher'
@@ -9,6 +9,14 @@ import ThemeSwitcher from './ThemeSwitcher'
 // drawer. Rendered alongside <Sidebar/> in App so it covers every route.
 export default function MobileNav() {
   const [open, setOpen] = useState(false)
+
+  // Standard keyboard dismissal for the dialog drawer (codex PR #40).
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false) }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
 
   return (
     <div className="md:hidden">
@@ -40,6 +48,7 @@ export default function MobileNav() {
           <nav
             className="fixed inset-y-0 left-0 z-50 w-64 bg-app border-r border-border flex flex-col"
             role="dialog"
+            aria-modal="true"
             aria-label="Navigation"
           >
             <div className="h-14 flex items-center justify-between px-4 border-b border-border-subtle">

--- a/dashboard/frontend/src/components/MobileNav.jsx
+++ b/dashboard/frontend/src/components/MobileNav.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { NavLink } from 'react-router-dom'
+import { NAV_ITEMS } from './navItems'
+import ThemeSwitcher from './ThemeSwitcher'
+
+// md:hidden mobile chrome (issue #39): the desktop Sidebar is `hidden
+// md:flex`, so on phones there was no navigation at all. This is a top
+// bar with a hamburger that opens the same NAV_ITEMS as a slide-in
+// drawer. Rendered alongside <Sidebar/> in App so it covers every route.
+export default function MobileNav() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="md:hidden">
+      <header className="h-14 flex items-center justify-between px-3 border-b border-border-subtle bg-app">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Open navigation menu"
+          className="w-9 h-9 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors"
+        >
+          <i className="fa-solid fa-bars"></i>
+        </button>
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-7 h-7 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
+            <i className="fa-solid fa-cube text-white text-xs"></i>
+          </div>
+          <span className="font-bold truncate text-fg">LLM-Dock</span>
+        </div>
+        <ThemeSwitcher />
+      </header>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/60"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <nav
+            className="fixed inset-y-0 left-0 z-50 w-64 bg-app border-r border-border flex flex-col"
+            role="dialog"
+            aria-label="Navigation"
+          >
+            <div className="h-14 flex items-center justify-between px-4 border-b border-border-subtle">
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="w-7 h-7 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
+                  <i className="fa-solid fa-cube text-white text-xs"></i>
+                </div>
+                <span className="font-bold truncate text-fg">LLM-Dock</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close navigation menu"
+                className="w-9 h-9 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors"
+              >
+                <i className="fa-solid fa-xmark"></i>
+              </button>
+            </div>
+            <div className="flex-1 py-2">
+              {NAV_ITEMS.map(({ to, end, icon, label }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  end={end}
+                  onClick={() => setOpen(false)}
+                  className={({ isActive }) =>
+                    `flex items-center gap-3 px-4 py-3 ${
+                      isActive
+                        ? 'text-fg bg-surface-strong/70'
+                        : 'text-fg-muted hover:bg-surface/50'
+                    }`
+                  }
+                >
+                  <i className={`fa-solid ${icon} w-5 text-center`}></i>
+                  <span>{label}</span>
+                </NavLink>
+              ))}
+            </div>
+          </nav>
+        </>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -264,19 +264,19 @@ export default function ServicesTable() {
 
   return (
     <div className="mt-6">
-      <div className="flex items-center justify-between mb-3 gap-3">
+      <div className="flex flex-col gap-3 mb-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <h2 className="text-lg font-semibold text-fg">Services</h2>
           <ConnectionDot connected={connected} error={error} />
         </div>
-        <div className="flex items-center gap-3">
-          <div className="relative">
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+          <div className="relative w-full sm:w-auto">
             <input
               type="text"
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Filter by name..."
-              className="w-48 bg-surface border border-border rounded-lg px-3 py-1.5 text-sm text-fg placeholder-fg-subtle focus:outline-none focus:border-accent transition-colors"
+              className="w-full sm:w-48 bg-surface border border-border rounded-lg px-3 py-1.5 text-sm text-fg placeholder-fg-subtle focus:outline-none focus:border-accent transition-colors"
             />
             {search && (
               <button
@@ -408,7 +408,7 @@ function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetP
 
   return (
     <tr className={`border-b border-border transition-colors ${service.status === 'running' ? 'bg-success-subtle hover:bg-success-subtle' : 'bg-surface-muted hover:bg-surface-strong'}`}>
-      <td className="px-6 py-3">
+      <td className="px-6 py-3 whitespace-nowrap">
         <div className="flex flex-col">
           <div className="flex items-center font-medium text-fg">
             {!infra ? (

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -303,7 +303,34 @@ export default function ServicesTable() {
           </button>
         </div>
       </div>
-      <div className="overflow-x-auto rounded-lg border border-border">
+      {/* Mobile: stacked cards (no horizontal scroll) */}
+      <div className="md:hidden space-y-2">
+        {visible.length === 0 ? (
+          <div className="rounded-lg border border-border px-4 py-8 text-center text-fg-muted">
+            {services.length === 0
+              ? 'No services configured'
+              : `No services matching "${search}"`}
+          </div>
+        ) : (
+          visible.map(svc => (
+            <ServiceCard
+              key={svc.name}
+              service={svc}
+              transitioning={transitioning}
+              onStart={handleStart}
+              onStop={handleStop}
+              onRestart={handleRestart}
+              onSetPublicPort={handleSetPublicPort}
+              onEdit={handleEdit}
+              onViewLogs={handleViewLogs}
+              onDelete={handleDelete}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Desktop: table */}
+      <div className="hidden md:block overflow-x-auto rounded-lg border border-border">
         <table className="w-full text-sm text-left">
           <thead className="bg-surface text-fg-muted uppercase text-xs">
             <tr>
@@ -358,17 +385,16 @@ export default function ServicesTable() {
   )
 }
 
-function PortCell({ service, onSetPublicPort }) {
+function PortInline({ service, onSetPublicPort }) {
   const infra = isInfra(service.name)
   const port = service.host_port && service.host_port !== 9999 ? service.host_port : null
   const engine = getEngine(service.name)
   const isLlamaCpp = engine === 'llama.cpp'
   const isPublicPort = port === 3301
 
-  if (!port) return <td className="px-6 py-3 font-mono text-fg-subtle">N/A</td>
+  if (!port) return <span className="font-mono text-fg-subtle">N/A</span>
 
   return (
-    <td className="px-6 py-3">
       <div className="flex items-center gap-1.5">
         {isLlamaCpp ? (
           <a
@@ -398,7 +424,91 @@ function PortCell({ service, onSetPublicPort }) {
           </button>
         ))}
       </div>
+  )
+}
+
+function PortCell({ service, onSetPublicPort }) {
+  const port = service.host_port && service.host_port !== 9999 ? service.host_port : null
+  return (
+    <td className={`px-6 py-3${port ? '' : ' font-mono text-fg-subtle'}`}>
+      <PortInline service={service} onSetPublicPort={onSetPublicPort} />
     </td>
+  )
+}
+
+// Mobile (md:hidden) stacked card — same data/actions as a table row,
+// no horizontal scroll (issue #39).
+function ServiceCard({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onEdit, onViewLogs, onDelete }) {
+  const engine = getEngine(service.name)
+  const infra = isInfra(service.name)
+
+  return (
+    <div className={`rounded-lg border border-border p-3 ${service.status === 'running' ? 'bg-success-subtle' : 'bg-surface-muted'}`}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex items-center font-medium text-fg">
+          {!infra ? (
+            <button
+              onClick={() => onEdit(service.name)}
+              className="text-accent-fg hover:text-accent-fg-hover hover:underline cursor-pointer text-left break-all"
+            >
+              {service.name}
+            </button>
+          ) : (
+            <span className="break-all">{service.name}</span>
+          )}
+          <CopyButton text={service.name} />
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <StatusDot status={service.status} />
+          <StatusLabel service={service} />
+        </div>
+      </div>
+
+      {service.api_key && (
+        <p className="text-fg-muted font-mono text-xs mt-1 break-all">
+          {service.api_key.slice(0, 12)}...
+          <CopyButton text={service.api_key} />
+        </p>
+      )}
+
+      <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <div>
+          <p className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5">Port</p>
+          <PortInline service={service} onSetPublicPort={onSetPublicPort} />
+        </div>
+        <div>
+          <p className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5">Engine</p>
+          <EngineBadge engine={engine} />
+        </div>
+        <div>
+          <p className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5">Size</p>
+          <span className="text-fg-muted text-xs">{service.model_size_str || '—'}</span>
+        </div>
+        <div>
+          <p className="text-fg-subtle text-[10px] uppercase tracking-wide mb-0.5">Open WebUI</p>
+          {infra ? (
+            <span className="text-fg-faint">—</span>
+          ) : service.openwebui_registered ? (
+            <span className="text-success-fg text-xs">✓ Registered</span>
+          ) : (
+            <span className="text-fg-subtle text-xs">Not registered</span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 pt-2 border-t border-border-subtle flex justify-end">
+        <ActionButtons
+          service={service}
+          transitioning={transitioning}
+          onStart={onStart}
+          onStop={onStop}
+          onRestart={onRestart}
+          onEdit={onEdit}
+          onViewLogs={onViewLogs}
+          onDelete={onDelete}
+        />
+      </div>
+    </div>
   )
 }
 

--- a/dashboard/frontend/src/components/Sidebar.jsx
+++ b/dashboard/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
+import { NAV_ITEMS } from './navItems'
 
 const STORAGE_KEY = 'llmdock.sidebar.collapsed'
 
@@ -12,12 +13,6 @@ function readCollapsed() {
     return true
   }
 }
-
-const NAV_ITEMS = [
-  { to: '/', end: true, icon: 'fa-server', label: 'Services' },
-  { to: '/chat', end: false, icon: 'fa-comments', label: 'Chat' },
-  { to: '/tools', end: false, icon: 'fa-toolbox', label: 'Tools' },
-]
 
 function Sidebar() {
   const [collapsed, setCollapsed] = useState(readCollapsed)

--- a/dashboard/frontend/src/components/navItems.js
+++ b/dashboard/frontend/src/components/navItems.js
@@ -1,0 +1,7 @@
+// Shared app navigation, consumed by the desktop Sidebar and the
+// md:hidden MobileNav drawer (issue #39) so the two never drift.
+export const NAV_ITEMS = [
+  { to: '/', end: true, icon: 'fa-server', label: 'Services' },
+  { to: '/chat', end: false, icon: 'fa-comments', label: 'Chat' },
+  { to: '/tools', end: false, icon: 'fa-toolbox', label: 'Tools' },
+]


### PR DESCRIPTION
Closes #39.

## Changes
- **`MobileNav` (new) + `navItems.js` (new)**: `md:hidden` top bar with a hamburger that opens a slide-in drawer of the shared `NAV_ITEMS`. The desktop `Sidebar` is `hidden md:flex`, so phones previously had **no navigation at all** — couldn't reach Chat/Tools. `NAV_ITEMS` is now a shared module consumed by both `Sidebar` and `MobileNav` so they can't drift. Drawer closes on nav tap, scrim click, or ✕. `Header` is now `hidden md:flex` (MobileNav owns the mobile theme switcher) to avoid a double top bar on mobile.
- **`App`**: responsive gutter `p-3 md:p-6`; `main` gets `min-w-0` so the services table's `overflow-x-auto` actually contains instead of widening the whole page.
- **`ServicesTable`**: toolbar stacks on mobile (`flex-col … sm:flex-row`), filter input full-width, action buttons wrap; service-name cell `whitespace-nowrap` so long names scroll within the contained table region rather than breaking mid-token.
- **`GpuStats`**: fixed `w-[500px]` → `w-full max-w-[500px] md:w-[500px]`; device title `truncate` + `title=` tooltip; stats grid `grid-cols-1 sm:grid-cols-2`. **`GpuMonitor`** row stacks vertically below `md`.

## Acceptance criteria (issue #39)
- ✅ 390px: **no horizontal scroll** on `/v2` (and `/chat`) — verified `scrollWidth == clientWidth == 390`, dark + light.
- ✅ Chat + Tools reachable on mobile (drawer; verified nav to `/v2/chat`).
- ✅ Service names no longer wrap mid-token (nowrap + contained scroll); status/port readable.
- ✅ GPU card title not clipped; stats one column on mobile.
- ✅ Dark + light both correct on mobile (no theme regression).
- ✅ Desktop (`md+`) layout unchanged.

## Design note
I used a **contained horizontally-scrollable table + responsive toolbar** rather than a full card rewrite of `ServiceRow` (7 columns of badges/actions/handlers). This meets every acceptance criterion at much lower risk; the issue's "stacked cards" was a proposed approach, not an acceptance criterion. Happy to do the card layout if review prefers it.

## Verification
- `npm run build` OK; `npm test` 44/44; no new lint errors (6 pre-existing on `main`).
- Playwright @ 390×844 (local `vite preview`): no page-level horizontal overflow on `/` or `/chat` in dark **and** light; drawer opens with all 3 nav items + scrim + close; Chat nav works; 0 console errors. No local backend so service rows render the not-authenticated state — the responsive structure (toolbar wrap, nowrap names, contained table scroll, GPU stacking) is verified by the zero-overflow result + code.