### PR TITLE
fix(chat): inline text-file attachments into outgoing message (#50)

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -46,6 +46,20 @@ function langHintFromName(name) {
   return ext
 }
 
+// Pick a fence that won't be closed early by backtick runs inside `content`.
+// CommonMark allows fences of any length ≥ 3, and the closing fence must be at
+// least as long as the opening one — so we pick one strictly longer than the
+// longest internal run.
+export function pickFence(content) {
+  let longest = 0
+  const re = /`+/g
+  let m
+  while ((m = re.exec(content)) !== null) {
+    if (m[0].length > longest) longest = m[0].length
+  }
+  return '`'.repeat(Math.max(3, longest + 1))
+}
+
 function formatSize(bytes) {
   if (bytes == null) return ''
   if (bytes < 1024) return `${bytes} B`
@@ -93,18 +107,35 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
   }, [value])
 
   function addTextFile(file) {
+    // Push a placeholder synchronously so submit knows a read is in
+    // flight. Without this, hitting Enter between file-pick and
+    // FileReader.onload would silently drop the attachment AND then
+    // resurrect a stale chip in the freshly-cleared composer.
+    const token = Symbol('attachment')
+    setAttachments(prev => [...prev, {
+      token,
+      name: file.name,
+      size: file.size,
+      type: file.type || fileExt(file.name),
+      content: null,
+      truncated: false,
+      pending: true,
+    }])
     const reader = new FileReader()
     reader.onload = () => {
       const text = String(reader.result ?? '')
       const truncated = text.length > MAX_INLINE_BYTES
       const content = truncated ? text.slice(0, MAX_INLINE_BYTES) : text
-      setAttachments(prev => [...prev, {
-        name: file.name,
-        size: file.size,
-        type: file.type || fileExt(file.name),
-        content,
-        truncated,
-      }])
+      setAttachments(prev => prev.map(a =>
+        a.token === token
+          ? { ...a, content, truncated, pending: false }
+          : a
+      ))
+    }
+    reader.onerror = () => {
+      // Drop the placeholder on read failure so it doesn't wedge the
+      // composer in a permanent "pending" state.
+      setAttachments(prev => prev.filter(a => a.token !== token))
     }
     reader.readAsText(file)
   }
@@ -212,7 +243,8 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
       const blocks = ready.map(a => {
         const lang = langHintFromName(a.name)
         const note = a.truncated ? ` (truncated to ${MAX_INLINE_BYTES} bytes)` : ''
-        return `**Attached file: \`${a.name}\`**${note}\n\n\`\`\`${lang}\n${a.content}\n\`\`\``
+        const fence = pickFence(a.content)
+        return `**Attached file: \`${a.name}\`**${note}\n\n${fence}${lang}\n${a.content}\n${fence}`
       }).join('\n\n')
       msg = msg ? `${msg}\n\n${blocks}` : blocks
     }
@@ -223,7 +255,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     e.preventDefault()
     const msg = buildMessage()
     const imgDataUrls = images.map(i => i.dataUrl)
-    if ((!msg && imgDataUrls.length === 0) || disabled) return
+    if ((!msg && imgDataUrls.length === 0) || disabled || anyAttachmentPending) return
     onSend(msg, imgDataUrls.length > 0 ? imgDataUrls : undefined)
     setValue('')
     setImages([])
@@ -237,7 +269,8 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     }
   }
 
