### PR TITLE
feat(chat): editable default main_system_prompt — UI (issue #23 phase 2)

### DIFF
--- a/dashboard/frontend/src/components/tools/DefaultPromptEditor.jsx
+++ b/dashboard/frontend/src/components/tools/DefaultPromptEditor.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react'
+import useMainSystemPrompt from '../../hooks/useMainSystemPrompt'
+
+// Editor for the global default `main_system_prompt` applied to every NEW
+// conversation. Existing conversations keep their own stored copy and are
+// untouched by edits here.
+export default function DefaultPromptEditor() {
+  const { data, loading, error, save, reset } = useMainSystemPrompt()
+
+  const [content, setContent] = useState('')
+  const [dirty, setDirty] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState(null)
+  const [savedNote, setSavedNote] = useState(null)
+  const [confirmingReset, setConfirmingReset] = useState(false)
+
+  // Sync the textarea from the server value whenever it changes — but not
+  // while the user has unsaved edits, so a background refresh can't stomp
+  // their work.
+  useEffect(() => {
+    if (data && !dirty) setContent(data.current ?? '')
+  }, [data, dirty])
+
+  function onChange(v) {
+    setContent(v)
+    setDirty(true)
+    setActionError(null)
+    setSavedNote(null)
+    setConfirmingReset(false)
+  }
+
+  async function handleSave() {
+    setBusy(true)
+    setActionError(null)
+    setSavedNote(null)
+    try {
+      await save(content)
+      setDirty(false)
+      setSavedNote('Saved')
+    } catch (e) {
+      setActionError(e.message || 'Save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleReset() {
+    setBusy(true)
+    setActionError(null)
+    setSavedNote(null)
+    try {
+      const d = await reset()
+      setContent(d.current ?? '')
+      setDirty(false)
+      setSavedNote('Reset to built-in')
+    } catch (e) {
+      setActionError(e.message || 'Reset failed')
+    } finally {
+      setBusy(false)
+      setConfirmingReset(false)
+    }
+  }
+
+  function handleDiscard() {
+    setContent(data?.current ?? '')
+    setDirty(false)
+    setActionError(null)
+    setSavedNote(null)
+    setConfirmingReset(false)
+  }
+
+  const isEmpty = !content.trim()
+  const customized = !!data?.customized
+
+  return (
+    <div className="border border-border rounded bg-app">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border">
+        <div className="text-sm text-fg-muted">
+          <i className="fa-solid fa-message mr-2 text-fg-subtle"></i>
+          Default system prompt
+          {customized && (
+            <span className="ml-2 text-xs text-warning-fg border border-warning rounded px-1.5 py-0.5">
+              Modified from built-in
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {savedNote && <span className="text-xs text-success-fg">{savedNote}</span>}
+          {dirty && <span className="text-xs text-warning-fg">Unsaved</span>}
+
+          {confirmingReset ? (
+            <>
+              <span className="text-xs text-fg-muted">Reset to built-in?</span>
+              <button
+                onClick={handleReset}
+                disabled={busy}
+                className="text-xs px-2 py-1 rounded bg-danger hover:bg-danger text-white disabled:opacity-50"
+              >
+                Confirm reset
+              </button>
+              <button
+                onClick={() => setConfirmingReset(false)}
+                disabled={busy}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={handleDiscard}
+                disabled={busy || !dirty}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Discard
+              </button>
+              <button
+                onClick={() => { setConfirmingReset(true); setActionError(null); setSavedNote(null) }}
+                disabled={busy || !customized}
+                title={customized ? 'Discard the customization and revert to the built-in prompt' : 'Already using the built-in prompt'}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Reset to built-in
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={busy || !dirty || isEmpty}
+                className="text-xs px-2 py-1 rounded bg-accent-strong hover:bg-accent-hover disabled:opacity-50 text-white"
+              >
+                Save
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <p className="px-3 pt-2 text-xs text-fg-subtle">
+        Applied to every new conversation. Existing conversations keep their own copy and are unaffected.
+        Tool-specific guidance belongs in each MCP server's <span className="font-mono">tool_hint</span>, not here.
+      </p>
+
+      {loading ? (
+        <div className="px-3 py-6 text-sm text-fg-subtle">
+          <i className="fa-solid fa-spinner fa-spin mr-2"></i>Loading…
+        </div>
+      ) : (
+        <textarea
+          value={content}
+          onChange={(e) => onChange(e.target.value)}
+          spellCheck={false}
+          disabled={busy}
+          className="w-full h-64 bg-surface-muted text-fg font-mono text-xs p-3 mt-2 focus:outline-none resize-y disabled:opacity-60"
+          placeholder="The default system prompt for new conversations…"
+        />
+      )}
+
+      {(error || actionError || isEmpty) && !loading && (
+        <div className="px-3 py-2 border-t border-border text-xs space-y-1">
+          {error && (
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}</div>
+          )}
+          {actionError && (
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{actionError}</div>
+          )}
+          {isEmpty && (
+            <div className="text-warning-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>Prompt cannot be empty.</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/tools/DefaultPromptEditor.test.jsx
+++ b/dashboard/frontend/src/components/tools/DefaultPromptEditor.test.jsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+// The component drives everything through the useMainSystemPrompt hook;
+// mock it so each test controls the data / save / reset behavior.
+const mockSave = vi.fn()
+const mockReset = vi.fn()
+let hookState
+
+vi.mock('../../hooks/useMainSystemPrompt', () => ({
+  default: () => hookState,
+}))
+
+import DefaultPromptEditor from './DefaultPromptEditor'
+
+const BUILTIN = 'You are a helpful assistant.'
+
+beforeEach(() => {
+  mockSave.mockReset()
+  mockReset.mockReset()
+  hookState = {
+    data: { current: BUILTIN, builtin: BUILTIN, customized: false },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    save: mockSave,
+    reset: mockReset,
+  }
+})
+
+afterEach(() => {
+  // vitest globals are off, so RTL's auto-cleanup isn't registered —
+  // unmount explicitly or screen queries see prior renders' DOM.
+  cleanup()
+})
+
+function getTextarea(container) {
+  return container.querySelector('textarea')
+}
+
+describe('DefaultPromptEditor', () => {
+  it('shows a loading state with no textarea while loading', () => {
+    hookState = { ...hookState, data: null, loading: true }
+    const { container } = render(<DefaultPromptEditor />)
+    expect(container.textContent).toContain('Loading…')
+    expect(getTextarea(container)).toBeNull()
+  })
+
+  it('populates the textarea with the current prompt once loaded', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    expect(getTextarea(container).value).toBe(BUILTIN)
+  })
+
+  it('hides the modified badge when not customized', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    expect(container.textContent).not.toContain('Modified from built-in')
+  })
+
+  it('shows the modified badge when customized', () => {
+    hookState.data = { current: 'custom', builtin: BUILTIN, customized: true }
+    const { container } = render(<DefaultPromptEditor />)
+    expect(container.textContent).toContain('Modified from built-in')
+  })
+
+  it('Save is disabled until the prompt is edited', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeDisabled()
+    fireEvent.change(getTextarea(container), { target: { value: 'edited prompt' } })
+    expect(save).toBeEnabled()
+  })
+
+  it('marks the editor dirty when edited', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.change(getTextarea(container), { target: { value: 'edited' } })
+    expect(container.textContent).toContain('Unsaved')
+  })
+
+  it('Save calls the hook with the edited content and clears dirty', async () => {
+    mockSave.mockResolvedValue({ current: 'edited prompt', builtin: BUILTIN, customized: true })
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.change(getTextarea(container), { target: { value: 'edited prompt' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('edited prompt'))
+    await waitFor(() => expect(container.textContent).toContain('Saved'))
+    expect(container.textContent).not.toContain('Unsaved')
+  })
+
+  it('Save is blocked and a warning shown when the prompt is empty', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.change(getTextarea(container), { target: { value: '   ' } })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(container.textContent).toContain('Prompt cannot be empty.')
+  })
+
+  it('surfaces a save error from the hook', async () => {
+    mockSave.mockRejectedValue(new Error('content must not be empty'))
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.change(getTextarea(container), { target: { value: 'x' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(container.textContent).toContain('content must not be empty'))
+  })
+
+  it('Discard reverts edits back to the loaded value', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.change(getTextarea(container), { target: { value: 'edited' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }))
+    expect(getTextarea(container).value).toBe(BUILTIN)
+    expect(container.textContent).not.toContain('Unsaved')
+  })
+
+  it('Reset to built-in is disabled when already on the built-in', () => {
+    const { container } = render(<DefaultPromptEditor />)
+    expect(screen.getByRole('button', { name: 'Reset to built-in' })).toBeDisabled()
+    expect(container).toBeTruthy()
+  })
+
+  it('Reset flow: confirm step then hook call', async () => {
+    hookState.data = { current: 'custom prompt', builtin: BUILTIN, customized: true }
+    mockReset.mockResolvedValue({ current: BUILTIN, builtin: BUILTIN, customized: false })
+    const { container } = render(<DefaultPromptEditor />)
+
+    // First click reveals an inline confirm — it does not call the hook.
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to built-in' }))
+    expect(mockReset).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Reset to built-in?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reset' }))
+    await waitFor(() => expect(mockReset).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(getTextarea(container).value).toBe(BUILTIN))
+    expect(container.textContent).toContain('Reset to built-in')
+  })
+
+  it('Reset can be cancelled at the confirm step', () => {
+    hookState.data = { current: 'custom prompt', builtin: BUILTIN, customized: true }
+    const { container } = render(<DefaultPromptEditor />)
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to built-in' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(container.textContent).not.toContain('Reset to built-in?')
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a load error from the hook', () => {
+    hookState = { ...hookState, data: null, loading: false, error: 'Failed to load default prompt' }
+    const { container } = render(<DefaultPromptEditor />)
+    expect(container.textContent).toContain('Failed to load default prompt')
+  })
+})

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import useRegistry from '../../hooks/useRegistry'
 import RegistryEditor from './RegistryEditor'
+import DefaultPromptEditor from './DefaultPromptEditor'
 import ServerTestPanel from './ServerTestPanel'
 
 function ServerRow({ server, selected, onSelect }) {
@@ -133,6 +134,8 @@ export default function ToolsPage() {
           declared in a JSON file on disk.
         </p>
       </div>
+
+      <DefaultPromptEditor />
 
       <RegistryEditor
         initialContent={json?.content}

--- a/dashboard/frontend/src/hooks/useMainSystemPrompt.js
+++ b/dashboard/frontend/src/hooks/useMainSystemPrompt.js
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  getMainSystemPrompt,
+  putMainSystemPrompt,
+  resetMainSystemPrompt,
+} from '../services/chatSettings'
+
+// Loads and mutates the global default `main_system_prompt`. `data` is the
+// { current, builtin, customized } payload, or null until the first load
+// resolves. `save` / `reset` throw on failure so the editor can surface
+// the message; on success they refresh `data` from the server response.
+export default function useMainSystemPrompt() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const mountedRef = useRef(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const d = await getMainSystemPrompt()
+      if (!mountedRef.current) return
+      setData(d)
+      setError(null)
+    } catch (e) {
+      if (mountedRef.current) setError(e.message || 'Failed to load default prompt')
+    } finally {
+      if (mountedRef.current) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    refresh()
+    return () => { mountedRef.current = false }
+  }, [refresh])
+
+  const save = useCallback(async (content) => {
+    const d = await putMainSystemPrompt(content)
+    if (mountedRef.current) setData(d)
+    return d
+  }, [])
+
+  const reset = useCallback(async () => {
+    const d = await resetMainSystemPrompt()
+    if (mountedRef.current) setData(d)
+    return d
+  }, [])
+
+  return { data, loading, error, refresh, save, reset }
+}

--- a/dashboard/frontend/src/services/chatSettings.js
+++ b/dashboard/frontend/src/services/chatSettings.js
@@ -1,0 +1,14 @@
+import { fetchAPI } from '../api'
+
+// Editable global default `main_system_prompt`. The backend returns
+// { current, builtin, customized } from every verb so the UI never has to
+// do its own string compare to know whether the value differs from the
+// built-in baseline.
+const PATH = '/chat/settings/main-system-prompt'
+
+export const getMainSystemPrompt = () => fetchAPI(PATH)
+
+export const putMainSystemPrompt = (content) =>
+  fetchAPI(PATH, { method: 'PUT', body: JSON.stringify({ content }) })
+
+export const resetMainSystemPrompt = () => fetchAPI(PATH, { method: 'DELETE' })


### PR DESCRIPTION
Phase 2 of issue #23. Builds the dashboard editor for the global default `main_system_prompt` on top of the phase-1 API (merged in #41).

## What

- **`services/chatSettings.js`** — `getMainSystemPrompt` / `putMainSystemPrompt` / `resetMainSystemPrompt`, thin `fetchAPI` wrappers over `/api/chat/settings/main-system-prompt`.
- **`hooks/useMainSystemPrompt.js`** — loads `{current, builtin, customized}`; `save`/`reset` refresh state from the server response; mount-guarded against late resolution.
- **`components/tools/DefaultPromptEditor.jsx`** — textarea bound to the current prompt with Save / Discard / Reset-to-built-in.
  - "Modified from built-in" badge driven by the server's `customized` flag — no client-side string compare.
  - Reset is a two-step inline confirm (no `window.confirm`).
  - A background refresh never stomps unsaved edits (sync gated on `!dirty`).
  - Save is blocked on empty/whitespace content, with a visible warning.
- **`components/tools/ToolsPage.jsx`** — mounts the editor above the MCP registry editor: base prompt first, tool hints second.

## Acceptance criterion

This closes **criterion #1** — editing the global default prompt is now possible from the dashboard UI, no code edit + restart. Criteria #2–#4 were satisfied in phase 1.

## Tests

- 14 new tests in `DefaultPromptEditor.test.jsx`: loading state, populate-from-server, modified badge on/off, dirty tracking, save success + clears dirty, save error surfaced, empty-content block, discard, reset confirm/cancel flow, load error.
- Full frontend suite: **58 passed**. `vite build` clean. No new lint warnings.

Phase 3 (docs + websearch `tool_hint` example) follows on a separate branch.