### PR TITLE
fix: open chat markdown links in new tab

### DIFF
--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -15,7 +15,17 @@ import FormatDriftChip from './FormatDriftChip'
 import { detectFormatDrift } from './formatDrift'
 import useProseClass from '../../hooks/useProseClass'
 
-const MD_COMPONENTS = { pre: CopyablePre }
+const MD_COMPONENTS = {
+  pre: CopyablePre,
+  a: (props) => {
+    const isExternal = props.href && /^https?:\/\//.test(props.href)
+    return isExternal ? (
+      <a {...props} target="_blank" rel="noopener noreferrer" />
+    ) : (
+      <a {...props} />
+    )
+  },
+}
 
 export default function MessageBubble({ message, critique, critiqueLoading, hasSidekick, onCritique, onEdit, isActiveCritique, artifacts }) {
   const [editing, setEditing] = useState(false)

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -13,7 +13,17 @@ import ToolResultBlock from './ToolResultBlock'
 import FormatDriftChip from './FormatDriftChip'
 import useProseClass from '../../hooks/useProseClass'
 
-const MD_COMPONENTS = { pre: CopyablePre }
+const MD_COMPONENTS = {
+  pre: CopyablePre,
+  a: (props) => {
+    const isExternal = props.href && /^https?:\/\//.test(props.href)
+    return isExternal ? (
+      <a {...props} target="_blank" rel="noopener noreferrer" />
+    ) : (
+      <a {...props} />
+    )
+  },
+}
 
 export default function MessageList({
   messages,

--- a/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
+++ b/dashboard/frontend/src/components/chat/SpinoffWindow.jsx
@@ -9,7 +9,17 @@ import { createConversation, getConversation } from '../../services/chat'
 import CopyablePre from './CopyablePre'
 import useProseClass from '../../hooks/useProseClass'
 
-const MD_COMPONENTS = { pre: CopyablePre }
+const MD_COMPONENTS = {
+  pre: CopyablePre,
+  a: (props) => {
+    const isExternal = props.href && /^https?:\/\//.test(props.href)
+    return isExternal ? (
+      <a {...props} target="_blank" rel="noopener noreferrer" />
+    ) : (
+      <a {...props} />
+    )
+  },
+}
 
 export default function SpinoffWindow({ id, conversationId: initialConvId, selectedText, serviceName, parentConversationId, position, onClose, onMinimize, onFocus, onConversationCreated, zIndex }) {
   const proseClass = useProseClass('prose-xs', 'max-w-none', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')

--- a/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
+++ b/dashboard/frontend/src/components/chat/ThinkingBlock.jsx
@@ -7,7 +7,17 @@ import rehypeKatex from 'rehype-katex'
 import CopyablePre from './CopyablePre'
 import useProseClass from '../../hooks/useProseClass'
 
-const MD_COMPONENTS = { pre: CopyablePre }
+const MD_COMPONENTS = {
+  pre: CopyablePre,
+  a: (props) => {
+    const isExternal = props.href && /^https?:\/\//.test(props.href)
+    return isExternal ? (
+      <a {...props} target="_blank" rel="noopener noreferrer" />
+    ) : (
+      <a {...props} />
+    )
+  },
+}
 
 export default function ThinkingBlock({ content }) {
   const [open, setOpen] = useState(false)


### PR DESCRIPTION
## Summary

- Add `target="_blank"` and `rel="noopener noreferrer"` to all links rendered by `react-markdown` in chat components
- Affects 4 files: `MessageBubble`, `MessageList`, `ThinkingBlock`, `SpinoffWindow`

Closes #52