-  const canSend = !disabled && (value.trim() || images.length > 0 || attachments.length > 0 || pendingInserts.length > 0)
+  const anyAttachmentPending = attachments.some(a => a.pending)
+  const canSend = !disabled && !anyAttachmentPending && (value.trim() || images.length > 0 || attachments.length > 0 || pendingInserts.length > 0)
 
   return (
     <div
@@ -316,7 +349,11 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
                 key={i}
                 className="group flex items-center gap-2 text-xs bg-elevated border border-hairline border-l-2 border-l-accent rounded px-2 py-1.5 max-w-[260px]"
               >
-                <i className="fa-solid fa-file-lines text-accent flex-shrink-0"></i>
+                {att.pending ? (
+                  <i className="fa-solid fa-spinner fa-spin text-accent flex-shrink-0" aria-label="Reading file"></i>
+                ) : (
+                  <i className="fa-solid fa-file-lines text-accent flex-shrink-0"></i>
+                )}
                 <span className="font-mono text-fg-muted truncate" title={att.name}>{att.name}</span>
                 <span className="font-mono text-fg-subtle flex-shrink-0">{formatSize(att.size)}</span>
                 <button

--- a/dashboard/frontend/src/components/chat/ChatInput.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.jsx
@@ -1,15 +1,22 @@
 import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 
-// Attach affordance allowlist (issue #29 §5). This is the affordance only —
-// where non-image attachments are stored/used is feature #28.
+// Attach allowlist. Non-image entries are inlined into the outgoing message
+// as fenced code blocks (see buildMessage). PDFs are intentionally excluded
+// — they can't be extracted client-side without a parser; the full artifact
+// store in issue #28 will handle binary uploads.
 const ALLOWED_EXT = new Set([
   // text / docs
-  'txt', 'md', 'markdown', 'pdf', 'json', 'csv', 'tsv', 'log',
+  'txt', 'md', 'markdown', 'json', 'csv', 'tsv', 'log',
   // code
   'js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs', 'java', 'c', 'h',
   'cpp', 'cc', 'hpp', 'cs', 'php', 'swift', 'kt', 'sh', 'bash', 'zsh',
   'sql', 'html', 'css', 'scss', 'yml', 'yaml', 'toml', 'ini', 'xml',
 ])
+
+// Cap per-file inlined text — guards against accidentally pasting a 50MB
+// log into the prompt. The cap is generous (most code/config files are
+// well under this) and produces a visible truncation marker when hit.
+const MAX_INLINE_BYTES = 512 * 1024
 
 function fileExt(name) {
   const i = name.lastIndexOf('.')
@@ -24,13 +31,19 @@ function isAllowed(file) {
   if (isImage(file)) return true
   if (
     file.type.startsWith('text/') ||
-    file.type === 'application/pdf' ||
     file.type === 'application/json' ||
     file.type === 'text/csv'
   ) {
     return true
   }
   return ALLOWED_EXT.has(fileExt(file.name))
+}
+
+function langHintFromName(name) {
+  const ext = fileExt(name)
+  if (!ext) return ''
+  if (ext === 'md' || ext === 'markdown') return 'markdown'
+  return ext
 }
 
 function formatSize(bytes) {
@@ -43,7 +56,7 @@ function formatSize(bytes) {
 const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInserts = [], onClearInsert, focusKey }, ref) {
   const [value, setValue] = useState('')
   const [images, setImages] = useState([]) // [{dataUrl, name, size}]
-  const [attachments, setAttachments] = useState([]) // [{name, size, type}] — affordance only (#28)
+  const [attachments, setAttachments] = useState([]) // [{name, size, type, content, truncated}]
   const [dragOver, setDragOver] = useState(false)
   const textareaRef = useRef(null)
   const fileInputRef = useRef(null)
@@ -79,6 +92,23 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     }
   }, [value])
 
+  function addTextFile(file) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = String(reader.result ?? '')
+      const truncated = text.length > MAX_INLINE_BYTES
+      const content = truncated ? text.slice(0, MAX_INLINE_BYTES) : text
+      setAttachments(prev => [...prev, {
+        name: file.name,
+        size: file.size,
+        type: file.type || fileExt(file.name),
+        content,
+        truncated,
+      }])
+    }
+    reader.readAsText(file)
+  }
+
   function addImageFile(file) {
     const reader = new FileReader()
     reader.onload = () => {
@@ -101,11 +131,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
       if (isImage(file)) {
         addImageFile(file)
       } else {
-        setAttachments(prev => [...prev, {
-          name: file.name,
-          size: file.size,
-          type: file.type || fileExt(file.name),
-        }])
+        addTextFile(file)
       }
     }
   }
@@ -181,6 +207,15 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
       const prefix = `The following issues were identified by a reviewer:\n${issueLines}\n\nPlease address these issues.`
       msg = msg ? `${prefix}\n\n${msg}` : prefix
     }
+    const ready = attachments.filter(a => a.content != null)
+    if (ready.length > 0) {
+      const blocks = ready.map(a => {
+        const lang = langHintFromName(a.name)
+        const note = a.truncated ? ` (truncated to ${MAX_INLINE_BYTES} bytes)` : ''
+        return `**Attached file: \`${a.name}\`**${note}\n\n\`\`\`${lang}\n${a.content}\n\`\`\``
+      }).join('\n\n')
+      msg = msg ? `${msg}\n\n${blocks}` : blocks
+    }
     return msg
   }
 
@@ -192,8 +227,6 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     onSend(msg, imgDataUrls.length > 0 ? imgDataUrls : undefined)
     setValue('')
     setImages([])
-    // Non-image attachments are an affordance only; their transport is
-    // owned by feature #28. Clear them so the composer resets cleanly.
     setAttachments([])
   }
 
@@ -204,7 +237,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
     }
   }
 
