### PR TITLE
fix(chat): make the per-conversation system prompt actually editable

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -43,6 +43,9 @@ export default function ChatArea({
   const [spinoffs, setSpinoffs] = useState([]) // [{id, text, minimized, zIndex}]
   const topZRef = useRef(100)
   const composerRef = useRef(null)
+  // Tracks an in-flight system-prompt save so a fast send can't POST a
+  // message before the prompt PUT lands (SystemPromptEditor saves on blur).
+  const pendingPromptSaveRef = useRef(null)
 
   const quoteSelection = useCallback((text) => {
     if (!text) return
@@ -153,7 +156,31 @@ export default function ChatArea({
   }
 
   async function handleSystemPromptChange(field, value) {
-    await updateConversation(conversation.id, { [field]: value })
+    const save = updateConversation(conversation.id, { [field]: value })
+    pendingPromptSaveRef.current = save
+    try {
+      await save
+    } finally {
+      // Only clear if a newer save hasn't replaced this one.
+      if (pendingPromptSaveRef.current === save) pendingPromptSaveRef.current = null
+    }
+  }
+
+  async function handleSend(msg, images) {
+    // SystemPromptEditor persists on blur; focusing the composer blurs it,
+    // so a save may be in flight right as the user hits send. Wait it out
+    // so the backend reads the new prompt when it generates the reply.
+    const pending = pendingPromptSaveRef.current
+    if (pending) {
+      try {
+        await pending
+      } catch {
+        // The failure is already surfaced in SystemPromptEditor; don't
+        // block the send on it (the prompt just stays at its old value).
+      }
+    }
+    onSend(msg, images)
+    setPendingInserts([])
   }
 
   return (
@@ -226,7 +253,7 @@ export default function ChatArea({
         <ChatInput
           ref={composerRef}
           focusKey={conversation.id}
-          onSend={(msg, images) => { onSend(msg, images); setPendingInserts([]) }}
+          onSend={handleSend}
           disabled={streaming || !conversation.main_service}
           pendingInserts={pendingInserts}
           onClearInsert={(idx) => setPendingInserts(prev => prev.filter((_, i) => i !== idx))}

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -43,9 +43,9 @@ export default function ChatArea({
   const [spinoffs, setSpinoffs] = useState([]) // [{id, text, minimized, zIndex}]
   const topZRef = useRef(100)
   const composerRef = useRef(null)
-  // Tracks an in-flight system-prompt save so a fast send can't POST a
-  // message before the prompt PUT lands (SystemPromptEditor saves on blur).
-  const pendingPromptSaveRef = useRef(null)
+  // Lets handleSend flush a just-edited system prompt to the server before
+  // the message is posted (SystemPromptEditor persists on blur).
+  const promptEditorRef = useRef(null)
 
   const quoteSelection = useCallback((text) => {
     if (!text) return
@@ -155,30 +155,17 @@ export default function ChatArea({
     onReloadConversation?.(conversation.id)
   }
 
-  async function handleSystemPromptChange(field, value) {
-    const save = updateConversation(conversation.id, { [field]: value })
-    pendingPromptSaveRef.current = save
-    try {
-      await save
-    } finally {
-      // Only clear if a newer save hasn't replaced this one.
-      if (pendingPromptSaveRef.current === save) pendingPromptSaveRef.current = null
-    }
+  function handleSystemPromptChange(field, value) {
+    return updateConversation(conversation.id, { [field]: value })
   }
 
   async function handleSend(msg, images) {
     // SystemPromptEditor persists on blur; focusing the composer blurs it,
-    // so a save may be in flight right as the user hits send. Wait it out
-    // so the backend reads the new prompt when it generates the reply.
-    const pending = pendingPromptSaveRef.current
-    if (pending) {
-      try {
-        await pending
-      } catch {
-        // The failure is already surfaced in SystemPromptEditor; don't
-        // block the send on it (the prompt just stays at its old value).
-      }
-    }
+    // so a save — or a chain of them, if the user edited again mid-save —
+    // can still be running. flush() resolves only once the prompt is fully
+    // persisted, so the backend reads the new prompt for the reply. A
+    // failed save is surfaced in the editor and does not block the send.
+    await promptEditorRef.current?.flush()
     onSend(msg, images)
     setPendingInserts([])
   }
@@ -218,6 +205,7 @@ export default function ChatArea({
             state resets cleanly when the user switches conversations. */}
         <SystemPromptEditor
           key={conversation.id}
+          ref={promptEditorRef}
           mainPrompt={conversation.main_system_prompt || ''}
           onSaveMain={v => handleSystemPromptChange('main_system_prompt', v)}
         />

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -46,6 +46,10 @@ export default function ChatArea({
   // Lets handleSend flush a just-edited system prompt to the server before
   // the message is posted (SystemPromptEditor persists on blur).
   const promptEditorRef = useRef(null)
+  // Guards handleSend against re-entry: the composer stays enabled while
+  // handleSend awaits the prompt flush (streaming is still false), so a
+  // double-submit would otherwise open two concurrent SSE streams.
+  const sendInFlightRef = useRef(false)
 
   const quoteSelection = useCallback((text) => {
     if (!text) return
@@ -160,14 +164,25 @@ export default function ChatArea({
   }
 
   async function handleSend(msg, images) {
-    // SystemPromptEditor persists on blur; focusing the composer blurs it,
-    // so a save — or a chain of them, if the user edited again mid-save —
-    // can still be running. flush() resolves only once the prompt is fully
-    // persisted, so the backend reads the new prompt for the reply. A
-    // failed save is surfaced in the editor and does not block the send.
-    await promptEditorRef.current?.flush()
-    onSend(msg, images)
-    setPendingInserts([])
+    // Drop a re-entrant submit that lands while we're still awaiting the
+    // flush below — otherwise both calls reach onSend with a pre-streaming
+    // sendMessage closure and start concurrent streams. Once onSend runs,
+    // sendMessage flips `streaming` true and the composer's own disabled
+    // guard takes over.
+    if (sendInFlightRef.current) return
+    sendInFlightRef.current = true
+    try {
+      // SystemPromptEditor persists on blur; focusing the composer blurs it,
+      // so a save — or a chain of them, if the user edited again mid-save —
+      // can still be running. flush() resolves only once the prompt is fully
+      // persisted, so the backend reads the new prompt for the reply. A
+      // failed save is surfaced in the editor and does not block the send.
+      await promptEditorRef.current?.flush()
+      onSend(msg, images)
+      setPendingInserts([])
+    } finally {
+      sendInFlightRef.current = false
+    }
   }
 
   return (

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -187,12 +187,12 @@ export default function ChatArea({
           )}
         </div>
 
-        {/* System prompt editor */}
+        {/* System prompt editor — keyed by conversation so local edit
+            state resets cleanly when the user switches conversations. */}
         <SystemPromptEditor
+          key={conversation.id}
           mainPrompt={conversation.main_system_prompt || ''}
-          sidekickPrompt={conversation.sidekick_system_prompt || ''}
-          onChangeMain={v => handleSystemPromptChange('main_system_prompt', v)}
-          onChangeSidekick={v => handleSystemPromptChange('sidekick_system_prompt', v)}
+          onSaveMain={v => handleSystemPromptChange('main_system_prompt', v)}
         />
 
         {/* Error display */}

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -139,13 +139,13 @@ describe('ChatArea — send gating on a pending system-prompt save', () => {
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello model', undefined))
   })
 
-  it('sends immediately when there is no pending prompt save', () => {
+  it('sends when there is no pending prompt save', async () => {
     const onSend = vi.fn()
     const { container } = renderConversation(onSend)
     const composer = container.querySelector('textarea') // prompt editor collapsed
     fireEvent.change(composer, { target: { value: 'hi' } })
     fireEvent.keyDown(composer, { key: 'Enter' })
-    expect(onSend).toHaveBeenCalledWith('hi', undefined)
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hi', undefined))
   })
 
   it('still sends if the prompt save fails', async () => {
@@ -162,6 +162,47 @@ describe('ChatArea — send gating on a pending system-prompt save', () => {
     fireEvent.change(composer, { target: { value: 'hello' } })
     fireEvent.keyDown(composer, { key: 'Enter' })
 
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello', undefined))
+  })
+
+  it('waits for the whole save chain when an edit lands during a save', async () => {
+    // Regression for PR #44 codex iteration 3: when a second edit is made
+    // while the first save is in flight, SystemPromptEditor's commit loop
+    // issues a follow-up PUT after the first resolves. The send must wait
+    // for that follow-up too — not just the first promise — or the reply
+    // is generated with the intermediate prompt.
+    let resolveA, resolveB
+    mockUpdateConversation
+      .mockImplementationOnce(() => new Promise((r) => { resolveA = r }))
+      .mockImplementationOnce(() => new Promise((r) => { resolveB = r }))
+    const onSend = vi.fn()
+    const { container } = renderConversation(onSend)
+
+    fireEvent.click(screen.getByRole('button', { name: /System Prompt/ }))
+    const promptTextarea = container.querySelectorAll('textarea')[0]
+
+    // Edit to A and blur → save A starts (deferred).
+    fireEvent.change(promptTextarea, { target: { value: 'A' } })
+    fireEvent.blur(promptTextarea)
+    // Edit to B and blur → dropped by the editor's saving guard.
+    fireEvent.change(promptTextarea, { target: { value: 'B' } })
+    fireEvent.blur(promptTextarea)
+
+    // Send while save A is still in flight.
+    const composer = container.querySelectorAll('textarea')[1]
+    fireEvent.change(composer, { target: { value: 'hello' } })
+    fireEvent.keyDown(composer, { key: 'Enter' })
+    await Promise.resolve()
+    expect(onSend).not.toHaveBeenCalled()
+
+    // A resolves → the editor enqueues save B → send must STILL be held.
+    resolveA({})
+    await waitFor(() => expect(mockUpdateConversation).toHaveBeenCalledTimes(2))
+    expect(mockUpdateConversation).toHaveBeenNthCalledWith(2, 'conv-1', { main_system_prompt: 'B' })
+    expect(onSend).not.toHaveBeenCalled()
+
+    // Only once B lands does the send proceed.
+    resolveB({})
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello', undefined))
   })
 })

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import ChatArea from './ChatArea'
 
 // useRunningServices (pulled in transitively by the empty-state composer's
@@ -9,6 +9,20 @@ import ChatArea from './ChatArea'
 vi.mock('../../hooks/useRunningServices', () => ({
   default: () => ({ services: [], loading: false }),
 }))
+
+// Heavy children that fetch or need extra context — not under test here.
+// The conversation-branch tests keep SystemPromptEditor and ChatInput real.
+vi.mock('./ModelSelector', () => ({ default: () => null }))
+vi.mock('./McpToggle', () => ({ default: () => null }))
+vi.mock('./MessageList', () => ({ default: () => null }))
+
+const { mockUpdateConversation } = vi.hoisted(() => ({ mockUpdateConversation: vi.fn() }))
+vi.mock('../../services/chat', async (importActual) => ({
+  ...(await importActual()),
+  updateConversation: (...args) => mockUpdateConversation(...args),
+}))
+
+afterEach(() => cleanup())
 
 describe('ChatArea no-conversation states', () => {
   it('shows the create composer when there is no route conversation', () => {
@@ -66,5 +80,88 @@ describe('ChatArea no-conversation states', () => {
     )
     expect(container.textContent).toContain('Loading conversation')
     expect(container.querySelector('textarea')).toBeNull()
+  })
+})
+
+describe('ChatArea — send gating on a pending system-prompt save', () => {
+  // Regression for PR #44 codex iteration 1: SystemPromptEditor persists on
+  // blur; focusing the composer blurs it, so a save can be in flight when
+  // the user hits send. The send must wait for that PUT or the backend
+  // generates the first reply with the stale prompt.
+  beforeEach(() => {
+    mockUpdateConversation.mockReset()
+  })
+
+  function renderConversation(onSend) {
+    return render(
+      <ChatArea
+        conversation={{
+          id: 'conv-1',
+          main_service: 'vllm-test',
+          main_system_prompt: 'original',
+          mcp_servers: [],
+        }}
+        awaitingConversation={false}
+        defaultModelName="vllm-test"
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+        streaming={false}
+        onSend={onSend}
+      />
+    )
+  }
+
+  it('waits for an in-flight prompt save before sending the message', async () => {
+    let resolveSave
+    mockUpdateConversation.mockReturnValue(new Promise((r) => { resolveSave = r }))
+    const onSend = vi.fn()
+    const { container } = renderConversation(onSend)
+
+    // Edit + blur the system prompt — starts the (still-pending) save.
+    fireEvent.click(screen.getByRole('button', { name: /System Prompt/ }))
+    const promptTextarea = container.querySelectorAll('textarea')[0]
+    fireEvent.change(promptTextarea, { target: { value: 'edited prompt' } })
+    fireEvent.blur(promptTextarea)
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', { main_system_prompt: 'edited prompt' })
+
+    // Send a message before the save resolves.
+    const composer = container.querySelectorAll('textarea')[1]
+    fireEvent.change(composer, { target: { value: 'hello model' } })
+    fireEvent.keyDown(composer, { key: 'Enter' })
+
+    // The send must be held while the prompt PUT is in flight.
+    await Promise.resolve()
+    expect(onSend).not.toHaveBeenCalled()
+
+    // Once the save lands, the send proceeds.
+    resolveSave({})
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello model', undefined))
+  })
+
+  it('sends immediately when there is no pending prompt save', () => {
+    const onSend = vi.fn()
+    const { container } = renderConversation(onSend)
+    const composer = container.querySelector('textarea') // prompt editor collapsed
+    fireEvent.change(composer, { target: { value: 'hi' } })
+    fireEvent.keyDown(composer, { key: 'Enter' })
+    expect(onSend).toHaveBeenCalledWith('hi', undefined)
+  })
+
+  it('still sends if the prompt save fails', async () => {
+    mockUpdateConversation.mockRejectedValue(new Error('save failed'))
+    const onSend = vi.fn()
+    const { container } = renderConversation(onSend)
+
+    fireEvent.click(screen.getByRole('button', { name: /System Prompt/ }))
+    const promptTextarea = container.querySelectorAll('textarea')[0]
+    fireEvent.change(promptTextarea, { target: { value: 'edited' } })
+    fireEvent.blur(promptTextarea)
+
+    const composer = container.querySelectorAll('textarea')[1]
+    fireEvent.change(composer, { target: { value: 'hello' } })
+    fireEvent.keyDown(composer, { key: 'Enter' })
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello', undefined))
   })
 })

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -205,4 +205,34 @@ describe('ChatArea — send gating on a pending system-prompt save', () => {
     resolveB({})
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello', undefined))
   })
+
+  it('ignores a re-entrant submit while a prompt save is still flushing', async () => {
+    // Regression for PR #44 codex iteration 4: the composer stays enabled
+    // while handleSend awaits flush() (streaming is still false), so a
+    // double-submit must not reach onSend twice and open concurrent
+    // streams.
+    let resolveSave
+    mockUpdateConversation.mockReturnValue(new Promise((r) => { resolveSave = r }))
+    const onSend = vi.fn()
+    const { container } = renderConversation(onSend)
+
+    fireEvent.click(screen.getByRole('button', { name: /System Prompt/ }))
+    const promptTextarea = container.querySelectorAll('textarea')[0]
+    fireEvent.change(promptTextarea, { target: { value: 'edited' } })
+    fireEvent.blur(promptTextarea) // save now in flight
+
+    const composer = container.querySelectorAll('textarea')[1]
+    fireEvent.change(composer, { target: { value: 'first' } })
+    fireEvent.keyDown(composer, { key: 'Enter' }) // submit 1 — awaits flush
+    fireEvent.change(composer, { target: { value: 'second' } })
+    fireEvent.keyDown(composer, { key: 'Enter' }) // submit 2 — must be dropped
+
+    await Promise.resolve()
+    expect(onSend).not.toHaveBeenCalled()
+
+    // After the save resolves, exactly one send goes through.
+    resolveSave({})
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1))
+    expect(onSend).toHaveBeenCalledWith('first', undefined)
+  })
 })

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
@@ -1,7 +1,39 @@
 import { useState } from 'react'
 
-export default function SystemPromptEditor({ mainPrompt, sidekickPrompt, onChangeMain, onChangeSidekick }) {
+// Per-conversation main system prompt. The textarea is backed by LOCAL
+// state — the previous version bound `value` straight to the persisted
+// `conversation.main_system_prompt` prop while `onChange` only fired an
+// async server PUT, so every keystroke was re-rendered back to the stale
+// prop value and the box looked read-only. Here the edit lives locally
+// and is persisted once, on blur.
+//
+// The parent remounts this component per conversation (key={conversation.id}),
+// so local state initializes cleanly from the prop on every conversation
+// switch without a useEffect resync.
+export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
   const [open, setOpen] = useState(false)
+  const [value, setValue] = useState(mainPrompt)
+  // Last value known to be persisted. Drives the dirty indicator without
+  // depending on the parent reloading the conversation after a save.
+  const [savedValue, setSavedValue] = useState(mainPrompt)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  const dirty = value !== savedValue
+
+  async function commit() {
+    if (!dirty || saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      await onSaveMain(value)
+      setSavedValue(value)
+    } catch (e) {
+      setError(e.message || 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
 
   return (
     <div className="border-b border-border">
@@ -11,28 +43,28 @@ export default function SystemPromptEditor({ mainPrompt, sidekickPrompt, onChang
       >
         <i className={`fa-solid fa-chevron-${open ? 'down' : 'right'} text-[10px]`}></i>
         <i className="fa-solid fa-sliders"></i>
-        <span>System Prompts</span>
+        <span>System Prompt</span>
+        {saving && <span className="text-fg-subtle">Saving…</span>}
+        {!saving && dirty && <span className="text-warning-fg">Unsaved</span>}
       </button>
       {open && (
-        <div className="px-4 pb-3 space-y-3">
-          <div>
-            <label className="text-xs text-fg-muted mb-1 block">Main Model</label>
-            <textarea
-              value={mainPrompt}
-              onChange={e => onChangeMain(e.target.value)}
-              rows={3}
-              className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"
-            />
-          </div>
-          <div>
-            <label className="text-xs text-fg-muted mb-1 block">Critic Model</label>
-            <textarea
-              value={sidekickPrompt}
-              onChange={e => onChangeSidekick(e.target.value)}
-              rows={3}
-              className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"
-            />
-          </div>
+        <div className="px-4 pb-3 space-y-1">
+          <label className="text-xs text-fg-muted block">Main Model</label>
+          <textarea
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            onBlur={commit}
+            rows={3}
+            className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"
+          />
+          <p className="text-[10px] text-fg-subtle">
+            Applies to this conversation only. Saved when you click away.
+          </p>
+          {error && (
+            <p className="text-[10px] text-danger-fg">
+              <i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 // Per-conversation main system prompt. The textarea is backed by LOCAL
 // state — the previous version bound `value` straight to the persisted
@@ -10,7 +10,14 @@ import { useRef, useState } from 'react'
 // The parent remounts this component per conversation (key={conversation.id}),
 // so local state initializes cleanly from the prop on every conversation
 // switch without a useEffect resync.
-export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
+//
+// Exposes an imperative `flush()` so the parent can guarantee the latest
+// edit is fully persisted before it sends a message — otherwise the
+// backend would generate the reply with the stale prompt.
+const SystemPromptEditor = forwardRef(function SystemPromptEditor(
+  { mainPrompt, onSaveMain },
+  ref,
+) {
   const [open, setOpen] = useState(false)
   const [value, setValue] = useState(mainPrompt)
   // Last value known to be persisted. Drives the dirty indicator without
@@ -18,9 +25,12 @@ export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
   const [savedValue, setSavedValue] = useState(mainPrompt)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
-  // Mirrors `value` so the async commit loop can read the latest text
-  // after an await without a stale closure.
+  // Refs mirror the two values so the async commit loop and flush() can
+  // read the latest state after an await without a stale closure.
   const valueRef = useRef(mainPrompt)
+  const savedValueRef = useRef(mainPrompt)
+  // The in-flight commit loop's promise, or null when idle.
+  const commitRunningRef = useRef(null)
 
   const dirty = value !== savedValue
 
@@ -29,30 +39,45 @@ export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
     valueRef.current = next
   }
 
-  async function commit() {
-    // A blur that lands while a save is already running is a no-op here —
-    // the loop below re-reads `valueRef` after each request, so the edit
-    // is still persisted without its own blur being honored.
-    if (saving) return
-    if (valueRef.current === savedValue) return
-    setSaving(true)
-    setError(null)
-    let persisted = savedValue
-    try {
-      // Persist until what's on disk matches the textarea — covers edits
-      // made while an earlier request was in flight.
-      while (valueRef.current !== persisted) {
-        const snapshot = valueRef.current
-        await onSaveMain(snapshot)
-        persisted = snapshot
+  // Persist the textarea to the server. Idempotent while running: a second
+  // call returns the in-flight promise. The loop re-reads `valueRef` after
+  // every request, so an edit made mid-save (whose blur was swallowed
+  // because a save was already running) is still persisted.
+  function commit() {
+    if (commitRunningRef.current) return commitRunningRef.current
+    if (valueRef.current === savedValueRef.current) return null
+    const run = (async () => {
+      setSaving(true)
+      setError(null)
+      try {
+        while (valueRef.current !== savedValueRef.current) {
+          const snapshot = valueRef.current
+          await onSaveMain(snapshot)
+          savedValueRef.current = snapshot
+          setSavedValue(snapshot)
+        }
+      } catch (e) {
+        setError(e.message || 'Save failed')
+      } finally {
+        setSaving(false)
+        commitRunningRef.current = null
       }
-      setSavedValue(persisted)
-    } catch (e) {
-      setError(e.message || 'Save failed')
-    } finally {
-      setSaving(false)
+    })()
+    commitRunningRef.current = run
+    return run
+  }
+
+  // Resolve once the textarea is fully persisted: kick off a save if the
+  // value is dirty, then wait out the (possibly looping) commit. Used by
+  // the parent to gate message sends on the prompt being saved.
+  async function flush() {
+    commit()
+    while (commitRunningRef.current) {
+      await commitRunningRef.current
     }
   }
+
+  useImperativeHandle(ref, () => ({ flush }))
 
   return (
     <div className="border-b border-border">
@@ -88,4 +113,6 @@ export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
       )}
     </div>
   )
-}
+})
+
+export default SystemPromptEditor

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 // Per-conversation main system prompt. The textarea is backed by LOCAL
 // state — the previous version bound `value` straight to the persisted
@@ -18,16 +18,35 @@ export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
   const [savedValue, setSavedValue] = useState(mainPrompt)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
+  // Mirrors `value` so the async commit loop can read the latest text
+  // after an await without a stale closure.
+  const valueRef = useRef(mainPrompt)
 
   const dirty = value !== savedValue
 
+  function handleChange(next) {
+    setValue(next)
+    valueRef.current = next
+  }
+
   async function commit() {
-    if (!dirty || saving) return
+    // A blur that lands while a save is already running is a no-op here —
+    // the loop below re-reads `valueRef` after each request, so the edit
+    // is still persisted without its own blur being honored.
+    if (saving) return
+    if (valueRef.current === savedValue) return
     setSaving(true)
     setError(null)
+    let persisted = savedValue
     try {
-      await onSaveMain(value)
-      setSavedValue(value)
+      // Persist until what's on disk matches the textarea — covers edits
+      // made while an earlier request was in flight.
+      while (valueRef.current !== persisted) {
+        const snapshot = valueRef.current
+        await onSaveMain(snapshot)
+        persisted = snapshot
+      }
+      setSavedValue(persisted)
     } catch (e) {
       setError(e.message || 'Save failed')
     } finally {
@@ -52,7 +71,7 @@ export default function SystemPromptEditor({ mainPrompt, onSaveMain }) {
           <label className="text-xs text-fg-muted block">Main Model</label>
           <textarea
             value={value}
-            onChange={e => setValue(e.target.value)}
+            onChange={e => handleChange(e.target.value)}
             onBlur={commit}
             rows={3}
             className="w-full bg-surface border border-border rounded px-3 py-2 text-xs text-fg resize-none focus:outline-none focus:border-accent"

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
@@ -84,4 +84,33 @@ describe('SystemPromptEditor', () => {
     fireEvent.blur(ta)  // nothing changed since the save
     expect(onSave).toHaveBeenCalledTimes(1)
   })
+
+  it('persists an edit made while an earlier save is still in flight', async () => {
+    // Regression for PR #44 codex iteration 2: a blur during an in-flight
+    // save was dropped by the `saving` guard, so the later edit never got
+    // persisted. The commit loop must catch it once the first PUT settles.
+    let resolveFirst
+    const onSave = vi.fn()
+      .mockImplementationOnce(() => new Promise((r) => { resolveFirst = r }))
+      .mockResolvedValueOnce(undefined)
+    const { container } = render(<SystemPromptEditor mainPrompt="orig" onSaveMain={onSave} />)
+    expand()
+    const ta = container.querySelector('textarea')
+
+    // Edit to A and blur — starts the (deferred) save of A.
+    fireEvent.change(ta, { target: { value: 'A' } })
+    fireEvent.blur(ta)
+    expect(onSave).toHaveBeenNthCalledWith(1, 'A')
+
+    // Edit to B while A's save is in flight; this blur is dropped by the
+    // `saving` guard and must NOT trigger its own save yet.
+    fireEvent.change(ta, { target: { value: 'B' } })
+    fireEvent.blur(ta)
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    // Once A's save settles, the loop must persist the latest value (B).
+    resolveFirst()
+    await waitFor(() => expect(onSave).toHaveBeenNthCalledWith(2, 'B'))
+    await waitFor(() => expect(container.textContent).not.toContain('Unsaved'))
+  })
 })

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import SystemPromptEditor from './SystemPromptEditor'
+
+// vitest globals are off, so RTL auto-cleanup isn't registered.
+afterEach(() => cleanup())
+
+function expand() {
+  fireEvent.click(screen.getByRole('button', { name: /System Prompt/ }))
+}
+
+describe('SystemPromptEditor', () => {
+  it('is collapsed by default', () => {
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={vi.fn()} />)
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+
+  it('expands to a single textarea — no critic/sidekick prompt', () => {
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={vi.fn()} />)
+    expand()
+    expect(container.querySelectorAll('textarea')).toHaveLength(1)
+    expect(container.textContent).not.toMatch(/critic/i)
+    expect(container.textContent).not.toMatch(/sidekick/i)
+  })
+
+  it('is editable — typed text appears in the textarea', () => {
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={vi.fn()} />)
+    expand()
+    const ta = container.querySelector('textarea')
+    expect(ta.value).toBe('hello')
+    fireEvent.change(ta, { target: { value: 'hello world' } })
+    expect(ta.value).toBe('hello world')
+  })
+
+  it('persists on blur when the prompt changed', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={onSave} />)
+    expand()
+    const ta = container.querySelector('textarea')
+    fireEvent.change(ta, { target: { value: 'edited prompt' } })
+    fireEvent.blur(ta)
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('edited prompt'))
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not persist on blur when the prompt is unchanged', () => {
+    const onSave = vi.fn()
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={onSave} />)
+    expand()
+    fireEvent.blur(container.querySelector('textarea'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('shows Unsaved while dirty and clears it after a successful save', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={onSave} />)
+    expand()
+    const ta = container.querySelector('textarea')
+    fireEvent.change(ta, { target: { value: 'edited' } })
+    expect(container.textContent).toContain('Unsaved')
+    fireEvent.blur(ta)
+    await waitFor(() => expect(container.textContent).not.toContain('Unsaved'))
+  })
+
+  it('keeps Unsaved and surfaces the error when the save fails', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('network down'))
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={onSave} />)
+    expand()
+    const ta = container.querySelector('textarea')
+    fireEvent.change(ta, { target: { value: 'edited' } })
+    fireEvent.blur(ta)
+    await waitFor(() => expect(container.textContent).toContain('network down'))
+    expect(container.textContent).toContain('Unsaved')
+  })
+
+  it('does not re-save an already-saved value on a second blur', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const { container } = render(<SystemPromptEditor mainPrompt="hello" onSaveMain={onSave} />)
+    expand()
+    const ta = container.querySelector('textarea')
+    fireEvent.change(ta, { target: { value: 'edited' } })
+    fireEvent.blur(ta)
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    fireEvent.blur(ta)  // nothing changed since the save
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/SystemPromptEditor.test.jsx
@@ -85,6 +85,35 @@ describe('SystemPromptEditor', () => {
     expect(onSave).toHaveBeenCalledTimes(1)
   })
 
+  it('flush() persists an unsaved (un-blurred) edit and resolves only after it lands', async () => {
+    let resolveSave
+    const onSave = vi.fn().mockImplementationOnce(() => new Promise((r) => { resolveSave = r }))
+    const ref = { current: null }
+    const { container } = render(
+      <SystemPromptEditor ref={ref} mainPrompt="orig" onSaveMain={onSave} />,
+    )
+    expand()
+    // Edit but do NOT blur — flush() must still persist it.
+    fireEvent.change(container.querySelector('textarea'), { target: { value: 'edited' } })
+
+    let flushed = false
+    ref.current.flush().then(() => { flushed = true })
+    await Promise.resolve()
+    expect(onSave).toHaveBeenCalledWith('edited')
+    expect(flushed).toBe(false) // still in flight
+
+    resolveSave()
+    await waitFor(() => expect(flushed).toBe(true))
+  })
+
+  it('flush() resolves immediately when there is nothing to save', async () => {
+    const onSave = vi.fn()
+    const ref = { current: null }
+    render(<SystemPromptEditor ref={ref} mainPrompt="orig" onSaveMain={onSave} />)
+    await ref.current.flush()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
   it('persists an edit made while an earlier save is still in flight', async () => {
     // Regression for PR #44 codex iteration 2: a blur during an in-flight
     // save was dropped by the `saving` guard, so the later edit never got


### PR DESCRIPTION
## Problem

The chat page's "System Prompts" panel was effectively read-only. The textareas were controlled components bound straight to the persisted `conversation.main_system_prompt` / `sidekick_system_prompt` props, while `onChange` only fired an async server PUT and never touched local state. Every keystroke re-rendered the textarea back to the stale prop value, so the box looked frozen — and each keystroke also fired a full PUT request.

This is a pre-existing bug, separate from issue #23 (which made the *global default* prompt editable on the Tools page).

## Fix

- **`SystemPromptEditor.jsx`** — the Main Model prompt is now backed by **local state** and persisted once, **on blur**. A `savedValue` tracks the last-persisted text so the "Unsaved" indicator is correct without the parent reloading the conversation. Save errors surface inline; a failed save keeps the editor dirty.
- **Removed the Critic Model (sidekick) textarea** — the sidekick prompt isn't tuned per-conversation. The `sidekick_system_prompt` DB field and its default are untouched; only the per-conversation editor is dropped.
- **`ChatArea.jsx`** — keys `SystemPromptEditor` by `conversation.id` so local edit state resets cleanly on conversation switch; passes the renamed `onSaveMain`.

## Tests

New `SystemPromptEditor.test.jsx` (8 tests): collapsed-by-default, single textarea (no critic), editability, save-on-blur, no-op blur when unchanged, Unsaved-indicator lifecycle, error surfacing, no double-save. Full frontend suite: **66 passed**. Lint + `vite build` clean.