### PR TITLE
Phase 1 (#58): extract prompt builder and SSE event codec

### DIFF
--- a/dashboard/chat/event_codec.py
+++ b/dashboard/chat/event_codec.py
@@ -1,0 +1,53 @@
+"""SSE encoding for chat runtime events.
+
+Extracted from chat.routes (Phase 1 of #58) so the wire format lives in one
+place and can be shared by persisted chat, spinoff, run reattachment, and
+future ghost streams. The frontend SSE parser should not need to know which
+producer emitted a frame.
+
+This phase only centralizes the framing — it does NOT change any byte that
+goes out. In particular, model deltas are still forwarded as the raw upstream
+chunk (see encode_sse_delta); normalizing them into a typed frame is deferred
+to its own paired frontend+backend PR.
+"""
+import json
+
+# Terminal sentinel that closes a stream. Kept as a constant because it is
+# emitted verbatim and parsed verbatim on the client.
+DONE = "data: [DONE]\n\n"
+
+
+def encode_sse(payload: dict) -> str:
+    """Frame an already-shaped payload dict as an SSE `data:` line.
+
+    Used for frames that don't carry a `type` key — currently just the legacy
+    error frame `{"error": "..."}`. `default=str` is a safety net for
+    non-JSON-serializable values (e.g. artifact content objects); it never
+    fires for plain dicts, so output is identical to a bare json.dumps.
+    """
+    return f"data: {json.dumps(payload, default=str)}\n\n"
+
+
+def encode_sse_event(event_type: str, data: dict = None) -> str:
+    """Frame a typed runtime event as `{"type": event_type, **data}`.
+
+    Insertion order is `type` first, matching the hand-written frames this
+    replaced, so the serialized bytes are unchanged.
+    """
+    payload = {"type": event_type}
+    if data:
+        payload.update(data)
+    return encode_sse(payload)
+
+
+def encode_sse_delta(raw: str) -> str:
+    """Forward an upstream model delta chunk verbatim.
+
+    Deltas are deliberately NOT re-encoded into a typed `{"type": "delta"}`
+    frame: the raw OpenAI-compatible chunk is passed straight through, exactly
+    as the old code did. This is the one documented exception to typed framing.
+    Normalizing it is a coordinated frontend+backend change deferred to its own
+    PR (#58); keeping the exception in one function makes that change a
+    one-line edit here plus its frontend counterpart.
+    """
+    return f"data: {raw}\n\n"

--- a/dashboard/chat/prompt_builder.py
+++ b/dashboard/chat/prompt_builder.py
@@ -1,0 +1,50 @@
+"""Prompt construction for chat turns.
+
+Extracted from chat.routes._stream_response (Phase 1 of #58) so the message
+array can be built from explicit inputs rather than Flask globals / a live
+Conversation row. This lets the upcoming background runtime and non-persisted
+modes (Ghost Chat, #57) build prompts the same way persisted chat does.
+"""
+import datetime
+
+from .llm_proxy import build_messages_array
+from .mcp_registry import get_tool_hints
+
+
+def _date_line(today: datetime.date) -> str:
+    # Models keep training on data with a past cutoff, so without an explicit
+    # "today" they write stale years into time-sensitive queries.
+    return (
+        f"Current date: {today.isoformat()} ({today.strftime('%A')}). "
+        'Use this as "today" when interpreting time-sensitive questions.'
+    )
+
+
+def build_chat_messages(
+    system_prompt: str,
+    messages: list,
+    enabled_servers: list,
+    include_date_line: bool = True,
+) -> list:
+    """Build the OpenAI-compatible message array for a chat turn.
+
+    Augments the system prompt with MCP tool hints (when servers are enabled)
+    and an explicit current-date line, then delegates row->dict shaping
+    (including image multipart content) to build_messages_array.
+
+    Mirrors the behavior previously inlined in _stream_response; the only
+    new affordance is `include_date_line`, which defaults to the historical
+    always-on behavior.
+    """
+    prompt = system_prompt or ""
+
+    if enabled_servers:
+        hints = get_tool_hints(enabled_servers)
+        if hints:
+            prompt = f"{prompt}\n\n{hints}" if prompt else hints
+
+    if include_date_line:
+        line = _date_line(datetime.date.today())
+        prompt = f"{prompt}\n\n{line}" if prompt else line
+
+    return build_messages_array(prompt, messages)

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 import os
@@ -14,9 +13,11 @@ from auth import require_auth
 from .db import ChatDB
 from .models import Conversation, Message, Critique, Artifact
 from .constants import DEFAULT_MAIN_SYSTEM_PROMPT, DEFAULT_SIDEKICK_SYSTEM_PROMPT, DEFAULT_CONTEXT_WINDOW
-from .llm_proxy import stream_chat_completion, build_messages_array, resolve_service
+from .llm_proxy import stream_chat_completion, resolve_service
 from .critique import build_critique_context, request_critique, validate_annotations
-from .mcp_registry import list_available_servers, get_tool_hints
+from .mcp_registry import list_available_servers
+from .prompt_builder import build_chat_messages
+from .event_codec import DONE, encode_sse, encode_sse_event, encode_sse_delta
 from . import settings_store
 from .tool_loop import stream_with_tools
 
@@ -331,21 +332,11 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
     db.add_message(user_msg)
     db.touch_conversation(conv.id)
 
-    # Build messages array, augmenting system prompt with tool hints and
-    # an explicit "today's date" line. Models keep training on data with a
-    # past cutoff, so without this they'll write 2024/2025 in queries even
-    # when the user is asking about now.
+    # Build messages array, augmenting system prompt with tool hints and an
+    # explicit "today's date" line (see prompt_builder).
     messages = db.get_messages(conv.id)
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-    system_prompt = conv.main_system_prompt
-    if enabled_servers:
-        hints = get_tool_hints(enabled_servers)
-        if hints:
-            system_prompt = f"{system_prompt}\n\n{hints}" if system_prompt else hints
-    today = datetime.date.today()
-    date_line = f"Current date: {today.isoformat()} ({today.strftime('%A')}). Use this as \"today\" when interpreting time-sensitive questions."
-    system_prompt = f"{system_prompt}\n\n{date_line}" if system_prompt else date_line
-    messages_array = build_messages_array(system_prompt, messages)
+    messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
 
     # Get MCP tools
     tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None
@@ -423,37 +414,37 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
     try:
         for event_type, data in stream:
             if event_type == "__heartbeat__":
-                yield f"data: {json.dumps({'type': 'heartbeat', 'elapsed_s': data['elapsed_s']})}\n\n"
+                yield encode_sse_event("heartbeat", {"elapsed_s": data["elapsed_s"]})
                 continue
             if event_type == "delta":
                 accumulated_content += data.get("content", "") or ""
                 accumulated_reasoning += data.get("reasoning_content", "") or ""
-                yield f"data: {data['raw']}\n\n"
+                yield encode_sse_delta(data["raw"])
             elif event_type == "tool_call_pending":
-                yield f"data: {json.dumps({'type': 'tool_call_pending', 'index': data['index'], 'name': data['name']})}\n\n"
+                yield encode_sse_event("tool_call_pending", {"index": data["index"], "name": data["name"]})
             elif event_type == "parse_warning":
                 # Format-drift signal from llm_proxy. Stash so we can persist
                 # alongside the message on `done`; also forward live so the UI
                 # shows the chip before the response finishes streaming.
                 last_parse_warning = data
-                yield f"data: {json.dumps({'type': 'parse_warning', **data})}\n\n"
+                yield encode_sse_event("parse_warning", data)
             elif event_type == "tool_call":
                 collected_tool_calls.append({
                     "name": data["name"],
                     "arguments": data["arguments"],
                     "server_id": data["server_id"],
                 })
-                yield f"data: {json.dumps({'type': 'tool_call', 'name': data['name'], 'arguments': data['arguments'], 'server_id': data['server_id']})}\n\n"
+                yield encode_sse_event("tool_call", {"name": data["name"], "arguments": data["arguments"], "server_id": data["server_id"]})
             elif event_type == "tool_result":
                 for tc in reversed(collected_tool_calls):
                     if tc["name"] == data["name"] and "result" not in tc:
                         tc["result"] = data["result"]
                         break
-                yield f"data: {json.dumps({'type': 'tool_result', 'name': data['name'], 'result': data['result'], 'server_id': data['server_id']})}\n\n"
+                yield encode_sse_event("tool_result", {"name": data["name"], "result": data["result"], "server_id": data["server_id"]})
             elif event_type == "artifact":
                 collected_artifacts.append(data)
                 # Send artifact to frontend (without full content to keep SSE lean)
-                yield f"data: {json.dumps({'type': 'artifact', 'artifact_type': data['type'], 'title': data.get('title'), 'content': data['content']}, default=str)}\n\n"
+                yield encode_sse_event("artifact", {"artifact_type": data["type"], "title": data.get("title"), "content": data["content"]})
             elif event_type == "done":
                 next_seq = db.next_seq(conv.id)
                 assistant_msg = Message(
@@ -492,19 +483,19 @@ def _stream_response(db: ChatDB, conv: Conversation, user_msg: Message, mcp_mana
                         language=art_data.get("language"),
                     ))
                 db.touch_conversation(conv.id)
-                yield "data: [DONE]\n\n"
-                yield f"data: {json.dumps({'type': 'message_saved', 'message_id': assistant_msg_id, 'seq': next_seq})}\n\n"
+                yield DONE
+                yield encode_sse_event("message_saved", {"message_id": assistant_msg_id, "seq": next_seq})
             elif event_type == "error":
                 # Set had_error BEFORE yielding — a client disconnect during
                 # the yield would otherwise fire GeneratorExit -> finally
                 # without the flag set, and a server-side model failure with
                 # accumulated deltas would still write a partial.
                 had_error = True
-                yield f"data: {json.dumps({'error': data['message']})}\n\n"
+                yield encode_sse({"error": data["message"]})
                 return
 
         if not done:
-            yield f"data: {json.dumps({'error': 'Stream ended unexpectedly'})}\n\n"
+            yield encode_sse({"error": "Stream ended unexpectedly"})
     except GeneratorExit:
         # Client disconnected mid-stream (navigation, tab close, network
         # drop). Flask raises this at the next yield after the WSGI layer
@@ -610,7 +601,7 @@ def send_message(conv_id):
             try:
                 new_title = _auto_generate_title(db, conv_id, content, conv.main_service)
                 if new_title:
-                    yield f"data: {json.dumps({'type': 'conversation_updated', 'id': conv_id, 'title': new_title})}\n\n"
+                    yield encode_sse_event("conversation_updated", {"id": conv_id, "title": new_title})
             except Exception:
                 logger.exception("auto-title failed")
 
@@ -738,11 +729,11 @@ def spinoff():
     def generate():
         for event_type, event_data in stream_chat_completion(service_name, messages_array):
             if event_type == "delta":
-                yield f"data: {event_data['raw']}\n\n"
+                yield encode_sse_delta(event_data["raw"])
             elif event_type == "done":
-                yield "data: [DONE]\n\n"
+                yield DONE
             elif event_type == "error":
-                yield f"data: {json.dumps({'error': event_data['message']})}\n\n"
+                yield encode_sse({"error": event_data["message"]})
                 return
 
     return Response(stream_with_context(generate()), mimetype="text/event-stream",

--- a/dashboard/tests/test_chat_prompt_builder.py
+++ b/dashboard/tests/test_chat_prompt_builder.py
@@ -1,0 +1,90 @@
+"""Unit tests for chat.prompt_builder.build_chat_messages (Phase 1 of #58).
+
+The builder was extracted from _stream_response; these pin its system-prompt
+augmentation (tool hints + date line) and its delegation of row->dict shaping
+(including image multipart) to build_messages_array.
+"""
+import datetime
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import prompt_builder
+from chat.models import Message
+
+
+def _user(content="hi", images_json=None):
+    return Message(
+        id=str(uuid.uuid4()),
+        conversation_id="c",
+        role="user",
+        content=content,
+        images_json=images_json,
+        seq=0,
+    )
+
+
+def _system_text(arr):
+    assert arr[0]["role"] == "system"
+    return arr[0]["content"]
+
+
+def test_date_line_appended_by_default(monkeypatch):
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", lambda s: "")
+    arr = prompt_builder.build_chat_messages("You are helpful.", [_user()], [])
+    sys_text = _system_text(arr)
+    assert sys_text.startswith("You are helpful.\n\n")
+    assert "Current date:" in sys_text
+    today = datetime.date.today()
+    assert today.isoformat() in sys_text
+    # The user message is carried through.
+    assert arr[1] == {"role": "user", "content": "hi"}
+
+
+def test_date_line_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", lambda s: "")
+    arr = prompt_builder.build_chat_messages("Base.", [_user()], [], include_date_line=False)
+    assert _system_text(arr) == "Base."
+
+
+def test_tool_hints_prepended_before_date_line(monkeypatch):
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", lambda servers: f"HINTS for {servers}")
+    arr = prompt_builder.build_chat_messages("Base.", [_user()], ["sympy-math"])
+    sys_text = _system_text(arr)
+    assert "Base." in sys_text
+    assert "HINTS for ['sympy-math']" in sys_text
+    # Order: base prompt, then hints, then date line.
+    assert sys_text.index("Base.") < sys_text.index("HINTS") < sys_text.index("Current date:")
+
+
+def test_no_hints_when_no_servers(monkeypatch):
+    called = {"n": 0}
+
+    def _hints(servers):
+        called["n"] += 1
+        return "SHOULD NOT APPEAR"
+
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", _hints)
+    arr = prompt_builder.build_chat_messages("Base.", [_user()], [])
+    assert "SHOULD NOT APPEAR" not in _system_text(arr)
+    assert called["n"] == 0  # not consulted when no servers enabled
+
+
+def test_empty_system_prompt_yields_date_line_only(monkeypatch):
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", lambda s: "")
+    arr = prompt_builder.build_chat_messages("", [_user()], [])
+    # No leading blank lines when there was no base prompt.
+    assert _system_text(arr).startswith("Current date:")
+
+
+def test_images_delegated_to_multipart(monkeypatch):
+    monkeypatch.setattr(prompt_builder, "get_tool_hints", lambda s: "")
+    msg = _user(content="look", images_json='["data:image/png;base64,AAAA"]')
+    arr = prompt_builder.build_chat_messages("", [msg], [], include_date_line=False)
+    # System prompt is empty + no date line -> only the user message remains.
+    assert len(arr) == 1
+    content = arr[0]["content"]
+    assert {"type": "text", "text": "look"} in content
+    assert {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}} in content

--- a/dashboard/tests/test_event_codec.py
+++ b/dashboard/tests/test_event_codec.py
@@ -1,0 +1,53 @@
+"""Unit tests for chat.event_codec (Phase 1 of #58).
+
+Pin the SSE framing so the wire format is stable across persisted chat,
+spinoff, and future run/ghost streams. The delta passthrough is asserted to
+stay raw (the documented exception that a later paired FE+BE PR will change).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import event_codec
+
+
+def test_done_sentinel():
+    assert event_codec.DONE == "data: [DONE]\n\n"
+
+
+def test_encode_sse_event_prefixes_type_and_frames():
+    out = event_codec.encode_sse_event("tool_call", {"name": "solve", "server_id": "x"})
+    assert out.startswith("data: ") and out.endswith("\n\n")
+    payload = json.loads(out[len("data: "):-2])
+    assert payload == {"type": "tool_call", "name": "solve", "server_id": "x"}
+    # `type` is the first key so the serialized bytes match the old hand-written
+    # frames.
+    assert out.startswith('data: {"type": "tool_call"')
+
+
+def test_encode_sse_event_without_data():
+    assert event_codec.encode_sse_event("done_marker") == 'data: {"type": "done_marker"}\n\n'
+
+
+def test_encode_sse_typeless_payload():
+    # The legacy error frame carries no `type` key.
+    assert event_codec.encode_sse({"error": "boom"}) == 'data: {"error": "boom"}\n\n'
+
+
+def test_encode_sse_delta_passthrough_is_raw():
+    raw = '{"choices":[{"delta":{"content":"hi"}}]}'
+    out = event_codec.encode_sse_delta(raw)
+    # Forwarded verbatim — NOT wrapped in a typed {"type":"delta"} frame.
+    assert out == f"data: {raw}\n\n"
+    assert "\"type\"" not in out
+
+
+def test_encode_sse_handles_non_serializable_via_default_str():
+    class Weird:
+        def __str__(self):
+            return "weird!"
+
+    out = event_codec.encode_sse({"x": Weird()})
+    assert json.loads(out[len("data: "):-2]) == {"x": "weird!"}


### PR DESCRIPTION
## Phase 1 of #58 — Extract prompt building and SSE event encoding

Moves prompt construction and SSE framing out of `_stream_response` into dedicated modules, so the upcoming background runtime (Phase 3+) and non-persisted modes (Ghost Chat, #57) can reuse them. **Behavior-preserving** — no background processing yet.

### New modules

- **`chat/prompt_builder.py`** — `build_chat_messages(system_prompt, messages, enabled_servers, include_date_line=True)` absorbs the inline tool-hint + current-date system-prompt augmentation that lived in `_stream_response`, and delegates row→dict shaping (including image multipart) to the existing `build_messages_array`. `include_date_line` defaults to the historical always-on behavior.
- **`chat/event_codec.py`** — `encode_sse_event` / `encode_sse` / `encode_sse_delta` / `DONE` centralize the wire format. **Deltas stay a raw passthrough** (`encode_sse_delta`) — the one documented exception to typed framing; per the issue decision, normalizing deltas into a typed frame is deferred to its own paired frontend+backend PR.

### `routes.py`

`_stream_response`, the `send_message` auto-title tail, and the `spinoff` loop now route through the codec. Spinoff reuses the shared encoder (Phase 1 acceptance: "spinoff can reuse the same encoder where practical"). Net `routes.py`: −31/+22 lines.

### Why this is safe

The Phase 0 exact-frame characterization tests pass **unchanged**, which proves the SSE output is byte-identical (the codec preserves key order and `default=str`). New unit tests cover the builder and codec directly.

### Tests

```
cd dashboard
pytest tests/test_chat_prompt_builder.py tests/test_event_codec.py \
       tests/test_chat_stream_events.py tests/test_partial_save.py tests/test_chat_settings_routes.py
# 47 passed
pytest tests/   # full suite: 240 passed
```

Refs #58 (Phase 1).
