### PR TITLE
docs(chat): default-prompt settings + websearch tool_hint (issue #23 phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,41 @@ Editing the file:
 Secrets stay in the external MCP server's own `.env`; the registry only
 holds paths.
 
+## Editing the default chat system prompt
+
+Every new conversation inherits a global default `main_system_prompt`. It
+is **editable from the dashboard** — Tools page → "Default system prompt"
+card — so iterating on it no longer needs a code edit + service restart.
+
+- **Storage:** `dashboard/chat_settings.json` — a JSON singleton,
+  gitignored (machine-local, holds user prompt text). If it's absent,
+  unreadable, malformed, or has no `main_system_prompt` key, the built-in
+  `DEFAULT_MAIN_SYSTEM_PROMPT` in `dashboard/chat/constants.py` is used.
+  Override the path with `LLM_DOCK_CHAT_SETTINGS_FILE`.
+- **API** (bearer auth), `/api/chat/settings/main-system-prompt`:
+  - `GET` → `{current, builtin, customized}` — `customized` is true only
+    when a non-empty override is stored *and* it differs from the
+    built-in, so it's safe to drive a "modified" indicator off it.
+  - `PUT {"content": "..."}` → store the override (rejects empty /
+    whitespace-only content, and non-object JSON bodies, with 400).
+  - `DELETE` → drop the override, reverting to the built-in.
+- `create_conversation` reads the configured default **only** when the
+  request body has no explicit `main_system_prompt`. Existing
+  conversations are unaffected — each carries its own copy in `chat.db`.
+- Core logic is `chat/settings_store.py` (pure, unit-tested in
+  `dashboard/tests/test_settings_store.py`); endpoints + the
+  conversation-creation integration test live in
+  `dashboard/tests/test_chat_settings_routes.py`.
+
+**Keep tool-specific guidance out of this prompt.** Anything about how to
+use a particular tool (web search, sympy, schemdraw, render-html, …)
+belongs in that MCP server's `tool_hint` — it is appended to the system
+prompt by `mcp_registry.get_tool_hints()` only when the server is enabled
+for the conversation. The base prompt should hold only generic style /
+accuracy / tool-posture guidance. See
+`dashboard/mcp_servers.example.json` for the `websearch` `tool_hint`
+carrying the web-research guidance.
+
 ## Reference: working embedding service
 
 `vllm-nomic-embed-text-v1.5` (port 3320) — see `services.json`. Smoke

--- a/dashboard/mcp_servers.example.json
+++ b/dashboard/mcp_servers.example.json
@@ -10,6 +10,6 @@
       "stdio"
     ],
     "icon": "fa-magnifying-glass",
-    "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details."
+    "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. When the query is about the current state of anything (prices, products, events, rankings, \"best X in Y\"), take the year from the `Current date:` line in this system prompt — do not append a year from your training data unless the user explicitly asked about that specific year. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details."
   }
 }


### PR DESCRIPTION
Phase 3 (final) of issue #23 — documentation and the websearch `tool_hint` example.

## What

- **`CLAUDE.md`** — new section "Editing the default chat system prompt": storage (`chat_settings.json`, gitignored, `LLM_DOCK_CHAT_SETTINGS_FILE` override), the `GET/PUT/DELETE /api/chat/settings/main-system-prompt` API and its `{current, builtin, customized}` contract, the `create_conversation` precedence rule (explicit body prompt > configured default > built-in), test locations, and the standing rule that tool-specific guidance lives in each MCP server's `tool_hint`, never the base prompt.
- **`dashboard/mcp_servers.example.json`** — the `websearch` `tool_hint` now carries the web-research year guidance ("take the year from the `Current date:` line, not a year from training data") that Phase 1 stripped from the default prompt. It now loads if-and-only-if the websearch server is enabled for the conversation — which is the core point of issue #23 (acceptance criterion #3).

## Issue #23 — final status

All four acceptance criteria are met across the three phases:

- **#1** Editing the global default prompt from the dashboard UI — ✅ phase 1 (API) + phase 2 (Tools-page editor).
- **#2** No-MCP conversation has no tool-specific text — ✅ phase 1; locked in by `test_builtin_prompt_has_no_tool_specific_guidance`.
- **#3** Websearch MCP enabled → web-research guidance appended from the server's `tool_hint` — ✅ this phase wires the example content; runtime append already lived in `routes._stream_response`.
- **#4** Existing conversations unaffected — ✅ phase 1; they keep their own `main_system_prompt` in `chat.db`.

Docs-only change — no code, no new tests.