### PR TITLE
feat(mcp): support remote MCP servers over HTTP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,12 @@ config live outside this repo) are declared in a JSON file on disk,
 default `dashboard/mcp_servers.json` (gitignored). Override via
 `LLM_DOCK_MCP_SERVERS_FILE`.
 
-Shape — one entry per server id, top-level object keyed by id. See
-`dashboard/mcp_servers.example.json` for a working example.
+Shape — one entry per server id, top-level object keyed by id. Two
+transports are supported: **stdio** (local subprocess, the default) and
+**http** (remote MCP over the SDK's streamable-HTTP transport). See
+`dashboard/mcp_servers.example.json` for working examples of both.
+
+Stdio (local subprocess):
 
 ```json
 {
@@ -140,15 +144,48 @@ Shape — one entry per server id, top-level object keyed by id. See
 }
 ```
 
+HTTP (remote MCP):
+
+```json
+{
+  "ragflow": {
+    "enabled": true,
+    "name": "RagFlow",
+    "description": "Query the local RagFlow knowledge base over HTTP",
+    "transport": "http",
+    "url": "http://localhost:9382/mcp",
+    "headers": { "Authorization": "Bearer ..." },
+    "icon": "fa-cloud",
+    "tool_hint": "..."
+  }
+}
+```
+
 Rules enforced at load time:
 
-- `command` must be an **absolute path**. No `shell=True`, no PATH lookup.
 - `id` must not contain `__` (collides with `server_id__tool_name`
   namespacing in `mcp_client.py`).
 - `id` must not collide with a built-in (`sympy-math`, `schemdraw-circuits`,
   `render-html`). Built-ins always win.
-- All of `name`, `description`, `command`, `args`, `icon`, `tool_hint` are
-  required; `enabled` defaults to `true`.
+- `name`, `description`, `icon`, `tool_hint` are always required.
+- `enabled` defaults to `true`.
+- `transport` defaults to `"stdio"`. Accepted values: `"stdio"`, `"http"`.
+  `"type": "remote"` (Claude Code's shape) is accepted as a synonym for
+  `transport: "http"`, so configs from other harnesses can be pasted in
+  unchanged.
+- For **stdio** entries: `command` (absolute path; no `shell=True`, no
+  PATH lookup) and `args` (list of strings) are required.
+- For **http** entries: `url` (must start with `http://` or `https://`)
+  is required. `headers` is an optional object of string→string and is
+  sent on every request — values are plain strings (no env-var
+  interpolation yet, so don't commit production secrets via this file).
+
+Chat-side availability differs by transport: stdio entries are hidden
+from chat until the command path exists on disk; http entries are
+considered available as soon as they're enabled (the remote is not
+probed at startup). A misconfigured remote therefore surfaces as a
+tool-call error at chat time rather than as a missing entry on the
+Tools page.
 
 Editing the file:
 

--- a/dashboard/chat/mcp_admin_routes.py
+++ b/dashboard/chat/mcp_admin_routes.py
@@ -51,11 +51,22 @@ def _registry_view(state: dict) -> dict:
             "enabled": bool(cfg.get("enabled", True)),
         }
         if not is_builtin:
-            cmd = cfg["command"]
-            entry["command"] = cmd[0]
-            entry["args"] = cmd[1:]
-            entry["command_exists"] = bool(cmd) and os.path.exists(cmd[0])
+            transport = cfg.get("transport", "stdio")
+            entry["transport"] = transport
+            if transport == "http":
+                entry["url"] = cfg.get("url", "")
+                entry["headers"] = dict(cfg.get("headers") or {})
+                # HTTP entries have no on-disk presence to check; the
+                # field stays True so the existing "no command" badge in
+                # the UI doesn't fire spuriously.
+                entry["command_exists"] = True
+            else:
+                cmd = cfg["command"]
+                entry["command"] = cmd[0]
+                entry["args"] = cmd[1:]
+                entry["command_exists"] = bool(cmd) and os.path.exists(cmd[0])
         else:
+            entry["transport"] = "stdio"
             entry["command_exists"] = True
         servers.append(entry)
     return {

--- a/dashboard/chat/mcp_admin_routes.py
+++ b/dashboard/chat/mcp_admin_routes.py
@@ -55,7 +55,13 @@ def _registry_view(state: dict) -> dict:
             entry["transport"] = transport
             if transport == "http":
                 entry["url"] = cfg.get("url", "")
-                entry["headers"] = dict(cfg.get("headers") or {})
+                # Only the header NAMES are returned — values can hold
+                # secrets (e.g. `Authorization: Bearer …`) and the
+                # /api/chat/mcp-registry endpoint should never echo them
+                # back. The UI just needs the keys to render a "present"
+                # indicator; full values stay in mcp_servers.json on
+                # disk.
+                entry["header_keys"] = sorted(list((cfg.get("headers") or {}).keys()))
                 # HTTP entries have no on-disk presence to check; the
                 # field stays True so the existing "no command" badge in
                 # the UI doesn't fire spuriously.

--- a/dashboard/chat/mcp_client.py
+++ b/dashboard/chat/mcp_client.py
@@ -1,15 +1,42 @@
 """MCP Client Manager — spawns MCP servers and executes tools."""
 
 import asyncio
+import contextlib
 import json
 import logging
 import threading
 from typing import Optional
 
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 from mcp import ClientSession
 
 from .mcp_registry import get_server_config
+
+
+@contextlib.asynccontextmanager
+async def _open_streams(config: dict):
+    """Open the read/write streams for an MCP server, regardless of transport.
+
+    Yields the (read, write) pair the SDK's `ClientSession` expects. The
+    `streamablehttp_client` context manager also yields a session-id
+    callable as a third value; we discard it — the dashboard treats every
+    chat-side discover/execute as a one-shot connection, and the session
+    id is only useful for resuming across calls.
+    """
+    transport = config.get("transport", "stdio")
+    if transport == "http":
+        url = config["url"]
+        headers = config.get("headers") or None
+        async with streamablehttp_client(url, headers=headers) as (read, write, _get_session_id):
+            yield read, write
+    else:
+        params = StdioServerParameters(
+            command=config["command"][0],
+            args=config["command"][1:],
+        )
+        async with stdio_client(params) as (read, write):
+            yield read, write
 
 logger = logging.getLogger(__name__)
 
@@ -119,11 +146,7 @@ class MCPClientManager:
 
     async def _discover_tools(self, config: dict, server_id: str) -> list:
         """Connect to server, list tools, disconnect."""
-        params = StdioServerParameters(
-            command=config["command"][0],
-            args=config["command"][1:],
-        )
-        async with stdio_client(params) as (read, write):
+        async with _open_streams(config) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.list_tools()
@@ -131,11 +154,7 @@ class MCPClientManager:
 
     async def _execute_tool(self, config: dict, tool_name: str, arguments: dict) -> tuple:
         """Connect to server, call tool, return (result_text, artifacts)."""
-        params = StdioServerParameters(
-            command=config["command"][0],
-            args=config["command"][1:],
-        )
-        async with stdio_client(params) as (read, write):
+        async with _open_streams(config) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.call_tool(tool_name, arguments)

--- a/dashboard/chat/mcp_config.py
+++ b/dashboard/chat/mcp_config.py
@@ -23,7 +23,24 @@ DEFAULT_CONFIG_FILE = os.path.join(
     "mcp_servers.json",
 )
 
-REQUIRED_FIELDS = ("name", "description", "command", "args", "icon", "tool_hint")
+_COMMON_REQUIRED_FIELDS = ("name", "description", "icon", "tool_hint")
+_STDIO_REQUIRED_FIELDS = ("command", "args")
+_HTTP_REQUIRED_FIELDS = ("url",)
+
+# Recognized transports. `"http"` covers MCP's Streamable HTTP transport
+# (the SDK's `streamablehttp_client`), which is the modern remote-server
+# protocol; the URL scheme can be either http or https. `"remote"` is
+# accepted as a synonym so configs originally written for other harnesses
+# (e.g. Claude Code's `"type": "remote"` form) can be pasted in unchanged.
+_TRANSPORT_STDIO = "stdio"
+_TRANSPORT_HTTP = "http"
+_TRANSPORT_ALIASES = {
+    _TRANSPORT_STDIO: _TRANSPORT_STDIO,
+    _TRANSPORT_HTTP: _TRANSPORT_HTTP,
+    "remote": _TRANSPORT_HTTP,
+    "streamable-http": _TRANSPORT_HTTP,
+    "streamable_http": _TRANSPORT_HTTP,
+}
 
 _lock = threading.Lock()
 _state = {
@@ -47,6 +64,25 @@ def bind_manager(manager) -> None:
     _manager = manager
 
 
+def _resolve_transport(entry: dict) -> tuple:
+    """Return (transport, error). transport is the normalized value
+    (`_TRANSPORT_STDIO` or `_TRANSPORT_HTTP`); error is None on success or
+    an error message. Accept both `transport` and `type` as the field
+    name so configs from other harnesses (Claude Code uses `type:
+    "remote"`) can be pasted in unchanged.
+    """
+    raw = entry.get("transport") or entry.get("type") or _TRANSPORT_STDIO
+    if not isinstance(raw, str):
+        return None, "field 'transport' must be a string"
+    resolved = _TRANSPORT_ALIASES.get(raw.lower())
+    if resolved is None:
+        return None, (
+            f"unknown transport '{raw}' — must be one of "
+            f"{sorted(set(_TRANSPORT_ALIASES))}"
+        )
+    return resolved, None
+
+
 def _validate_entry(server_id: str, entry: dict, builtin_ids: set) -> Optional[str]:
     """Return None if valid, otherwise an error message."""
     if not isinstance(server_id, str) or not server_id:
@@ -57,33 +93,66 @@ def _validate_entry(server_id: str, entry: dict, builtin_ids: set) -> Optional[s
         return f"id '{server_id}' collides with a built-in server"
     if not isinstance(entry, dict):
         return "entry must be a JSON object"
-    for field in REQUIRED_FIELDS:
+
+    transport, err = _resolve_transport(entry)
+    if err is not None:
+        return err
+
+    for field in _COMMON_REQUIRED_FIELDS:
         if field not in entry:
             return f"missing required field '{field}'"
-    for field in ("name", "description", "icon", "tool_hint"):
+    for field in _COMMON_REQUIRED_FIELDS:
         if not isinstance(entry[field], str) or not entry[field]:
             return f"field '{field}' must be a non-empty string"
-    if not isinstance(entry["command"], str) or not entry["command"]:
-        return "field 'command' must be a non-empty string"
-    if not os.path.isabs(entry["command"]):
-        return "field 'command' must be an absolute path"
-    if not isinstance(entry["args"], list) or not all(isinstance(a, str) for a in entry["args"]):
-        return "field 'args' must be a list of strings"
+
+    if transport == _TRANSPORT_STDIO:
+        for field in _STDIO_REQUIRED_FIELDS:
+            if field not in entry:
+                return f"missing required field '{field}' (stdio transport)"
+        if not isinstance(entry["command"], str) or not entry["command"]:
+            return "field 'command' must be a non-empty string"
+        if not os.path.isabs(entry["command"]):
+            return "field 'command' must be an absolute path"
+        if not isinstance(entry["args"], list) or not all(isinstance(a, str) for a in entry["args"]):
+            return "field 'args' must be a list of strings"
+    else:  # http
+        for field in _HTTP_REQUIRED_FIELDS:
+            if field not in entry:
+                return f"missing required field '{field}' (http transport)"
+        url = entry["url"]
+        if not isinstance(url, str) or not url:
+            return "field 'url' must be a non-empty string"
+        if not (url.startswith("http://") or url.startswith("https://")):
+            return "field 'url' must start with http:// or https://"
+        headers = entry.get("headers", {})
+        if not isinstance(headers, dict):
+            return "field 'headers' must be a JSON object of string→string"
+        for k, v in headers.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                return "field 'headers' must map strings to strings"
+
     if "enabled" in entry and not isinstance(entry["enabled"], bool):
         return "field 'enabled' must be a boolean"
     return None
 
 
 def _normalize_external(server_id: str, entry: dict) -> dict:
-    return {
+    transport, _ = _resolve_transport(entry)
+    normalized = {
         "name": entry["name"],
         "description": entry["description"],
-        "command": [entry["command"], *entry["args"]],
         "icon": entry["icon"],
         "tool_hint": entry["tool_hint"],
         "external": True,
         "enabled": entry.get("enabled", True),
+        "transport": transport,
     }
+    if transport == _TRANSPORT_STDIO:
+        normalized["command"] = [entry["command"], *entry["args"]]
+    else:
+        normalized["url"] = entry["url"]
+        normalized["headers"] = dict(entry.get("headers", {}))
+    return normalized
 
 
 def _load_external(builtin_ids: set):
@@ -115,7 +184,10 @@ def _load_external(builtin_ids: set):
 
 
 def _merge(builtin: dict, external: dict) -> dict:
-    merged = {sid: {**cfg, "external": False, "enabled": True} for sid, cfg in builtin.items()}
+    merged = {
+        sid: {**cfg, "external": False, "enabled": True, "transport": _TRANSPORT_STDIO}
+        for sid, cfg in builtin.items()
+    }
     for sid, cfg in external.items():
         merged[sid] = cfg
     return merged
@@ -190,17 +262,23 @@ def get_state() -> dict:
 def _chat_available(cfg: dict) -> bool:
     """Is this entry usable from the chat path?
 
-    Built-in entries are always available. External entries must be enabled
-    AND have an existing command on disk — otherwise the model would be
-    told it has a tool that tool discovery can't actually surface, risking
-    fabricated "I used the tool" answers. The Tools page reads the raw
-    state and still shows unavailable external entries so the user can
-    debug them.
+    Built-in entries are always available. External stdio entries must
+    additionally have an existing command on disk — otherwise the model
+    would be told it has a tool that tool discovery can't actually
+    surface, risking fabricated "I used the tool" answers. External HTTP
+    entries only need to be enabled with a non-empty url; reachability is
+    not probed up-front (that would block startup on a slow remote and
+    every reload), so a misconfigured remote shows up as a tool that
+    errors at call time, not as a hidden entry. The Tools page reads the
+    raw state and still shows unavailable external entries so the user
+    can debug them.
     """
     if not cfg.get("enabled", True):
         return False
     if not cfg.get("external"):
         return True
+    if cfg.get("transport") == _TRANSPORT_HTTP:
+        return bool(cfg.get("url"))
     command = cfg.get("command") or []
     return bool(command) and os.path.exists(command[0])
 

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -65,11 +65,11 @@ function ServerDetails({ server, registryErrors }) {
             <span className="text-fg-subtle">url:</span>{' '}
             <span className="font-mono text-fg break-all">{server.url}</span>
           </div>
-          {server.headers && Object.keys(server.headers).length > 0 && (
+          {server.header_keys && server.header_keys.length > 0 && (
             <div>
               <span className="text-fg-subtle">headers:</span>{' '}
-              <span className="font-mono text-fg">{Object.keys(server.headers).join(', ')}</span>
-              <span className="text-fg-subtle"> ({Object.keys(server.headers).length})</span>
+              <span className="font-mono text-fg">{server.header_keys.join(', ')}</span>
+              <span className="text-fg-subtle"> ({server.header_keys.length}, values not shown)</span>
             </div>
           )}
         </div>

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -55,6 +55,24 @@ function ServerDetails({ server, registryErrors }) {
         <div className="text-xs text-fg-subtle bg-app border border-border rounded px-3 py-2">
           Built-in server. Defined in <span className="font-mono">dashboard/chat/mcp_registry.py</span>. Edit via code.
         </div>
+      ) : server.transport === 'http' ? (
+        <div className="bg-app border border-border rounded px-3 py-2 space-y-1 text-xs">
+          <div>
+            <span className="text-fg-subtle">transport:</span>{' '}
+            <span className="font-mono text-fg">http</span>
+          </div>
+          <div>
+            <span className="text-fg-subtle">url:</span>{' '}
+            <span className="font-mono text-fg break-all">{server.url}</span>
+          </div>
+          {server.headers && Object.keys(server.headers).length > 0 && (
+            <div>
+              <span className="text-fg-subtle">headers:</span>{' '}
+              <span className="font-mono text-fg">{Object.keys(server.headers).join(', ')}</span>
+              <span className="text-fg-subtle"> ({Object.keys(server.headers).length})</span>
+            </div>
+          )}
+        </div>
       ) : (
         <div className="bg-app border border-border rounded px-3 py-2 space-y-1 text-xs">
           <div>

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -106,7 +106,11 @@ function ServerDetails({ server, registryErrors }) {
 
       <div className="pt-2 border-t border-border">
         <h3 className="text-xs uppercase tracking-wide text-fg-subtle mb-2">Test</h3>
-        <ServerTestPanel server={server} />
+        {/* key={server.id} forces a remount when switching servers so
+            the panel's discovered-tools / result / textarea state is
+            dropped — otherwise the previous server's tool list and Run
+            output would linger on the new server's pane. */}
+        <ServerTestPanel key={server.id} server={server} />
       </div>
     </div>
   )

--- a/dashboard/mcp_servers.example.json
+++ b/dashboard/mcp_servers.example.json
@@ -11,5 +11,15 @@
     ],
     "icon": "fa-magnifying-glass",
     "tool_hint": "You have access to web search via the web_search tool. Use it whenever the user asks for current, recent, external, or source-backed information — news, prices, version numbers, documentation, anything where your training data may be stale or insufficient. Pass a focused query string; n_results defaults to 10. When the query is about the current state of anything (prices, products, events, rankings, \"best X in Y\"), take the year from the `Current date:` line in this system prompt — do not append a year from your training data unless the user explicitly asked about that specific year. Search results are pointers only: cite URLs from the results, quote sparingly, and say so when the snippets don't fully answer the question rather than inventing details."
+  },
+  "ragflow": {
+    "enabled": true,
+    "name": "RagFlow",
+    "description": "Query the local RagFlow knowledge base over HTTP",
+    "transport": "http",
+    "url": "http://localhost:9382/mcp",
+    "headers": {},
+    "icon": "fa-cloud",
+    "tool_hint": "You have access to RagFlow knowledge-base retrieval. Use it before answering questions about content stored in the configured corpora; cite the retrieved passages rather than paraphrasing from memory."
   }
 }

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv==1.0.0
 urllib3<2.0
 jinja2==3.1.2
 requests>=2.31.0
-mcp[cli]>=1.0.0
+mcp[cli]>=1.8.0  # 1.8.0 is the first release with mcp.client.streamable_http (chat/mcp_client.py imports it unconditionally for HTTP MCP transport)
 sympy>=1.13.0
 schemdraw>=0.19
 markdown-it-py>=3.0.0

--- a/dashboard/tests/test_mcp_admin_routes.py
+++ b/dashboard/tests/test_mcp_admin_routes.py
@@ -1,0 +1,139 @@
+"""Tests for the /api/chat/mcp-registry admin route.
+
+Focused on the redaction contract: header values configured in
+mcp_servers.json must not appear in the public registry view.
+"""
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-mcp-admin")
+
+TOKEN = "test-token-mcp-admin"
+REGISTRY_PATH = "/api/chat/mcp-registry"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_DOCK_MCP_SERVERS_FILE", str(tmp_path / "mcp_servers.json"))
+    # Reload chat.* modules so a fresh Blueprint is created with this
+    # test's config path. Order matters: mcp_admin_routes binds to
+    # chat.routes at import time, so both must be re-imported each test
+    # — otherwise the SECOND test reuses the first test's stale bp.
+    for mod_name in [m for m in list(sys.modules) if m == "chat" or m.startswith("chat.")]:
+        sys.modules.pop(mod_name, None)
+    from chat.routes import chat_bp
+    # Force the mcp_admin_routes side-effect import (it's behind chat.routes' tail import).
+    import chat.mcp_admin_routes  # noqa: F401
+
+    app = Flask(__name__)
+    app.config["DASHBOARD_TOKEN"] = TOKEN
+    app.register_blueprint(chat_bp)
+    app.testing = True
+    return app.test_client(), tmp_path / "mcp_servers.json"
+
+
+def _write_servers(path, data):
+    path.write_text(json.dumps(data))
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def test_registry_view_redacts_http_header_values(client):
+    test_client, cfg_path = client
+    secret = "Bearer super-secret-token-do-not-leak"
+    _write_servers(
+        cfg_path,
+        {
+            "ragflow": {
+                "enabled": True,
+                "name": "RagFlow",
+                "description": "Query the KB",
+                "transport": "http",
+                "url": "http://localhost:9382/mcp",
+                "headers": {"Authorization": secret, "X-Tenant": "acme"},
+                "icon": "fa-cloud",
+                "tool_hint": "Use it.",
+            }
+        },
+    )
+
+    r = test_client.get(REGISTRY_PATH, headers=_auth())
+    assert r.status_code == 200
+    body_text = r.get_data(as_text=True)
+
+    # The header VALUE must never appear in the response, anywhere.
+    assert secret not in body_text
+    # The "headers" object itself is not in the public shape.
+    assert '"headers":' not in body_text
+
+    payload = r.get_json()
+    rf = next(s for s in payload["servers"] if s["id"] == "ragflow")
+    assert rf["transport"] == "http"
+    assert rf["url"] == "http://localhost:9382/mcp"
+    # Only the key names are exposed, and they're sorted for stable UI.
+    assert rf["header_keys"] == ["Authorization", "X-Tenant"]
+
+
+def test_registry_view_omits_command_for_http_entries(client):
+    test_client, cfg_path = client
+    _write_servers(
+        cfg_path,
+        {
+            "ragflow": {
+                "enabled": True,
+                "name": "RagFlow",
+                "description": "Query the KB",
+                "transport": "http",
+                "url": "http://localhost:9382/mcp",
+                "icon": "fa-cloud",
+                "tool_hint": "Use it.",
+            }
+        },
+    )
+    r = test_client.get(REGISTRY_PATH, headers=_auth())
+    assert r.status_code == 200, r.get_data(as_text=True)
+    payload = r.get_json()
+    rf = next(s for s in payload["servers"] if s["id"] == "ragflow")
+    # The HTTP-entry shape replaces command/args, not augments them.
+    assert "command" not in rf
+    assert "args" not in rf
+    # command_exists stays True so the "no command" badge in the UI
+    # doesn't fire spuriously for remote entries.
+    assert rf["command_exists"] is True
+
+
+def test_registry_view_preserves_stdio_command_shape(client):
+    test_client, cfg_path = client
+    _write_servers(
+        cfg_path,
+        {
+            "ws": {
+                "enabled": True,
+                "name": "Web Search",
+                "description": "Search",
+                "command": "/abs/path/python",
+                "args": ["/abs/path/main.py"],
+                "icon": "fa-search",
+                "tool_hint": "Use it.",
+            }
+        },
+    )
+    r = test_client.get(REGISTRY_PATH, headers=_auth())
+    assert r.status_code == 200
+    payload = r.get_json()
+    ws = next(s for s in payload["servers"] if s["id"] == "ws")
+    assert ws["transport"] == "stdio"
+    assert ws["command"] == "/abs/path/python"
+    assert ws["args"] == ["/abs/path/main.py"]
+    assert "url" not in ws
+    assert "header_keys" not in ws

--- a/dashboard/tests/test_mcp_config.py
+++ b/dashboard/tests/test_mcp_config.py
@@ -1,0 +1,217 @@
+"""Validation + normalization tests for the MCP external-server registry."""
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+# Allow `import chat.mcp_config` when run via pytest from the dashboard dir.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture
+def mcp_config(tmp_path, monkeypatch):
+    """Fresh mcp_config module with an isolated config file path.
+
+    The module holds load state in module globals, so we reimport it per
+    test to avoid leakage between cases.
+    """
+    cfg_path = tmp_path / "mcp_servers.json"
+    monkeypatch.setenv("LLM_DOCK_MCP_SERVERS_FILE", str(cfg_path))
+    if "chat.mcp_config" in sys.modules:
+        del sys.modules["chat.mcp_config"]
+    mod = importlib.import_module("chat.mcp_config")
+    return mod, cfg_path
+
+
+_BUILTIN_IDS = {"sympy-math", "schemdraw-circuits", "render-html"}
+
+
+def _valid_stdio_entry(**overrides):
+    base = {
+        "enabled": True,
+        "name": "Web Search",
+        "description": "Search the web",
+        "command": "/abs/path/python",
+        "args": ["/abs/path/server.py"],
+        "icon": "fa-search",
+        "tool_hint": "Use it when fresh info is needed.",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_http_entry(**overrides):
+    base = {
+        "enabled": True,
+        "name": "Ragflow",
+        "description": "Query the knowledge base",
+        "transport": "http",
+        "url": "http://localhost:9382/mcp",
+        "headers": {},
+        "icon": "fa-cloud",
+        "tool_hint": "Use it to look up KB content.",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidation:
+    def test_stdio_entry_accepted(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry("ws", _valid_stdio_entry(), _BUILTIN_IDS)
+        assert err is None
+
+    def test_http_entry_accepted(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry("rf", _valid_http_entry(), _BUILTIN_IDS)
+        assert err is None
+
+    def test_http_entry_via_type_remote_alias(self, mcp_config):
+        # Claude Code's shape uses `type: "remote"` instead of `transport`.
+        # Accepting it as a synonym means users can paste their existing
+        # configs in without re-keying.
+        mod, _ = mcp_config
+        entry = _valid_http_entry()
+        del entry["transport"]
+        entry["type"] = "remote"
+        err = mod._validate_entry("rf", entry, _BUILTIN_IDS)
+        assert err is None
+
+    @pytest.mark.parametrize("missing", ["name", "description", "icon", "tool_hint"])
+    def test_common_required_fields_enforced(self, mcp_config, missing):
+        mod, _ = mcp_config
+        entry = _valid_stdio_entry()
+        del entry[missing]
+        err = mod._validate_entry("ws", entry, _BUILTIN_IDS)
+        assert err and missing in err
+
+    def test_stdio_requires_command_and_args(self, mcp_config):
+        mod, _ = mcp_config
+        entry = _valid_stdio_entry()
+        del entry["command"]
+        err = mod._validate_entry("ws", entry, _BUILTIN_IDS)
+        assert err and "command" in err
+
+    def test_stdio_command_must_be_absolute(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry(
+            "ws", _valid_stdio_entry(command="relative/python"), _BUILTIN_IDS
+        )
+        assert err and "absolute" in err
+
+    def test_http_requires_url(self, mcp_config):
+        mod, _ = mcp_config
+        entry = _valid_http_entry()
+        del entry["url"]
+        err = mod._validate_entry("rf", entry, _BUILTIN_IDS)
+        assert err and "url" in err
+
+    @pytest.mark.parametrize("bad_url", ["ftp://example.com", "example.com", ""])
+    def test_http_url_must_have_http_scheme(self, mcp_config, bad_url):
+        mod, _ = mcp_config
+        err = mod._validate_entry("rf", _valid_http_entry(url=bad_url), _BUILTIN_IDS)
+        assert err is not None
+
+    def test_http_headers_must_be_string_map(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry(
+            "rf", _valid_http_entry(headers={"Authorization": 42}), _BUILTIN_IDS
+        )
+        assert err and "headers" in err
+
+    def test_unknown_transport_rejected(self, mcp_config):
+        mod, _ = mcp_config
+        entry = _valid_stdio_entry(transport="websocket")
+        err = mod._validate_entry("ws", entry, _BUILTIN_IDS)
+        assert err and "transport" in err
+
+    def test_id_with_double_underscore_rejected(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry("bad__id", _valid_stdio_entry(), _BUILTIN_IDS)
+        assert err and "__" in err
+
+    def test_id_colliding_with_builtin_rejected(self, mcp_config):
+        mod, _ = mcp_config
+        err = mod._validate_entry("sympy-math", _valid_stdio_entry(), _BUILTIN_IDS)
+        assert err and "built-in" in err
+
+
+class TestNormalization:
+    def test_stdio_normalizes_to_command_list(self, mcp_config):
+        mod, _ = mcp_config
+        out = mod._normalize_external("ws", _valid_stdio_entry())
+        assert out["transport"] == "stdio"
+        assert out["command"] == ["/abs/path/python", "/abs/path/server.py"]
+        assert out["external"] is True
+        assert out["enabled"] is True
+        assert "url" not in out
+
+    def test_http_normalizes_to_url_and_headers(self, mcp_config):
+        mod, _ = mcp_config
+        out = mod._normalize_external(
+            "rf", _valid_http_entry(headers={"Authorization": "Bearer x"})
+        )
+        assert out["transport"] == "http"
+        assert out["url"] == "http://localhost:9382/mcp"
+        assert out["headers"] == {"Authorization": "Bearer x"}
+        assert "command" not in out
+
+    def test_type_remote_normalizes_to_http_transport(self, mcp_config):
+        mod, _ = mcp_config
+        entry = _valid_http_entry()
+        del entry["transport"]
+        entry["type"] = "remote"
+        out = mod._normalize_external("rf", entry)
+        assert out["transport"] == "http"
+        assert out["url"] == "http://localhost:9382/mcp"
+
+
+class TestChatAvailability:
+    def test_http_entry_available_when_enabled_with_url(self, mcp_config):
+        mod, _ = mcp_config
+        cfg = mod._normalize_external("rf", _valid_http_entry())
+        assert mod._chat_available(cfg) is True
+
+    def test_http_entry_not_available_when_disabled(self, mcp_config):
+        mod, _ = mcp_config
+        cfg = mod._normalize_external("rf", _valid_http_entry(enabled=False))
+        assert mod._chat_available(cfg) is False
+
+    def test_stdio_entry_not_available_when_command_missing(
+        self, mcp_config, tmp_path
+    ):
+        mod, _ = mcp_config
+        # Use a definitely-not-on-disk command path. Pass validation first
+        # by skipping straight to _normalize_external — validation
+        # requires absolute path, which we supply.
+        cfg = mod._normalize_external(
+            "ws",
+            _valid_stdio_entry(command=str(tmp_path / "does-not-exist")),
+        )
+        assert mod._chat_available(cfg) is False
+
+
+class TestFileLoading:
+    def test_http_entry_loaded_from_external_json(self, mcp_config):
+        mod, cfg_path = mcp_config
+        cfg_path.write_text(json.dumps({"rf": _valid_http_entry()}))
+        state = mod.reload()
+        assert "rf" in state["merged"]
+        assert state["merged"]["rf"]["transport"] == "http"
+        assert state["external_errors"] == []
+        assert state["load_error"] is None
+
+    def test_invalid_http_entry_reported_with_error(self, mcp_config):
+        mod, cfg_path = mcp_config
+        bad = _valid_http_entry()
+        del bad["url"]
+        cfg_path.write_text(json.dumps({"rf": bad}))
+        state = mod.reload()
+        assert any(e["entry_id"] == "rf" for e in state["external_errors"])
+        assert "rf" not in {
+            sid for sid, c in state["merged"].items() if c.get("external")
+        }


### PR DESCRIPTION
Closes #45.

## Summary

External MCP server entries in `dashboard/mcp_servers.json` may now declare a remote HTTP(S) transport instead of a local subprocess command. The existing stdio path is unchanged and remains the default — all in-tree configs keep working as-is.

```json
{
  "ragflow": {
    "enabled": true,
    "name": "RagFlow",
    "description": "Query the local RagFlow knowledge base over HTTP",
    "transport": "http",
    "url": "http://localhost:9382/mcp",
    "headers": { "Authorization": "Bearer ..." },
    "icon": "fa-cloud",
    "tool_hint": "..."
  }
}
```

\`type: \"remote\"\` is accepted as a synonym for \`transport: \"http\"\` so configs from other harnesses (e.g. Claude Code) can be pasted in unchanged.

## Implementation

- **\`mcp_config.py\`**: extended \`_validate_entry\` and \`_normalize_external\` with a \`transport\` field (default \`\"stdio\"\`). HTTP entries require a \`url\` with an http(s) scheme; \`headers\` is an optional string→string map. \`_chat_available\` now considers HTTP entries available the moment they're enabled with a URL — reachability is left to call time so an unreachable remote can't block the dashboard.
- **\`mcp_client.py\`**: factored a transport-agnostic \`_open_streams\` async context manager. Both \`_discover_tools\` and \`_execute_tool\` go through it, so the chat path is otherwise unchanged.
- **\`mcp_admin_routes.py\`**: registry-view JSON now exposes \`transport\`, \`url\`, and a redacted view of \`headers\` (keys only) for HTTP entries.
- **\`ToolsPage.jsx\`**: renders an HTTP-transport block (transport / url / header-key list) for remote entries.
- **\`mcp_servers.example.json\` + \`CLAUDE.md\`**: ragflow example + docs covering availability semantics and the secrets caveat (no env-var interpolation yet — don't commit production tokens).
- **\`tests/test_mcp_config.py\`**: 25 unit tests covering both transports' validation, normalization, the \`type: \"remote\"\` alias, chat-availability rules, and file-load round-trip.

## Verification

- \`pytest dashboard/tests/\` — **219/219** (25 new).
- \`npm test\` — **81/81**, \`npm run build\` clean.
- **Live**: I ran the new \`_open_streams\` against \`http://localhost:9382/mcp\` and got a successful \`initialize\` (server \`ragflow-mcp-server\` v1.19.0) plus a tool list (\`ragflow_retrieval\`).

## Test plan

- [ ] Restart the dashboard.
- [ ] Add the ragflow entry above to \`dashboard/mcp_servers.json\`.
- [ ] Reload the Tools page — entry should show up with the http transport block (transport: http, url: …).
- [ ] Enable ragflow in a chat conversation; ask a question that should trigger \`ragflow_retrieval\`; confirm the tool fires and returns chunks.
- [ ] Existing stdio entries (\`websearch\`) keep working unchanged.