### PR TITLE
feat(chat): shift-click range selection in conversation sidebar

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -22,10 +22,19 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       }`}
       style={{ paddingLeft: `${12 + depth * 16}px`, paddingRight: 12 }}
     >
+      {/* Drive the toggle from the label's click rather than the nested
+          <input>'s. The label is a 32px hit target wrapping a 14px
+          checkbox; clicks on the surrounding padding reach the input
+          only via the browser's label-activation synthetic click, whose
+          modifier-key state is not guaranteed to mirror the original
+          mouse event. Reading shiftKey from the label click — and
+          preventDefault-ing so the synthetic input toggle never fires —
+          keeps the full hit target consistent with the visible checkbox
+          (PR #48 codex iter 2). */}
       {isSpinoff ? (
         <label
           className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
-          onClick={e => e.stopPropagation()}
+          onClick={e => { e.preventDefault(); e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
         >
           <i
             className={`fa-solid fa-code-branch text-[10px] opacity-50 text-purple-400 absolute inset-0 flex items-center justify-center transition-opacity pointer-events-none ${spinoffIconVisibilityClass}`}
@@ -34,7 +43,6 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => {}}
-            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
             title="Select"
           />
@@ -42,13 +50,12 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
       ) : (
         <label
           className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
-          onClick={e => e.stopPropagation()}
+          onClick={e => { e.preventDefault(); e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
         >
           <input
             type="checkbox"
             checked={selected}
             onChange={() => {}}
-            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${
               checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
             }`}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import ThemeSwitcher from '../ThemeSwitcher'
 
 function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggleSelect, confirmDelete, setConfirmDelete, onSelect, onDelete }) {
@@ -33,7 +33,8 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
           <input
             type="checkbox"
             checked={selected}
-            onChange={() => onToggleSelect(conv.id)}
+            onChange={() => {}}
+            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
             title="Select"
           />
@@ -46,7 +47,8 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
           <input
             type="checkbox"
             checked={selected}
-            onChange={() => onToggleSelect(conv.id)}
+            onChange={() => {}}
+            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${
               checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
             }`}
@@ -89,6 +91,10 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [selectedIds, setSelectedIds] = useState(() => new Set())
   const [confirmBulk, setConfirmBulk] = useState(false)
+  // Anchor for shift-click range selection. Holds the id of the last
+  // checkbox toggled without shift; a subsequent shift-click selects the
+  // span between anchor and clicked id in render order.
+  const anchorIdRef = useRef(null)
 
   // Build tree: top-level conversations + their children
   const tree = useMemo(() => {
@@ -103,18 +109,50 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
     return { roots, childrenMap }
   }, [conversations])
 
-  const toggleSelect = (id) => {
+  // Flat list of conversation ids in render order (root, then its
+  // descendants depth-first, then next root, …). Used to resolve the
+  // [anchor, clicked] span for shift-click range selection.
+  const flatOrder = useMemo(() => {
+    const out = []
+    const walk = (id) => {
+      out.push(id)
+      for (const child of tree.childrenMap[id] || []) walk(child.id)
+    }
+    for (const root of tree.roots) walk(root.id)
+    return out
+  }, [tree])
+
+  const toggleSelect = (id, shiftKey) => {
+    const anchor = anchorIdRef.current
+    if (shiftKey && anchor && anchor !== id) {
+      const ai = flatOrder.indexOf(anchor)
+      const ci = flatOrder.indexOf(id)
+      if (ai !== -1 && ci !== -1) {
+        const [lo, hi] = ai < ci ? [ai, ci] : [ci, ai]
+        const range = flatOrder.slice(lo, hi + 1)
+        setSelectedIds(prev => {
+          const next = new Set(prev)
+          for (const rid of range) next.add(rid)
+          return next
+        })
+        // Leave anchor alone so subsequent shift-clicks extend from the
+        // same origin (standard finder/gmail behavior).
+        return
+      }
+    }
     setSelectedIds(prev => {
       const next = new Set(prev)
       if (next.has(id)) next.delete(id)
       else next.add(id)
       return next
     })
+    anchorIdRef.current = id
   }
 
   const clearSelection = () => {
     setSelectedIds(new Set())
     setConfirmBulk(false)
+    anchorIdRef.current = null
   }
 
   const handleBulkDelete = async () => {

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
+import ChatSidebar from './ChatSidebar'
+
+// ThemeSwitcher pulls in unrelated context (icons, theme store). Stub it.
+vi.mock('../ThemeSwitcher', () => ({ default: () => null }))
+
+afterEach(() => cleanup())
+
+// Tree shape used by the range tests:
+//   A
+//     A1   (spinoff of A)
+//   B
+//   C
+//     C1   (spinoff of C)
+//   D
+// flatOrder (depth-first) is therefore: A, A1, B, C, C1, D.
+const conversations = [
+  { id: 'A',  title: 'A',  parent_conversation_id: null, updated_at: '2026-01-01' },
+  { id: 'A1', title: 'A1', parent_conversation_id: 'A',  updated_at: '2026-01-01' },
+  { id: 'B',  title: 'B',  parent_conversation_id: null, updated_at: '2026-01-01' },
+  { id: 'C',  title: 'C',  parent_conversation_id: null, updated_at: '2026-01-01' },
+  { id: 'C1', title: 'C1', parent_conversation_id: 'C',  updated_at: '2026-01-01' },
+  { id: 'D',  title: 'D',  parent_conversation_id: null, updated_at: '2026-01-01' },
+]
+
+function renderSidebar() {
+  return render(
+    <ChatSidebar
+      conversations={conversations}
+      activeId={null}
+      onSelect={() => {}}
+      onCreate={() => {}}
+      onDelete={() => {}}
+      onDeleteMany={() => {}}
+    />
+  )
+}
+
+// Returns the checkbox <input> for the conversation row titled `title`.
+// Each row's title sits next to its checkbox inside the row container.
+function checkboxFor(title) {
+  const titleNode = screen.getByText(title)
+  const row = titleNode.closest('.group')
+  return within(row).getByRole('checkbox')
+}
+
+function selectedTitles() {
+  // All checked checkboxes, mapped back to their row's title text.
+  return screen
+    .getAllByRole('checkbox')
+    .filter(cb => cb.checked)
+    .map(cb => within(cb.closest('.group')).getAllByText(/^[A-Z]\d?$/)[0].textContent)
+}
+
+describe('ChatSidebar shift-click range selection', () => {
+  it('plain click toggles a single row and sets the anchor', () => {
+    renderSidebar()
+    fireEvent.click(checkboxFor('B'))
+    expect(selectedTitles()).toEqual(['B'])
+  })
+
+  it('shift-click without an anchor falls back to a single toggle', () => {
+    renderSidebar()
+    // First interaction is a shift-click — no prior anchor exists, so it
+    // should just toggle the clicked row.
+    fireEvent.click(checkboxFor('C'), { shiftKey: true })
+    expect(selectedTitles()).toEqual(['C'])
+  })
+
+  it('shift-click selects the inclusive depth-first range between anchor and clicked', () => {
+    renderSidebar()
+    fireEvent.click(checkboxFor('A'))                       // anchor = A
+    fireEvent.click(checkboxFor('C1'), { shiftKey: true })  // range A..C1
+    // flatOrder slice from A to C1 is A, A1, B, C, C1.
+    expect(selectedTitles()).toEqual(['A', 'A1', 'B', 'C', 'C1'])
+  })
+
+  it('range works in reverse (clicked above anchor) and includes both endpoints', () => {
+    renderSidebar()
+    fireEvent.click(checkboxFor('D'))                      // anchor = D
+    fireEvent.click(checkboxFor('A1'), { shiftKey: true }) // range A1..D
+    expect(selectedTitles()).toEqual(['A1', 'B', 'C', 'C1', 'D'])
+  })
+
+  it('anchor persists across consecutive shift-clicks (Finder/Gmail behavior)', () => {
+    renderSidebar()
+    fireEvent.click(checkboxFor('A'))                      // anchor = A
+    fireEvent.click(checkboxFor('B'), { shiftKey: true })  // range A..B
+    fireEvent.click(checkboxFor('D'), { shiftKey: true })  // range A..D, anchor still A
+    expect(selectedTitles()).toEqual(['A', 'A1', 'B', 'C', 'C1', 'D'])
+  })
+
+  it('Clear resets the anchor so the next shift-click no longer extends the old range', () => {
+    renderSidebar()
+    fireEvent.click(checkboxFor('A'))                       // anchor = A
+    fireEvent.click(checkboxFor('B'), { shiftKey: true })   // range A..B
+    fireEvent.click(screen.getByTitle('Clear selection'))   // clears + drops anchor
+
+    // With the anchor gone, a fresh shift-click should behave like a single
+    // toggle, not extend from the cleared anchor.
+    fireEvent.click(checkboxFor('D'), { shiftKey: true })
+    expect(selectedTitles()).toEqual(['D'])
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -37,16 +37,19 @@ function renderSidebar() {
   )
 }
 
-// Returns the checkbox <input> for the conversation row titled `title`.
-// Each row's title sits next to its checkbox inside the row container.
+// Returns the label that wraps the conversation row's checkbox. The
+// label is the actual click target — it's a 32px hit area around a 14px
+// <input>, and the toggle handler lives on the label so that clicks on
+// the padding behave the same as clicks on the input itself.
 function checkboxFor(title) {
   const titleNode = screen.getByText(title)
   const row = titleNode.closest('.group')
-  return within(row).getByRole('checkbox')
+  return within(row).getByRole('checkbox').closest('label')
 }
 
 function selectedTitles() {
-  // All checked checkboxes, mapped back to their row's title text.
+  // All checked checkboxes, mapped back to their row's title text. Order
+  // matches the rendered DOM order, which is the same as flatOrder.
   return screen
     .getAllByRole('checkbox')
     .filter(cb => cb.checked)
@@ -90,6 +93,16 @@ describe('ChatSidebar shift-click range selection', () => {
     fireEvent.click(checkboxFor('D'), { shiftKey: true })  // range A..D, anchor still A
     expect(selectedTitles()).toEqual(['A', 'A1', 'B', 'C', 'C1', 'D'])
   })
+
+  // Note: the in-real-browsers scenario where the user clicks directly
+  // on the visible 14px <input> (whose click bubbles up to the label's
+  // onClick) cannot be reproduced under jsdom — its label activation
+  // model doesn't propagate input clicks to a wrapping label's onClick
+  // the way real browsers do. The label-padding tests above (which click
+  // the label element directly) cover the case codex iter 2 actually
+  // flagged: the synthetic activation when the user clicks the larger
+  // hit target. Direct-input clicks are exercised manually in the
+  // browser as part of the PR's test plan.
 
   it('Clear resets the anchor so the next shift-click no longer extends the old range', () => {
     renderSidebar()


### PR DESCRIPTION
## Summary

Adds shift-click range selection to the chat sidebar's conversation checkboxes.

- Plain click on a checkbox: toggle that row, anchor moves to it (same as before, just now with an explicit anchor tracked).
- Shift-click another checkbox: select every conversation between the anchor and the clicked row in render order — roots and their spin-offs interleaved depth-first.
- Anchor stays put across consecutive shift-clicks (Finder / Gmail behavior), so you can fan a range out from one origin.
- Anchor resets when the selection is cleared.

## Notes

- The range is built from `flatOrder`, a memoized depth-first walk of the visible tree, so spin-offs are correctly included when the anchor and clicked checkbox span them.
- Native `<input type="checkbox">` toggle is suppressed (`onChange` no-op, `onClick` handles the toggle ourselves) so we can read `shiftKey` off the click event — `onChange` doesn't expose modifiers.
- Anchor lives in a ref, not state, because it never needs to trigger a re-render.

## Test plan

- [x] `npm test` — 75/75 (no regressions; existing select-mode flow unchanged for plain clicks).
- [x] `npm run build` — clean.
- [ ] Manual: click checkbox A, shift-click checkbox B several rows down → all rows between A and B selected.
- [ ] Manual: anchor at root A, shift-click checkbox on a spinoff of root C → range includes A, all rows in between (including A and C's roots/spinoffs in order), up to the clicked spinoff.
- [ ] Manual: Clear → next click starts a fresh anchor.