### PR TITLE
fix(chat): empty-state composer's first message actually POSTs

### DIFF
--- a/dashboard/docker_utils.py
+++ b/dashboard/docker_utils.py
@@ -96,6 +96,24 @@ def check_docker():
         return False
 
 
+def _service_kind(config):
+    """Classify a service config as 'chat' or 'embedding' from its params.
+
+    Embedding services are identified by vLLM's pooling runner / embed
+    convert flags or by llama.cpp's --embedding flag. Everything else
+    (instruct/chat models, base completion models) is treated as 'chat'
+    for the purposes of the chat composer's default-model selection.
+    """
+    params = (config or {}).get("params") or {}
+    if params.get("--runner") == "pooling":
+        return "embedding"
+    if params.get("--convert") == "embed":
+        return "embedding"
+    if "--embedding" in params or "--embeddings" in params:
+        return "embedding"
+    return "chat"
+
+
 def get_docker_services():
     """Get status of compose services from Docker"""
     client = docker.from_env()
@@ -108,6 +126,7 @@ def get_docker_services():
     template_type_map = {}
     model_path_map = {}
     model_name_map = {}
+    kind_map = {}
     for service_name in allowed_services:
         config = compose_mgr.get_service_from_db(service_name)
         if config:
@@ -115,6 +134,7 @@ def get_docker_services():
             template_type_map[service_name] = config.get("template_type", "")
             model_path_map[service_name] = config.get("model_path")
             model_name_map[service_name] = config.get("model_name")
+            kind_map[service_name] = _service_kind(config)
 
     # Get Open WebUI registered URLs (one query for all services)
     openwebui_urls = get_openwebui_registered_urls()
@@ -156,6 +176,7 @@ def get_docker_services():
                 "openwebui_registered": is_registered_in_openwebui(service_name),
                 "model_size": model_size,
                 "model_size_str": model_size_str,
+                "kind": kind_map.get(service_name, "chat"),
             }
 
     # Build complete services list from compose file
@@ -182,6 +203,7 @@ def get_docker_services():
                     "openwebui_registered": is_registered_in_openwebui(service_name),
                     "model_size": model_size,
                     "model_size_str": model_size_str,
+                    "kind": kind_map.get(service_name, "chat"),
                 }
             )
 

