### PR TITLE
fix(chat): preserve ChatPage state across /chat → /chat/:id

### DIFF
--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -26,8 +26,13 @@ function App() {
       <main className="flex-1 flex flex-col overflow-hidden min-w-0">
         <MobileNav />
         <Routes>
-          <Route path="/chat" element={<ChatPage />} />
-          <Route path="/chat/:conversationId" element={<ChatPage />} />
+          {/* Single route with an optional :conversationId so the empty
+              /chat URL and /chat/<id> both render the SAME ChatPage
+              instance. With two separate <Route> entries React Router
+              unmounts/remounts on the transition, which drops the
+              pendingMsgRef holding the empty-state composer's first
+              message. */}
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
           <Route path="/tools" element={<DefaultLayout><ToolsPage /></DefaultLayout>} />
           <Route path="/" element={<DefaultLayout><GpuMonitor /><ServicesTable /></DefaultLayout>} />
           <Route path="/services/:serviceName/*" element={<DefaultLayout><ServiceDetailsPage /></DefaultLayout>} />


### PR DESCRIPTION
## Summary

The empty-state composer at `/chat` queues its first message in a
component-level `pendingMsgRef`, then calls `navigate(\`/chat/${conv.id}\`)`
so the just-created conversation loads and a flush effect picks the
message off the ref. With the previous routing config:

```jsx
<Route path="/chat" element={<ChatPage />} />
<Route path="/chat/:conversationId" element={<ChatPage />} />
```

React Router treated those as two distinct routes, so the transition
unmounted the `ChatPage` instance at `/chat` and mounted a fresh one at
`/chat/:conversationId`. The fresh instance had `pendingMsgRef === null`,
so the queued first message was silently dropped — the new chat appeared
blank and the user had to retype.

Collapsing into a single route with an optional param keeps the same
component instance mounted across both URLs, so the ref survives the
transition.

```jsx
<Route path="/chat/:conversationId?" element={<ChatPage />} />
```

## Test plan

- [ ] Open `/chat`, type a message in the empty-state composer, submit.
- [ ] Verify the URL flips to `/chat/<new-id>` AND the typed message is
      sent automatically (no manual retype required).
- [ ] Repeat for a second consecutive new chat in the same session.
- [ ] Direct-load `/chat/<existing-id>` still loads the conversation.
- [ ] `npm test` — 74 passing.
- [ ] `npm run build` — clean.