### PR TITLE
Phase 2 (#54): wire ds4 as a dashboard engine type

### DIFF
--- a/dashboard/compose_manager.py
+++ b/dashboard/compose_manager.py
@@ -554,6 +554,10 @@ class ComposeManager:
             context["model_name"] = config["model_name"]
             context["alias"] = config["alias"]
             context["api_key"] = config["api_key"]
+        elif template_type == "ds4":
+            context["model_path"] = config["model_path"]
+            context["alias"] = config["alias"]
+            context["api_key"] = config["api_key"]
 
         rendered_flags = []
         extra_env = {}

--- a/dashboard/flag_metadata.py
+++ b/dashboard/flag_metadata.py
@@ -13,6 +13,7 @@ from service_templates import sanitize_service_name
 MANDATORY_FIELDS = {
     "llamacpp": ["port", "model_path", "alias", "api_key"],
     "vllm": ["port", "model_name", "alias", "api_key"],
+    "ds4": ["port", "model_path", "alias", "api_key"],
 }
 
 # ============================================
@@ -1174,6 +1175,128 @@ for _key, _cat in _LLAMACPP_LLAMA_SERVER_CATEGORIES.items():
         LLAMACPP_LLAMA_SERVER_FLAGS[_key]["category"] = _cat
 
 # ============================================
+# FLAG METADATA FOR ds4 (ds4-server)
+# antirez's DeepSeek-V4 engine. render_cli_flag() is permissive, so any
+# ds4-server flag works in params without an entry here; these just enrich
+# the UI param editor with type/category/description. -m, --host, --port are
+# supplied by the template and must NOT be set here.
+# ============================================
+
+DS4_FLAGS = {
+    # ========== CONTEXT & RUNTIME ==========
+    "ctx": {
+        "cli": "--ctx",
+        "type": "int",
+        "category": "Context & Runtime",
+        "description": "Allocated context tokens for the loaded model.",
+        "default": "65536",
+        "impact": "Critical",
+    },
+    "tokens": {
+        "cli": "--tokens",
+        "type": "int",
+        "category": "Context & Runtime",
+        "description": "Default max output tokens when a client omits a limit.",
+        "impact": "Medium",
+    },
+    "threads": {
+        "cli": "--threads",
+        "type": "int",
+        "category": "Context & Runtime",
+        "description": "CPU helper threads for host-side / reference work.",
+        "impact": "Low",
+    },
+    "power": {
+        "cli": "--power",
+        "type": "int",
+        "category": "Context & Runtime",
+        "description": "GPU duty-cycle target, 1..100.",
+        "default": "100",
+        "impact": "Low",
+    },
+    "warm_weights": {
+        "cli": "--warm-weights",
+        "type": "bool",
+        "category": "Context & Runtime",
+        "description": "Touch all model pages at startup to make weights resident in GPU memory before serving.",
+        "impact": "High",
+    },
+    # ========== BACKEND ==========
+    "cuda": {
+        "cli": "--cuda",
+        "type": "bool",
+        "category": "Backend",
+        "description": "Force the CUDA backend explicitly (otherwise auto-detected).",
+        "impact": "Low",
+    },
+    "ssd_streaming": {
+        "cli": "--ssd-streaming",
+        "type": "bool",
+        "category": "Backend",
+        "description": "Opt in to SSD-backed model streaming instead of full residency.",
+        "impact": "Medium",
+    },
+    "prefill_chunk": {
+        "cli": "--prefill-chunk",
+        "type": "int",
+        "category": "Backend",
+        "description": "Graph prefill chunk size. Default: auto.",
+        "impact": "Low",
+    },
+    # ========== DISK KV CACHE ==========
+    "kv_disk_dir": {
+        "cli": "--kv-disk-dir",
+        "type": "string",
+        "category": "Disk KV Cache",
+        "description": "Enable disk KV checkpoints in this directory (the image mounts /kv as writable).",
+        "default": "/kv",
+        "impact": "Medium",
+    },
+    "kv_disk_space_mb": {
+        "cli": "--kv-disk-space-mb",
+        "type": "int",
+        "category": "Disk KV Cache",
+        "description": "Disk budget in MB for KV checkpoints.",
+        "default": "4096",
+        "impact": "Low",
+    },
+    "kv_cache_min_tokens": {
+        "cli": "--kv-cache-min-tokens",
+        "type": "int",
+        "category": "Disk KV Cache",
+        "description": "Do not save/load checkpoints shorter than N tokens.",
+        "default": "512",
+        "impact": "Low",
+    },
+    # ========== HTTP API ==========
+    "cors": {
+        "cli": "--cors",
+        "type": "bool",
+        "category": "HTTP API",
+        "description": "Add Access-Control-Allow-* headers for browser JS clients.",
+        "impact": "Low",
+    },
+    "trace": {
+        "cli": "--trace",
+        "type": "string",
+        "category": "HTTP API",
+        "description": "Write prompts, cache decisions, output, and tool calls to this file.",
+        "impact": "Low",
+    },
+}
+
+DS4_VALIDATION = {
+    "ctx": {"type": "int", "min": 512, "max": 1000000},
+    "tokens": {"type": "int", "min": 1, "max": 1000000},
+    "threads": {"type": "int", "min": 1, "max": 256},
+    "power": {"type": "int", "min": 1, "max": 100},
+    "prefill_chunk": {"type": "int", "min": 1, "max": 65536},
+    "kv_disk_space_mb": {"type": "int", "min": 1, "max": 1048576},
+    "kv_cache_min_tokens": {"type": "int", "min": 1, "max": 1000000},
+}
+
+
+# ============================================
 # HELPER FUNCTIONS
 # ============================================
 
@@ -1186,6 +1309,8 @@ def get_flag_metadata(template_type: str) -> Dict[str, Any]:
         return LLAMACPP_LLAMA_BENCH_FLAGS
     elif template_type == "vllm":
         return VLLM_FLAGS
+    elif template_type == "ds4":
+        return DS4_FLAGS
     else:
         return {}
 
@@ -1196,6 +1321,8 @@ def get_validation_rules(template_type: str) -> Dict[str, Any]:
         return LLAMACPP_LLAMA_SERVER_VALIDATION
     elif template_type == "vllm":
         return VLLM_VALIDATION
+    elif template_type == "ds4":
+        return DS4_VALIDATION
     else:
         return {}
 

--- a/dashboard/frontend/src/components/ServiceConfigPanel.jsx
+++ b/dashboard/frontend/src/components/ServiceConfigPanel.jsx
@@ -340,6 +340,12 @@ function renderCommandPreview(config, apiKey, params) {
     if (config.model_path) parts.push(`-m ${config.model_path}`)
     parts.push(`--port 8080`)
     parts.push(`--api-key ${apiKey || '***'}`)
+  } else if (config.template_type === 'ds4') {
+    // ds4-server has no --api-key flag (auth not enforced by the container).
+    parts.push('ds4-server')
+    if (config.model_path) parts.push(`-m ${config.model_path}`)
+    parts.push(`--host 0.0.0.0`)
+    parts.push(`--port 8000`)
   } else {
     parts.push('vllm serve')
     if (config.model_name) parts.push(config.model_name)

--- a/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
+++ b/dashboard/frontend/src/components/ServiceDetailsHeader.jsx
@@ -66,6 +66,7 @@ function EngineBadge({ templateType }) {
   const engineMap = {
     llamacpp: { label: 'llama.cpp', classes: 'bg-badge-llamacpp-bg text-badge-llamacpp-fg' },
     vllm: { label: 'vLLM', classes: 'bg-badge-vllm-bg text-badge-vllm-fg' },
+    ds4: { label: 'DS4', classes: 'bg-badge-ds4-bg text-badge-ds4-fg' },
   }
   const engine = engineMap[templateType] || { label: templateType, classes: 'bg-badge-neutral-bg text-badge-neutral-fg' }
 

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -9,6 +9,7 @@ function getEngine(name) {
   if (name === 'open-webui') return 'WebUI'
   if (name.startsWith('llamacpp-')) return 'llama.cpp'
   if (name.startsWith('vllm-')) return 'vLLM'
+  if (name.startsWith('ds4-')) return 'DS4'
   return 'Unknown'
 }
 
@@ -39,6 +40,7 @@ function EngineBadge({ engine }) {
   const colors = {
     'llama.cpp': 'bg-badge-llamacpp-bg text-badge-llamacpp-fg',
     'vLLM': 'bg-badge-vllm-bg text-badge-vllm-fg',
+    'DS4': 'bg-badge-ds4-bg text-badge-ds4-fg',
     'WebUI': 'bg-badge-webui-bg text-badge-webui-fg',
     'Unknown': 'bg-badge-neutral-bg text-badge-neutral-fg'
   }

--- a/dashboard/frontend/src/hooks/useRunningServices.js
+++ b/dashboard/frontend/src/hooks/useRunningServices.js
@@ -18,7 +18,7 @@ export default function useRunningServices({ kind = 'chat' } = {}) {
     if (!services) return []
     return services.filter(s => {
       if (s.status !== 'running') return false
-      if (!s.name.startsWith('llamacpp-') && !s.name.startsWith('vllm-')) return false
+      if (!s.name.startsWith('llamacpp-') && !s.name.startsWith('vllm-') && !s.name.startsWith('ds4-')) return false
       if (kind === 'all') return true
       // Snapshot pre-rollout: treat missing kind as 'chat' so old payloads
       // don't filter everything out.

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -104,6 +104,8 @@
   --color-badge-llamacpp-fg: #93c5fd;
   --color-badge-vllm-bg:     rgb(147 51 234 / 0.30);
   --color-badge-vllm-fg:     #d8b4fe;
+  --color-badge-ds4-bg:      rgb(234 88 12 / 0.30);
+  --color-badge-ds4-fg:      #fdba74;
   --color-badge-webui-bg:    rgb(5 150 105 / 0.30);
   --color-badge-webui-fg:    #6ee7b7;
   --color-badge-neutral-bg:  rgb(75 85 99 / 0.30);
@@ -165,6 +167,8 @@
   --color-badge-llamacpp-fg: #1d4ed8;
   --color-badge-vllm-bg:     rgb(147 51 234 / 0.12);
   --color-badge-vllm-fg:     #7e22ce;
+  --color-badge-ds4-bg:      rgb(234 88 12 / 0.12);
+  --color-badge-ds4-fg:      #c2410c;
   --color-badge-webui-bg:    rgb(5 150 105 / 0.12);
   --color-badge-webui-fg:    #047857;
   --color-badge-neutral-bg:  rgb(100 116 139 / 0.12);

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -242,8 +242,8 @@ def create_service():
         template_type = data.get("template_type")
         if not template_type:
             return jsonify({"error": "template_type is required"}), 400
-        if template_type not in ["llamacpp", "vllm"]:
-            return jsonify({"error": 'template_type must be "llamacpp" or "vllm"'}), 400
+        if template_type not in ["llamacpp", "vllm", "ds4"]:
+            return jsonify({"error": 'template_type must be "llamacpp", "vllm", or "ds4"'}), 400
 
         # Auto-generate API key if not provided
         if not data.get("api_key"):
@@ -519,8 +519,8 @@ def rename_service(service_name):
 def get_flags_metadata(template_type):
     """Get flag metadata for a template type"""
     try:
-        if template_type not in ["llamacpp", "llamacpp_bench", "vllm"]:
-            return jsonify({"error": 'template_type must be "llamacpp", "llamacpp_bench", or "vllm"'}), 400
+        if template_type not in ["llamacpp", "llamacpp_bench", "vllm", "ds4"]:
+            return jsonify({"error": 'template_type must be "llamacpp", "llamacpp_bench", "vllm", or "ds4"'}), 400
 
         metadata = get_flag_metadata(template_type)
         mandatory = MANDATORY_FIELDS.get(template_type, [])

--- a/dashboard/routes/system.py
+++ b/dashboard/routes/system.py
@@ -40,6 +40,7 @@ def get_images_metadata():
         {
             "llamacpp": get_image_build_metadata("llm-dock-llamacpp"),
             "vllm": get_image_build_metadata("llm-dock-vllm"),
+            "ds4": get_image_build_metadata("llm-dock-ds4"),
             "timestamp": datetime.utcnow().isoformat() + "Z",
         }
     )

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -146,6 +146,10 @@
                             <input type="radio" name="engine" value="vllm" class="mr-2">
                             <span>vllm (safetensors/bin)</span>
                         </label>
+                        <label class="flex items-center">
+                            <input type="radio" name="engine" value="ds4" class="mr-2">
+                            <span>ds4 (DeepSeek-V4 GGUF)</span>
+                        </label>
                     </div>
                 </div>
 

--- a/dashboard/static/js/service-modal/create-service.js
+++ b/dashboard/static/js/service-modal/create-service.js
@@ -81,6 +81,14 @@ function getSmartDefaults(engine, modelSizeGB, vramTotalMB) {
         if (vramGB >= 24) params['--max-model-len'] = '8192';
         else if (vramGB >= 16) params['--max-model-len'] = '4096';
         else params['--max-model-len'] = '2048';
+    } else if (engine === 'ds4') {
+        // Make weights resident in VRAM before serving; pick a context that fits headroom.
+        params['--warm-weights'] = '';
+        const headroomGB = vramGB - (modelSizeGB * 1.05);
+        if (headroomGB >= 24) params['--ctx'] = '65536';
+        else if (headroomGB >= 12) params['--ctx'] = '32768';
+        else if (headroomGB >= 6) params['--ctx'] = '16384';
+        else params['--ctx'] = '8192';
     }
 
     return params;
@@ -240,6 +248,20 @@ function generateCommandPreview() {
         preview += `--trust-remote-code\n`;
         preview += `--served-model-name ${alias}\n`;
         preview += `--api-key ${apiKey}\n`;
+
+        paramsArray.forEach(p => {
+            if (p.value) {
+                preview += `${p.flag} ${p.value}\n`;
+            } else {
+                preview += `${p.flag}\n`;
+            }
+        });
+    } else if (engine === 'ds4') {
+        // ds4-server has no --api-key flag (auth not enforced by the container).
+        preview = 'ds4-server ';
+        preview += `-m ${modelPath || '/path/to/model.gguf'}\n`;
+        preview += `--host 0.0.0.0\n`;
+        preview += `--port 8000\n`;
 
         paramsArray.forEach(p => {
             if (p.value) {
@@ -463,22 +485,12 @@ async function openUpdateServiceModal(serviceName) {
         document.getElementById('service-name').value = serviceName;
         document.getElementById('service-name').disabled = true;
 
-        // Set engine based on template_type and disable it
+        // Set engine based on template_type and disable it (cannot change on edit)
         const engine = config.template_type;
-        const llamacppRadio = document.querySelector('input[name="engine"][value="llamacpp"]');
-        const vllmRadio = document.querySelector('input[name="engine"][value="vllm"]');
-
-        if (engine === 'llamacpp') {
-            llamacppRadio.checked = true;
-            vllmRadio.checked = false;
-        } else {
-            llamacppRadio.checked = false;
-            vllmRadio.checked = true;
-        }
-
-        // Disable engine radios
-        llamacppRadio.disabled = true;
-        vllmRadio.disabled = true;
+        document.querySelectorAll('input[name="engine"]').forEach(radio => {
+            radio.checked = radio.value === engine;
+            radio.disabled = true;
+        });
 
         // Trigger engine change to show/hide appropriate fields
         handleEngineChange();
@@ -492,7 +504,7 @@ async function openUpdateServiceModal(serviceName) {
         document.getElementById('api-key').value = config.api_key || '';
 
         // Engine-specific fields
-        if (engine === 'llamacpp') {
+        if (engine === 'llamacpp' || engine === 'ds4') {
             document.getElementById('model-path').value = config.model_path || '';
             // Hide file selector in update mode (no model data available)
             document.getElementById('gguf-file-selector').classList.add('hidden');
@@ -553,7 +565,8 @@ function handleEngineChange() {
     const modelPathInput = document.getElementById('model-path');
     const paramsSection = document.getElementById('params-section');
 
-    if (engine === 'llamacpp') {
+    if (engine === 'llamacpp' || engine === 'ds4') {
+        // Both use a GGUF file path (model_path).
         modelPathGroup.classList.remove('hidden');
         modelNameGroup.classList.add('hidden');
         modelPathInput.required = true;
@@ -610,7 +623,7 @@ async function handleCreateServiceSubmit(event) {
             if (port) requestBody.port = parseInt(port);
             if (apiKey) requestBody.api_key = apiKey;
 
-            if (engine === 'llamacpp') {
+            if (engine === 'llamacpp' || engine === 'ds4') {
                 requestBody.model_path = document.getElementById('model-path').value;
             } else {
                 requestBody.model_name = document.getElementById('model-hf-name').value;
@@ -641,7 +654,7 @@ async function handleCreateServiceSubmit(event) {
             if (port) requestBody.port = parseInt(port);
             if (apiKey) requestBody.api_key = apiKey;
 
-            if (engine === 'llamacpp') {
+            if (engine === 'llamacpp' || engine === 'ds4') {
                 requestBody.model_path = document.getElementById('model-path').value;
             } else {
                 requestBody.model_name = document.getElementById('model-hf-name').value;

--- a/dashboard/static/js/service-modal/param-reference.js
+++ b/dashboard/static/js/service-modal/param-reference.js
@@ -1,17 +1,20 @@
 // Parameter reference — fetches from backend API (single source of truth)
-let serveParamCache = null;
+// Cached per engine, since the reference panel supports more than one engine.
+const serveParamCache = {};
 
-async function fetchServeParamReference() {
-    if (serveParamCache) return serveParamCache;
+async function fetchServeParamReference(engine = 'llamacpp') {
+    if (serveParamCache[engine]) return serveParamCache[engine];
     try {
-        const data = await fetchAPI('/flag-metadata/llamacpp');
+        const data = await fetchAPI(`/flag-metadata/${engine}`);
         const flags = data.optional_flags || {};
 
         // Transform API format into flat array for rendering
         const CATEGORY_ORDER = [
             'Context', 'GPU', 'Multi-GPU', 'KV Cache', 'Batching',
             'Sampling', 'CPU', 'Memory', 'RoPE', 'LoRA',
-            'Speculative', 'Features'
+            'Speculative', 'Features',
+            // ds4 categories
+            'Context & Runtime', 'Backend', 'Disk KV Cache', 'HTTP API'
         ];
 
         const items = Object.entries(flags).map(([key, meta]) => ({
@@ -32,7 +35,7 @@ async function fetchServeParamReference() {
             return a.flag.localeCompare(b.flag);
         });
 
-        serveParamCache = items;
+        serveParamCache[engine] = items;
         return items;
     } catch (e) {
         console.error('Failed to load param reference:', e);
@@ -46,14 +49,14 @@ async function renderServeParamRef(filter = '') {
     const empty = document.getElementById('serve-param-ref-empty');
     if (!list) return;
 
-    // For vllm, we don't show the reference panel (different flags)
-    if (engine !== 'llamacpp') {
-        list.innerHTML = '<div class="text-gray-500 text-xs py-2">Reference available for llama.cpp only.</div>';
+    // vllm flags are documented elsewhere; the panel covers llama.cpp and ds4.
+    if (engine !== 'llamacpp' && engine !== 'ds4') {
+        list.innerHTML = '<div class="text-gray-500 text-xs py-2">Reference available for llama.cpp and ds4 only.</div>';
         empty.classList.add('hidden');
         return;
     }
 
-    const params = await fetchServeParamReference();
+    const params = await fetchServeParamReference(engine);
     const q = filter.toLowerCase();
     let html = '';
     let currentCat = '';

--- a/dashboard/static/js/service-modal/param-rows.js
+++ b/dashboard/static/js/service-modal/param-rows.js
@@ -91,6 +91,8 @@ function resetServiceParams() {
     const engine = document.querySelector('input[name="engine"]:checked')?.value;
     if (engine === 'llamacpp') {
         loadServiceParams({ '-ngl': '999', '-c': '8192' });
+    } else if (engine === 'ds4') {
+        loadServiceParams({ '--ctx': '65536', '--warm-weights': '' });
     } else {
         loadServiceParams({});
     }

--- a/dashboard/static/js/services.js
+++ b/dashboard/static/js/services.js
@@ -66,7 +66,8 @@ function renderServices(services) {
 
         // Determine internal port based on service type
         const internalPort = service.name.startsWith('llamacpp-') ? 8080 :
-                            service.name.startsWith('vllm-') ? 8000 : null;
+                            service.name.startsWith('vllm-') ? 8000 :
+                            service.name.startsWith('ds4-') ? 8000 : null;
 
         const portInfo = service.host_port && service.host_port !== 9999
             ? (internalPort ? `<span class="font-bold">${internalPort}</span>:${service.host_port}` : service.host_port)

--- a/dashboard/templates/ds4.j2
+++ b/dashboard/templates/ds4.j2
@@ -1,0 +1,41 @@
+  {{ service_name }}:
+    image: llm-dock-ds4
+    container_name: {{ service_name }}
+    restart: no
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    ports:
+      - "{{ port }}:8000"
+
+    ipc: host
+
+    environment:
+      - HF_HUB_OFFLINE=1
+{% for k, v in (extra_env or {}).items() %}
+      - {{ k }}={{ v }}
+{% endfor %}
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface:ro
+      - ${HOME}/.cache/models:/local-models:ro
+      - ${HOME}/.cache/ds4-kv:/kv
+
+    networks:
+      - llm-network
+
+    # Entrypoint is `ds4-server` (set in the image). ds4-server has no
+    # --api-key flag, so {{ api_key }} is stored in services.json but not
+    # enforced by the container; auth relies on the internal llm-network.
+    # Disk KV cache is opt-in via params, e.g. --kv-disk-dir /kv.
+    command: >
+      -m {{ model_path }}
+      --host 0.0.0.0
+      --port 8000
+      {% for flag in rendered_flags %}{{ flag }}
+      {% endfor %}

--- a/dashboard/templates/ds4.j2
+++ b/dashboard/templates/ds4.j2
@@ -22,7 +22,9 @@
       - {{ k }}={{ v }}
 {% endfor %}
     volumes:
-      - ${HOME}/.cache/huggingface:/root/.cache/huggingface:ro
+      # HF cache at /hf-cache to match llamacpp + the UI's host->container
+      # path transform (transformToContainerPath); model_path uses /hf-cache.
+      - ${HOME}/.cache/huggingface:/hf-cache:ro
       - ${HOME}/.cache/models:/local-models:ro
       - ${HOME}/.cache/ds4-kv:/kv
 


### PR DESCRIPTION
Phase 2 of #54 — makes **ds4** a first-class `template_type` alongside `vllm`/`llamacpp`, so a ds4 service can be created/edited/rendered through the dashboard and the CLI/services.json workflow.

## Backend
- **`templates/ds4.j2`** — compose service: GPU passthrough, `port:8000`, HF cache (RO) + `/local-models` + `/kv` mounts, command `ds4-server -m <gguf> --host 0.0.0.0 --port 8000 {params}`. ds4-server has no `--api-key`, so the per-service key is stored but not enforced (internal `llm-network`).
- **`compose_manager.py`** — ds4 render context (`model_path`/`alias`/`api_key`).
- **`flag_metadata.py`** — `MANDATORY_FIELDS['ds4']` + `DS4_FLAGS` (13 flags) + `DS4_VALIDATION` + getter branches.
- **`routes/services.py`** — accept `ds4` in create + flag-metadata endpoints.
- **`routes/system.py`** — expose `llm-dock-ds4` image build metadata.

## Frontend (both UIs)
- **React (`/v2`)** — engine badges (ServicesTable, ServiceDetailsHeader), command preview, running-services filter, ds4 badge colors in `index.css` (`@theme`).
- **Legacy static (`/`)** — engine radio, create/edit `model_path` handling, smart defaults (`--warm-weights`, `--ctx` by VRAM headroom), command preview, param reset.

ds4 uses a GGUF **file path** (`model_path`, like llamacpp). Internal port **8000** matches vLLM, so existing `8080 if llamacpp else 8000` branches need no change.

## Verification
- `222 passed` dashboard pytest suite.
- React `npm run build` clean; confirmed `bg-badge-ds4-bg`/`text-badge-ds4-fg` generated.
- `ds4.j2` renders a valid compose service (manual `_render_service` check).
- Static JS `node --check` clean.

## Not in this PR
Phase 3: `services.json` entry for the DeepSeek-V4 model, bring-up + smoke test, Open WebUI registration, CLAUDE.md docs.