--- a/dashboard/frontend/src/components/chat/pendingFlush.js
+++ b/dashboard/frontend/src/components/chat/pendingFlush.js
@@ -7,6 +7,13 @@
 //   'send'    — route + loaded conversation match and not streaming
 export function pendingFlushDecision(pending, convId, conversation, streaming) {
   if (!pending) return 'wait'
+  // convId is null on the empty-state /chat render that runs after
+  // handleCreateAndSend has set pendingMsgRef but before navigate() has
+  // committed the URL change. Treating that as 'abandon' clears the
+  // queued message before the flush effect ever gets a chance to send
+  // it (the bug behind PR #46 not actually fixing /new-chat-issue).
+  // Wait for the route to settle instead.
+  if (!convId) return 'wait'
   if (convId !== pending.convId) return 'abandon'
   if (conversation && conversation.id === pending.convId && !streaming) return 'send'
   return 'wait'

--- a/dashboard/frontend/src/components/chat/pendingFlush.test.js
+++ b/dashboard/frontend/src/components/chat/pendingFlush.test.js
@@ -21,10 +21,20 @@ describe('pendingFlushDecision', () => {
     expect(pendingFlushDecision(pending, 'C', { id: 'C' }, false)).toBe('send')
   })
 
-  it('abandons when the user has navigated away from the pending route', () => {
+  it('abandons when the user has navigated to a different conversation', () => {
     // codex iter 3 P1: a late getConversation resolving for C must not
     // trigger a background send once the route is B.
     expect(pendingFlushDecision(pending, 'B', { id: 'C' }, false)).toBe('abandon')
-    expect(pendingFlushDecision(pending, null, { id: 'C' }, false)).toBe('abandon')
+  })
+
+  it('waits (not abandon) while convId is null between ref-set and navigate commit', () => {
+    // Bug behind #46 not fixing /new-chat-issue: handleCreateAndSend sets
+    // pendingMsgRef.current synchronously then calls navigate(); a render
+    // can fire with convId still null (route hasn't committed yet) and
+    // pendingMsgRef already set. Treating that as 'abandon' would clear
+    // the queued message before the route settles and the POST never
+    // fires.
+    expect(pendingFlushDecision(pending, null, null, false)).toBe('wait')
+    expect(pendingFlushDecision(pending, null, { id: 'C' }, false)).toBe('wait')
   })
 })

--- a/dashboard/frontend/src/hooks/useRunningServices.js
+++ b/dashboard/frontend/src/hooks/useRunningServices.js
@@ -4,22 +4,27 @@ import useServicesSSE from './useServicesSSE'
 /**
  * Hook for getting running inference services (llama.cpp and vLLM only).
  * Derives state from the SSE stream via useServicesSSE.
- * 
- * @returns {{
- *   services: Array<Object>,
- *   loading: boolean
- * }} Hook return value with running services and loading state
+ *
+ * By default returns only chat-capable services — embedding pooling
+ * services (vLLM `--runner pooling` / `--convert embed`, llama.cpp
+ * `--embedding`) can't serve `/v1/chat/completions` and shouldn't appear
+ * in the chat composer's default-model slot. Pass `kind: 'all'` for the
+ * Services dashboard which needs every running container.
  */
-export default function useRunningServices() {
+export default function useRunningServices({ kind = 'chat' } = {}) {
   const { services, loading } = useServicesSSE()
 
   const runningServices = useMemo(() => {
     if (!services) return []
-    // Filter to only inference services (llama.cpp and vLLM), excluding infrastructure like open-webui
-    return services.filter(s =>
-      s.status === 'running' && (s.name.startsWith('llamacpp-') || s.name.startsWith('vllm-'))
-    )
-  }, [services])
+    return services.filter(s => {
+      if (s.status !== 'running') return false
+      if (!s.name.startsWith('llamacpp-') && !s.name.startsWith('vllm-')) return false
+      if (kind === 'all') return true
+      // Snapshot pre-rollout: treat missing kind as 'chat' so old payloads
+      // don't filter everything out.
+      return (s.kind || 'chat') === kind
+    })
+  }, [services, kind])
 
   return { services: runningServices, loading }
 }


### PR DESCRIPTION
## Summary

Two stacked bugs were keeping the empty-state composer broken. PR #46 only addressed a phantom (the route-consolidation theory turned out not to be the cause).

### 1. `pendingFlushDecision` was abandoning queued messages mid-navigate

`handleCreateAndSend` does:
\`\`\`js
pendingMsgRef.current = { convId: conv.id, content, images }  // sync
navigate(\`/chat/\${conv.id}\`)
\`\`\`

There's a render window where `pendingMsgRef.current` is set but the route hasn't committed yet — `convId === null`. The decision function treated that as "user navigated away" and cleared the ref. By the time `loadConversation` resolved, there was no pending message left to flush, so `POST /api/chat/conversations/<id>/messages` never fired.

(Diagnosis credit: `codex exec` looked at the control flow with fresh eyes after I'd been chasing the wrong theory.)

**Fix**: `if (!convId) return 'wait'` before the abandon check. Still abandons when the route is set to a *different* conversation, preserving the codex-iter-3 protection against stale-fetch background sends.

### 2. Embedding services were being picked as the default chat model

`runningServices[0]` could be `vllm-bge-m3` (vLLM pooling/embed). It can't serve `/v1/chat/completions`, so the resulting conversation was broken regardless of whether the message reached it.

**Fix**: backend stamps `kind: 'chat' | 'embedding'` on each service snapshot in `docker_utils.py` (detected from `--runner pooling` / `--convert embed` / `--embedding` flags); `useRunningServices` defaults to filtering to chat-kind. `ServicesTable` goes through `useServicesSSE` directly, so the main dashboard still shows everything.

## Test plan

- [x] `npm test` — 75/75 (1 new regression test in `pendingFlush.test.js`).
- [x] `npm run build` — clean.
- [x] `pytest dashboard/tests/` — 194/194.
- [ ] Restart dashboard service; open `/v2/chat`; type a message in the empty-state composer; verify `POST /api/chat/conversations/<id>/messages` fires and the assistant streams a reply.
- [ ] Verify embedding services no longer appear as the default in the empty-state hint text ("Type a message below — a chat will be created with `<model>`").