-  const canSend = !disabled && (value.trim() || images.length > 0 || pendingInserts.length > 0)
+  const canSend = !disabled && (value.trim() || images.length > 0 || attachments.length > 0 || pendingInserts.length > 0)
 
   return (
     <div
@@ -219,7 +252,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
         <div className="px-4 pt-3 max-w-6xl mx-auto">
           <div className="rounded border border-dashed border-accent/50 bg-accent/5 px-3 py-2 text-xs font-mono text-accent flex items-center gap-2">
             <i className="fa-solid fa-paperclip"></i>
-            Drop files to attach (images, text, pdf, json, csv, code)
+            Drop files to attach (images, text, json, csv, code)
           </div>
         </div>
       )}
@@ -306,7 +339,7 @@ const ChatInput = forwardRef(function ChatInput({ onSend, disabled, pendingInser
             ref={fileInputRef}
             type="file"
             multiple
-            accept="image/*,text/*,application/pdf,application/json,.md,.csv,.tsv,.log,.js,.jsx,.ts,.tsx,.py,.rb,.go,.rs,.java,.c,.h,.cpp,.cc,.hpp,.cs,.php,.swift,.kt,.sh,.sql,.html,.css,.scss,.yml,.yaml,.toml,.ini,.xml"
+            accept="image/*,text/*,application/json,.md,.csv,.tsv,.log,.js,.jsx,.ts,.tsx,.py,.rb,.go,.rs,.java,.c,.h,.cpp,.cc,.hpp,.cs,.php,.swift,.kt,.sh,.sql,.html,.css,.scss,.yml,.yaml,.toml,.ini,.xml"
             className="hidden"
             onChange={handleFilePick}
           />

--- a/dashboard/frontend/src/components/chat/ChatInput.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatInput.test.jsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react'
+import ChatInput, { pickFence } from './ChatInput'
+
+afterEach(() => cleanup())
+
+// Controllable FileReader: tests resolve reads explicitly so we can assert
+// behavior in the gap between file-pick and onload.
+class ControllableFileReader {
+  constructor() {
+    this.onload = null
+    this.onerror = null
+    this.result = null
+    ControllableFileReader.instances.push(this)
+  }
+  readAsText() {
+    // Caller invokes resolve()/reject() to settle.
+  }
+  resolve(text) {
+    this.result = text
+    if (this.onload) this.onload({ target: this })
+  }
+  reject() {
+    if (this.onerror) this.onerror({ target: this })
+  }
+}
+ControllableFileReader.instances = []
+
+let originalFileReader
+beforeEach(() => {
+  ControllableFileReader.instances = []
+  originalFileReader = globalThis.FileReader
+  globalThis.FileReader = ControllableFileReader
+})
+afterEach(() => {
+  globalThis.FileReader = originalFileReader
+})
+
+function pickFile(file) {
+  // Find the hidden <input type="file" /> and dispatch a change event.
+  const input = document.querySelector('input[type="file"]')
+  Object.defineProperty(input, 'files', { value: [file], configurable: true })
+  fireEvent.change(input)
+}
+
+function makeFile(name, content, type = 'text/plain') {
+  return new File([content], name, { type })
+}
+
+describe('ChatInput attachments', () => {
+  it('blocks send while a text-file read is pending', async () => {
+    const onSend = vi.fn()
+    render(<ChatInput onSend={onSend} disabled={false} />)
+
+    // Type some text BEFORE the read settles — this is the race codex
+    // flagged: in the old code the message would send without the
+    // attachment, and the chip would reappear in the cleared composer.
+    fireEvent.change(screen.getByPlaceholderText(/type a message/i), {
+      target: { value: 'hello' },
+    })
+
+    pickFile(makeFile('notes.md', '# heading\n\nbody'))
+
+    // Wait for the placeholder chip to render. While pending, the send
+    // button must be disabled, even though the composer has typed text.
+    const sendBtn = screen.getByRole('button', { name: '', hidden: true }) // submit
+    // Submit button is the one with type=submit; find it more robustly:
+    const submitBtn = document.querySelector('button[type="submit"]')
+    await waitFor(() => {
+      expect(document.querySelector('.fa-spinner')).toBeTruthy()
+    })
+    expect(submitBtn.disabled).toBe(true)
+
+    // Pressing Enter must also be a no-op while pending.
+    fireEvent.keyDown(screen.getByPlaceholderText(/type a message/i), {
+      key: 'Enter',
+    })
+    expect(onSend).not.toHaveBeenCalled()
+
+    // Resolve the read; now send must work and the message must include the
+    // file's content.
+    act(() => ControllableFileReader.instances[0].resolve('# heading\n\nbody'))
+
+    await waitFor(() => expect(submitBtn.disabled).toBe(false))
+    fireEvent.click(submitBtn)
+    expect(onSend).toHaveBeenCalledTimes(1)
+    const sentMsg = onSend.mock.calls[0][0]
+    expect(sentMsg).toContain('hello')
+    expect(sentMsg).toContain('Attached file: `notes.md`')
+    expect(sentMsg).toContain('# heading')
+  })
+
+  it('removes the attachment chip on read error', async () => {
+    render(<ChatInput onSend={() => {}} disabled={false} />)
+    pickFile(makeFile('broken.txt', 'whatever'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.fa-spinner')).toBeTruthy()
+    })
+
+    act(() => ControllableFileReader.instances[0].reject())
+
+    await waitFor(() => {
+      expect(document.querySelector('.fa-spinner')).toBeFalsy()
+      expect(document.querySelector('.fa-file-lines')).toBeFalsy()
+    })
+  })
+
+  it('uses a longer fence when the attached file contains ``` runs', async () => {
+    const onSend = vi.fn()
+    render(<ChatInput onSend={onSend} disabled={false} />)
+
+    const content = 'before\n```\ncode block inside\n```\nafter'
+    pickFile(makeFile('post.md', content))
+
+    await waitFor(() =>
+      expect(ControllableFileReader.instances.length).toBe(1)
+    )
+    act(() => ControllableFileReader.instances[0].resolve(content))
+
+    const submitBtn = document.querySelector('button[type="submit"]')
+    await waitFor(() => expect(submitBtn.disabled).toBe(false))
+    fireEvent.click(submitBtn)
+
+    expect(onSend).toHaveBeenCalledTimes(1)
+    const sentMsg = onSend.mock.calls[0][0]
+    // The wrapping fence must be longer than any backtick run inside the
+    // body, otherwise the inner ``` would close it prematurely.
+    expect(sentMsg).toMatch(/````markdown\n/)
+    expect(sentMsg).toMatch(/\n````\b|\n````$/m)
+    // And the inner fence must survive verbatim.
+    expect(sentMsg).toContain('```\ncode block inside\n```')
+  })
+})
+
+describe('pickFence', () => {
+  it('returns 3 backticks for content with no fences', () => {
+    expect(pickFence('plain text')).toBe('```')
+  })
+  it('returns 4 backticks when the content has a 3-tick run', () => {
+    expect(pickFence('```js\nfoo\n```')).toBe('````')
+  })
+  it('returns 5 backticks when the content has a 4-tick run', () => {
+    expect(pickFence('````\nnested\n````')).toBe('`````')
+  })
+  it('handles isolated single backticks without inflating the fence', () => {
+    expect(pickFence('inline `x` and `y`')).toBe('```')
+  })
+})

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -200,14 +200,18 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  /* Tailwind Typography adds `::before { content: "`" }` and
-     `::after { content: "`" }` to inline <code>, which prints the
-     literal backticks alongside the monospaced span. We already style
-     code via the surrounding prose; strip the decorative quotes. */
-  .prose :where(code):not(:where([class~="not-prose"] *))::before,
-  .prose :where(code):not(:where([class~="not-prose"] *))::after {
-    content: none;
-  }
+}
+
+/* Tailwind Typography injects literal backticks around inline <code>
+   via ::before/::after content. Override at root scope (not inside
+   @layer base — the typography plugin sits in a later layer and would
+   otherwise win) and force the result with !important so any future
+   plugin update can't silently bring the quotes back. */
+.prose code::before,
+.prose code::after,
+.prose-invert code::before,
+.prose-invert code::after {
+  content: none !important;
 }
 
 /* -------------------------------------------------------------------

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -199,6 +199,15 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  /* Tailwind Typography adds `::before { content: "`" }` and
+     `::after { content: "`" }` to inline <code>, which prints the
+     literal backticks alongside the monospaced span. We already style
+     code via the surrounding prose; strip the decorative quotes. */
+  .prose :where(code):not(:where([class~="not-prose"] *))::before,
+  .prose :where(code):not(:where([class~="not-prose"] *))::after {
+    content: none;
+  }
 }
 
 /* -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #50 — attaching a `.md` (or any other text file) no longer silently drops the content. `ChatInput` now reads text-file contents client-side via `FileReader.readAsText` and appends each attachment to the outgoing message as a fenced code block with a filename header and language hint derived from the extension.
- 512 KB per-file inline cap with a visible \`(truncated to …)\` marker; guards against accidentally pasting a multi-MB log into the prompt.
- Drops PDF from the picker / accept list — PDFs need a binary parser the unified artifact store in #28 will own. Until then we'd rather not show an attach chip that pretends to work.
- The previous "affordance only" path that #28 would have replaced is gone; the composer can now send a message containing only attachments (no text, no image).

## Test plan
- [x] `npm test -- --run` — 81/81 frontend tests pass
- [x] `npm run build` — clean
- [ ] Manual: attach a `.md`, hit send, verify the fenced block reaches the model
- [ ] Manual: drag-and-drop a `.py` and a `.json` together
- [ ] Manual: attach a >512 KB file, verify the truncation marker
- [ ] Manual: paste a copied file from the OS file manager