### PR TITLE
Phase 1 (#54): ds4 docker image + build script

### DIFF
--- a/build-ds4.sh
+++ b/build-ds4.sh
@@ -10,11 +10,14 @@ set -e
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+# Target GPU arch — override for non-Blackwell GPUs, e.g. CUDA_ARCH=sm_90 ./build-ds4.sh
+CUDA_ARCH="${CUDA_ARCH:-sm_120}"
+
 echo "=========================================="
 echo "  ds4 (DwarfStar 4) Docker Image Builder"
 echo "=========================================="
 echo ""
-echo "Building ds4 from source with CUDA (sm_120)..."
+echo "Building ds4 from source with CUDA (${CUDA_ARCH})..."
 echo ""
 
 # Capture build metadata
@@ -30,6 +33,7 @@ cd "$(dirname "$0")"
 docker build \
     --build-arg BUILD_DATE="$BUILD_DATE" \
     --build-arg BUILD_COMMIT="$BUILD_COMMIT" \
+    --build-arg CUDA_ARCH="$CUDA_ARCH" \
     -t llm-dock-ds4 ./ds4/
 
 echo ""

--- a/build-ds4.sh
+++ b/build-ds4.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# LLM-Dock - ds4 (DwarfStar 4) Docker Image Builder
+# Builds antirez's DeepSeek-V4 inference engine from source into a CUDA image.
+#
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo "=========================================="
+echo "  ds4 (DwarfStar 4) Docker Image Builder"
+echo "=========================================="
+echo ""
+echo "Building ds4 from source with CUDA (sm_120)..."
+echo ""
+
+# Capture build metadata
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+BUILD_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+echo "Build metadata:"
+echo "  Date: $BUILD_DATE"
+echo "  Commit: $BUILD_COMMIT"
+echo ""
+
+cd "$(dirname "$0")"
+docker build \
+    --build-arg BUILD_DATE="$BUILD_DATE" \
+    --build-arg BUILD_COMMIT="$BUILD_COMMIT" \
+    -t llm-dock-ds4 ./ds4/
+
+echo ""
+echo -e "${GREEN}=========================================="
+echo "  Build Complete!"
+echo "==========================================${NC}"
+echo ""
+echo "The 'llm-dock-ds4' image is now ready."
+echo ""

--- a/ds4/Dockerfile
+++ b/ds4/Dockerfile
@@ -11,6 +11,14 @@ FROM nvidia/cuda:12.9.0-devel-ubuntu24.04 AS builder
 # time of writing, no local diffs).
 ARG DS4_COMMIT=e34a8086693ba7ca5cfabd2b9028ee52f0bfac2e
 
+# Target GPU arch. Defaults to sm_120 (RTX PRO 6000 Blackwell); override via
+# build-ds4.sh for other GPUs. NOT cuda-generic/-arch=native, which needs the
+# GPU visible to nvcc — it isn't during `docker build`.
+# Note: ds4's Makefile compiles with -march=native, so binaries are also tuned
+# to the build host's CPU. Intentional here (image is built and run on the same
+# machine); rebuild on the target host if that ever changes.
+ARG CUDA_ARCH=sm_120
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential git ca-certificates && \
     rm -rf /var/lib/apt/lists/*
@@ -18,10 +26,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/antirez/ds4.git /src && \
     git -C /src checkout "${DS4_COMMIT}"
 
-# Build with an explicit GPU arch instead of `make cuda-generic`: the generic
-# target uses -arch=native, which requires the GPU to be visible to nvcc — it
-# is NOT during `docker build`. sm_120 = RTX PRO 6000 Blackwell.
-RUN make -C /src cuda CUDA_ARCH=sm_120
+RUN make -C /src cuda CUDA_ARCH="${CUDA_ARCH}"
 
 # ---- Runtime stage ---------------------------------------------------------
 # The runtime image already ships libcudart + libcublas, the only runtime libs

--- a/ds4/Dockerfile
+++ b/ds4/Dockerfile
@@ -1,0 +1,46 @@
+# LLM-Dock — DwarfStar 4 (ds4) image
+#
+# ds4 is antirez's native inference engine tailored for DeepSeek V4 Flash.
+# Built from source (no upstream image exists). Multi-stage: compile with the
+# full CUDA devel toolkit, ship only the binaries on the CUDA runtime image.
+
+# ---- Build stage -----------------------------------------------------------
+FROM nvidia/cuda:12.9.0-devel-ubuntu24.04 AS builder
+
+# Pinned to the commit verified to build on this host (== origin/main at the
+# time of writing, no local diffs).
+ARG DS4_COMMIT=e34a8086693ba7ca5cfabd2b9028ee52f0bfac2e
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/antirez/ds4.git /src && \
+    git -C /src checkout "${DS4_COMMIT}"
+
+# Build with an explicit GPU arch instead of `make cuda-generic`: the generic
+# target uses -arch=native, which requires the GPU to be visible to nvcc — it
+# is NOT during `docker build`. sm_120 = RTX PRO 6000 Blackwell.
+RUN make -C /src cuda CUDA_ARCH=sm_120
+
+# ---- Runtime stage ---------------------------------------------------------
+# The runtime image already ships libcudart + libcublas, the only runtime libs
+# the Makefile links. ds4_web.c uses raw POSIX sockets, so no libcurl/OpenSSL.
+FROM nvidia/cuda:12.9.0-runtime-ubuntu24.04
+
+# Build metadata
+ARG BUILD_DATE
+ARG BUILD_COMMIT
+ARG DS4_COMMIT=e34a8086693ba7ca5cfabd2b9028ee52f0bfac2e
+LABEL org.llm-dock.build.date="${BUILD_DATE}" \
+      org.llm-dock.build.commit="${BUILD_COMMIT}" \
+      org.llm-dock.ds4.commit="${DS4_COMMIT}"
+
+COPY --from=builder \
+     /src/ds4 /src/ds4-server /src/ds4-bench /src/ds4-eval /src/ds4-agent \
+     /usr/local/bin/
+
+EXPOSE 8000
+
+# Phase 2's ds4.j2 supplies the command args (-m <gguf> --ctx … --warm-weights …).
+ENTRYPOINT ["ds4-server"]


### PR DESCRIPTION
Phase 1 of #54 — foundation for running antirez's **DwarfStar 4 (ds4)** as an llm-dock engine.

## What's here
- **`ds4/Dockerfile`** — multi-stage build. Build stage (`nvidia/cuda:12.9.0-devel`) clones ds4 at pinned commit `e34a808` and runs `make cuda CUDA_ARCH=sm_120`; runtime stage (`cuda:12.9.0-runtime`) ships the 5 binaries. Explicit `sm_120` (not `cuda-generic`/`-arch=native`) because no GPU is visible during `docker build`.
- **`build-ds4.sh`** — mirrors `build-vllm.sh` (build metadata args, tags `llm-dock-ds4`).

## Verification
- `bash build-ds4.sh` → image builds clean (5 binaries compiled with `-arch=sm_120`).
- `docker run --rm --entrypoint ds4-server llm-dock-ds4 --help` → prints usage (links cleanly against runtime CUDA libs).
- `docker run --rm --gpus all --entrypoint ds4 llm-dock-ds4 --help` → OK with GPU runtime.

## Not in this PR
- Phase 2: `ds4.j2` template + `compose_manager`/`service_templates`/`flag_metadata` wiring + frontend engine option.
- Phase 3: `services.json` entry, bring-up, smoke test, Open WebUI, docs.

Note: `ds4-server` has no `--api-key` flag (no auth); acceptable on the internal `llm-network`, handled in Phase 2.