### PR TITLE
Phase 2 (#58): chat_runs storage without background execution

### DIFF
--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional, List, Tuple
 
 from .models import Conversation, Message, Critique, Artifact, ChatRun
-from .runs import ChatRunStatus, ACTIVE_STATUSES, ALL_STATUSES
+from .runs import ChatRunStatus, ACTIVE_STATUSES, TERMINAL_STATUSES, ALL_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -491,10 +491,13 @@ class ChatDB:
         list enrichment without reopening.
         """
         placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
+        # rowid (not id) is the chronological tiebreaker: created_at is only
+        # second-precision and ids are random UUIDs, so within one second only
+        # insertion order (rowid) reflects which run is actually newer.
         row = conn.execute(
             f"""SELECT * FROM chat_runs
                 WHERE conversation_id = ? AND status IN ({placeholders})
-                ORDER BY created_at DESC, id DESC LIMIT 1""",
+                ORDER BY created_at DESC, rowid DESC LIMIT 1""",
             (conv_id, *sorted(ACTIVE_STATUSES)),
         ).fetchone()
         return self._row_to_chat_run(row) if row else None
@@ -509,10 +512,11 @@ class ChatDB:
         rows = conn.execute(
             f"""SELECT * FROM chat_runs
                 WHERE status IN ({status_ph}) AND conversation_id IN ({conv_ph})
-                ORDER BY created_at ASC, id ASC""",
+                ORDER BY created_at ASC, rowid ASC""",
             (*sorted(ACTIVE_STATUSES), *conv_ids),
         ).fetchall()
-        # ASC order means the last write per conversation is the most recent run.
+        # ASC by insertion order (rowid) means the last write per conversation
+        # is the most recent run — chronological even within a one-second tie.
         latest = {}
         for row in rows:
             run = self._row_to_chat_run(row)
@@ -561,7 +565,7 @@ class ChatDB:
             placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
             rows = conn.execute(
                 f"""SELECT * FROM chat_runs WHERE status IN ({placeholders})
-                    ORDER BY created_at ASC, id ASC""",
+                    ORDER BY created_at ASC, rowid ASC""",
                 tuple(sorted(ACTIVE_STATUSES)),
             ).fetchall()
             return [self._row_to_chat_run(row) for row in rows]
@@ -576,6 +580,11 @@ class ChatDB:
         plain status bump doesn't clobber an earlier active_step. Timestamps:
         running -> started_at (first time only), completed/failed ->
         completed_at, cancelled -> cancelled_at.
+
+        Terminal runs are frozen: the WHERE clause excludes already-terminal
+        rows, so a completed/failed/cancelled run can never move back to an
+        active state (the lifecycle contract). Such a call is a harmless no-op
+        and returns the run unchanged.
         """
         if status not in ALL_STATUSES:
             raise ValueError(f"invalid run status: {status!r}")
@@ -594,11 +603,15 @@ class ChatDB:
             sets.append(f"completed_at = {now}")
         elif status == ChatRunStatus.CANCELLED:
             sets.append(f"cancelled_at = {now}")
+        terminal_ph = ",".join("?" for _ in TERMINAL_STATUSES)
         params.append(run_id)
+        params.extend(sorted(TERMINAL_STATUSES))
         conn = self._get_conn()
         try:
             conn.execute(
-                f"UPDATE chat_runs SET {', '.join(sets)} WHERE id = ?", params
+                f"""UPDATE chat_runs SET {', '.join(sets)}
+                    WHERE id = ? AND status NOT IN ({terminal_ph})""",
+                params,
             )
             conn.commit()
             return self.get_chat_run(run_id)

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -3,7 +3,8 @@ import sqlite3
 import logging
 from typing import Optional, List, Tuple
 
-from .models import Conversation, Message, Critique, Artifact
+from .models import Conversation, Message, Critique, Artifact, ChatRun
+from .runs import ChatRunStatus, ACTIVE_STATUSES, ALL_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,22 @@ CREATE TABLE IF NOT EXISTS artifacts (
 );
 
 CREATE INDEX IF NOT EXISTS idx_artifact_msg ON artifacts(message_id);
+
+CREATE TABLE IF NOT EXISTS chat_runs (
+    id              TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    user_message_id TEXT REFERENCES messages(id) ON DELETE SET NULL,
+    status          TEXT NOT NULL,
+    active_step     TEXT,
+    error           TEXT,
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    started_at      TEXT,
+    completed_at    TEXT,
+    cancelled_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_runs_conversation ON chat_runs(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_chat_runs_status ON chat_runs(status);
 """
 
 
@@ -154,6 +171,8 @@ class ChatDB:
                 return None
             conv = self._row_to_conversation(row)
             conv.messages = self.get_messages(conv_id, conn=conn)
+            run = self._active_run_for(conn, conv_id)
+            conv.active_run = run.active_run_dict() if run else None
             return conv
         finally:
             self._close_conn(conn)
@@ -167,6 +186,7 @@ class ChatDB:
                 (limit, offset),
             ).fetchall()
             convs = [self._row_to_conversation(row) for row in rows]
+            self._attach_active_runs(conn, convs)
             return convs, total
         finally:
             self._close_conn(conn)
@@ -219,6 +239,10 @@ class ChatDB:
         count = conn.execute(cte + "SELECT COUNT(DISTINCT id) FROM d", params).fetchone()[0]
         if count == 0:
             return 0
+        # Explicitly clear chat_runs for the deleted conversations. The FK is
+        # ON DELETE CASCADE, but the in-memory test DB (the persistent
+        # connection) doesn't enable PRAGMA foreign_keys, so don't rely on it.
+        conn.execute(cte + "DELETE FROM chat_runs WHERE conversation_id IN (SELECT id FROM d)", params)
         conn.execute(cte + "DELETE FROM conversations WHERE id IN (SELECT id FROM d)", params)
         return count
 
@@ -443,3 +467,149 @@ class ChatDB:
             return result
         finally:
             self._close_conn(conn)
+
+    # -- Chat runs (issue #58) --
+
+    def _row_to_chat_run(self, row: sqlite3.Row) -> ChatRun:
+        return ChatRun(
+            id=row["id"],
+            conversation_id=row["conversation_id"],
+            status=row["status"],
+            user_message_id=row["user_message_id"],
+            active_step=row["active_step"],
+            error=row["error"],
+            created_at=row["created_at"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            cancelled_at=row["cancelled_at"],
+        )
+
+    def _active_run_for(self, conn: sqlite3.Connection, conv_id: str) -> Optional[ChatRun]:
+        """Most recent queued/running run for a conversation, or None.
+
+        Shares the caller's connection so it can run inside get_conversation /
+        list enrichment without reopening.
+        """
+        placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
+        row = conn.execute(
+            f"""SELECT * FROM chat_runs
+                WHERE conversation_id = ? AND status IN ({placeholders})
+                ORDER BY created_at DESC, id DESC LIMIT 1""",
+            (conv_id, *sorted(ACTIVE_STATUSES)),
+        ).fetchone()
+        return self._row_to_chat_run(row) if row else None
+
+    def _attach_active_runs(self, conn: sqlite3.Connection, convs: List[Conversation]):
+        """Populate conv.active_run for a batch of conversations in one query."""
+        if not convs:
+            return
+        conv_ids = [c.id for c in convs]
+        status_ph = ",".join("?" for _ in ACTIVE_STATUSES)
+        conv_ph = ",".join("?" for _ in conv_ids)
+        rows = conn.execute(
+            f"""SELECT * FROM chat_runs
+                WHERE status IN ({status_ph}) AND conversation_id IN ({conv_ph})
+                ORDER BY created_at ASC, id ASC""",
+            (*sorted(ACTIVE_STATUSES), *conv_ids),
+        ).fetchall()
+        # ASC order means the last write per conversation is the most recent run.
+        latest = {}
+        for row in rows:
+            run = self._row_to_chat_run(row)
+            latest[run.conversation_id] = run
+        for c in convs:
+            run = latest.get(c.id)
+            c.active_run = run.active_run_dict() if run else None
+
+    def create_chat_run(self, run: ChatRun) -> ChatRun:
+        if run.status not in ALL_STATUSES:
+            raise ValueError(f"invalid run status: {run.status!r}")
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO chat_runs
+                   (id, conversation_id, user_message_id, status, active_step, error)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (run.id, run.conversation_id, run.user_message_id,
+                 run.status, run.active_step, run.error),
+            )
+            conn.commit()
+            return self.get_chat_run(run.id)
+        finally:
+            self._close_conn(conn)
+
+    def get_chat_run(self, run_id: str) -> Optional[ChatRun]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM chat_runs WHERE id = ?", (run_id,)
+            ).fetchone()
+            return self._row_to_chat_run(row) if row else None
+        finally:
+            self._close_conn(conn)
+
+    def get_active_run_for_conversation(self, conversation_id: str) -> Optional[ChatRun]:
+        conn = self._get_conn()
+        try:
+            return self._active_run_for(conn, conversation_id)
+        finally:
+            self._close_conn(conn)
+
+    def list_active_runs(self) -> List[ChatRun]:
+        conn = self._get_conn()
+        try:
+            placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
+            rows = conn.execute(
+                f"""SELECT * FROM chat_runs WHERE status IN ({placeholders})
+                    ORDER BY created_at ASC, id ASC""",
+                tuple(sorted(ACTIVE_STATUSES)),
+            ).fetchall()
+            return [self._row_to_chat_run(row) for row in rows]
+        finally:
+            self._close_conn(conn)
+
+    def update_chat_run_status(self, run_id: str, status: str,
+                               active_step: str = None, error: str = None) -> Optional[ChatRun]:
+        """Set a run's status, stamping the matching lifecycle timestamp.
+
+        active_step / error are only written when provided (non-None), so a
+        plain status bump doesn't clobber an earlier active_step. Timestamps:
+        running -> started_at (first time only), completed/failed ->
+        completed_at, cancelled -> cancelled_at.
+        """
+        if status not in ALL_STATUSES:
+            raise ValueError(f"invalid run status: {status!r}")
+        now = "strftime('%Y-%m-%dT%H:%M:%SZ','now')"
+        sets = ["status = ?"]
+        params = [status]
+        if active_step is not None:
+            sets.append("active_step = ?")
+            params.append(active_step)
+        if error is not None:
+            sets.append("error = ?")
+            params.append(error)
+        if status == ChatRunStatus.RUNNING:
+            sets.append(f"started_at = COALESCE(started_at, {now})")
+        elif status in (ChatRunStatus.COMPLETED, ChatRunStatus.FAILED):
+            sets.append(f"completed_at = {now}")
+        elif status == ChatRunStatus.CANCELLED:
+            sets.append(f"cancelled_at = {now}")
+        params.append(run_id)
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                f"UPDATE chat_runs SET {', '.join(sets)} WHERE id = ?", params
+            )
+            conn.commit()
+            return self.get_chat_run(run_id)
+        finally:
+            self._close_conn(conn)
+
+    def complete_chat_run(self, run_id: str) -> Optional[ChatRun]:
+        return self.update_chat_run_status(run_id, ChatRunStatus.COMPLETED)
+
+    def fail_chat_run(self, run_id: str, error: str) -> Optional[ChatRun]:
+        return self.update_chat_run_status(run_id, ChatRunStatus.FAILED, error=error)
+
+    def cancel_chat_run(self, run_id: str) -> Optional[ChatRun]:
+        return self.update_chat_run_status(run_id, ChatRunStatus.CANCELLED)

--- a/dashboard/chat/models.py
+++ b/dashboard/chat/models.py
@@ -86,6 +86,45 @@ class Artifact:
 
 
 @dataclass
+class ChatRun:
+    """A single model/tool turn, tracked independently of the HTTP response
+    that started it (issue #58). Persisted in the chat_runs table."""
+    id: str
+    conversation_id: str
+    status: str
+    user_message_id: Optional[str] = None
+    active_step: Optional[str] = None
+    error: Optional[str] = None
+    created_at: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    cancelled_at: Optional[str] = None
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "conversation_id": self.conversation_id,
+            "status": self.status,
+            "user_message_id": self.user_message_id,
+            "active_step": self.active_step,
+            "error": self.error,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "cancelled_at": self.cancelled_at,
+        }
+
+    def active_run_dict(self):
+        """The trimmed shape embedded in conversation-list payloads."""
+        return {
+            "id": self.id,
+            "status": self.status,
+            "active_step": self.active_step,
+            "started_at": self.started_at,
+        }
+
+
+@dataclass
 class Conversation:
     id: str
     title: str
@@ -99,6 +138,9 @@ class Conversation:
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
     messages: List[Message] = field(default_factory=list)
+    # Populated by the DB layer from chat_runs (not a stored column). The
+    # active_run_dict() shape of the conversation's queued/running run, or None.
+    active_run: Optional[dict] = None
 
     def to_dict(self, include_messages=False):
         d = {
@@ -111,6 +153,7 @@ class Conversation:
             "parent_conversation_id": self.parent_conversation_id,
             "selected_text": self.selected_text,
             "mcp_servers": json.loads(self.mcp_servers_json) if self.mcp_servers_json else [],
+            "active_run": self.active_run,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }

--- a/dashboard/chat/runs.py
+++ b/dashboard/chat/runs.py
@@ -1,0 +1,32 @@
+"""Chat run status vocabulary (Phase 2 of #58).
+
+A *run* is one model/tool turn whose lifecycle is tracked independently of the
+HTTP response that started it. This module holds only the status vocabulary so
+both the DB layer and (later) the background runner agree on the allowed values
+without importing each other. The persistence methods live on ChatDB; a richer
+ChatRunRepository may wrap them once the background runner needs it (Phase 3+).
+"""
+
+
+class ChatRunStatus:
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+# A run is "active" while it is queued or running — these are the only states
+# that should surface as an active_run on a conversation.
+ACTIVE_STATUSES = frozenset({ChatRunStatus.QUEUED, ChatRunStatus.RUNNING})
+
+# Terminal states never reactivate.
+TERMINAL_STATUSES = frozenset(
+    {ChatRunStatus.COMPLETED, ChatRunStatus.FAILED, ChatRunStatus.CANCELLED}
+)
+
+ALL_STATUSES = ACTIVE_STATUSES | TERMINAL_STATUSES
+
+
+def is_active(status: str) -> bool:
+    return status in ACTIVE_STATUSES

--- a/dashboard/tests/test_chat_runs.py
+++ b/dashboard/tests/test_chat_runs.py
@@ -132,17 +132,41 @@ def test_terminal_runs_are_not_active(terminal):
     assert run.id not in [r.id for r in db.list_active_runs()]
 
 
-def test_active_run_picks_most_recent():
+@pytest.mark.parametrize("terminal", [
+    ChatRunStatus.COMPLETED, ChatRunStatus.FAILED, ChatRunStatus.CANCELLED,
+])
+def test_terminal_run_cannot_be_reactivated(terminal):
+    """Terminal is final: a completed/failed/cancelled run can't go back to
+    running (the lifecycle contract). The call is a harmless no-op."""
     db = ChatDB(":memory:")
     conv = _conv(db)
-    old = db.create_chat_run(ChatRun(id="aaa-old", conversation_id=conv.id,
-                                     status=ChatRunStatus.QUEUED))
-    new = db.create_chat_run(ChatRun(id="zzz-new", conversation_id=conv.id,
-                                     status=ChatRunStatus.RUNNING))
-    # Same created_at second in a fast test; the id tiebreaker keeps it
-    # deterministic. Both are active here; lookup returns one, deterministically.
-    active = db.get_active_run_for_conversation(conv.id)
-    assert active.id in {old.id, new.id}
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    terminated = db.update_chat_run_status(run.id, terminal)
+    terminal_ts = (terminated.completed_at or terminated.cancelled_at)
+
+    after = db.update_chat_run_status(run.id, ChatRunStatus.RUNNING, active_step="generating")
+    assert after.status == terminal              # unchanged
+    assert after.active_step is None             # the no-op didn't write active_step
+    # Terminal timestamp preserved; not resurrected as active.
+    assert (after.completed_at or after.cancelled_at) == terminal_ts
+    assert db.get_active_run_for_conversation(conv.id) is None
+
+
+def test_active_run_picks_most_recent_by_insertion_not_id():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    # Insert the chronologically-newer run with an id that sorts EARLIER than
+    # the older one, so a text-id tiebreaker would pick the wrong (stale) run.
+    # Both share the same one-second created_at in a fast test, so only the
+    # rowid (insertion order) tiebreaker gets this right.
+    db.create_chat_run(ChatRun(id="zzz-old", conversation_id=conv.id,
+                               status=ChatRunStatus.QUEUED))
+    newer = db.create_chat_run(ChatRun(id="aaa-new", conversation_id=conv.id,
+                                       status=ChatRunStatus.RUNNING))
+
+    assert db.get_active_run_for_conversation(conv.id).id == newer.id
+    convs, _ = db.list_conversations()
+    assert convs[0].active_run["id"] == newer.id
 
 
 def test_list_active_runs_spans_conversations():

--- a/dashboard/tests/test_chat_runs.py
+++ b/dashboard/tests/test_chat_runs.py
@@ -1,0 +1,223 @@
+"""Tests for chat_runs storage (Phase 2 of #58).
+
+No background execution yet — these exercise the DB methods and the
+active_run enrichment on conversation payloads. Stub-free; pure SQLite.
+"""
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat.db import ChatDB
+from chat.models import Conversation, Message, ChatRun
+from chat.runs import ChatRunStatus
+
+
+def _conv(db, title="t"):
+    conv = Conversation(id=str(uuid.uuid4()), title=title, main_service="svc")
+    db.create_conversation(conv)
+    return conv
+
+
+def _user_msg(db, conv):
+    msg = Message(id=str(uuid.uuid4()), conversation_id=conv.id, role="user",
+                  content="hi", seq=db.next_seq(conv.id))
+    db.add_message(msg)
+    return msg
+
+
+def _run(conv, status=ChatRunStatus.QUEUED, user_message_id=None):
+    return ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                   status=status, user_message_id=user_message_id)
+
+
+# -- create / get / update ----------------------------------------------
+
+
+def test_create_get_run():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    msg = _user_msg(db, conv)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.QUEUED, user_message_id=msg.id))
+
+    assert run.id is not None
+    assert run.status == "queued"
+    assert run.user_message_id == msg.id
+    assert run.created_at  # DB default stamped
+    assert run.started_at is None
+
+    fetched = db.get_chat_run(run.id)
+    assert fetched.id == run.id
+    assert fetched.conversation_id == conv.id
+
+
+def test_get_missing_run_returns_none():
+    db = ChatDB(":memory:")
+    assert db.get_chat_run("nope") is None
+
+
+def test_create_run_rejects_bad_status():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    with pytest.raises(ValueError):
+        db.create_chat_run(_run(conv, status="bogus"))
+
+
+def test_update_status_stamps_started_at():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.QUEUED))
+
+    updated = db.update_chat_run_status(run.id, ChatRunStatus.RUNNING, active_step="generating")
+    assert updated.status == "running"
+    assert updated.active_step == "generating"
+    assert updated.started_at is not None
+
+    # A second running bump must not move started_at (COALESCE).
+    first_started = updated.started_at
+    again = db.update_chat_run_status(run.id, ChatRunStatus.RUNNING)
+    assert again.started_at == first_started
+    # active_step not passed -> preserved, not clobbered.
+    assert again.active_step == "generating"
+
+
+def test_complete_fail_cancel_helpers_stamp_timestamps():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+
+    r1 = db.create_chat_run(_run(conv))
+    done = db.complete_chat_run(r1.id)
+    assert done.status == "completed" and done.completed_at is not None
+
+    r2 = db.create_chat_run(_run(conv))
+    failed = db.fail_chat_run(r2.id, "model exploded")
+    assert failed.status == "failed" and failed.error == "model exploded"
+    assert failed.completed_at is not None
+
+    r3 = db.create_chat_run(_run(conv))
+    cancelled = db.cancel_chat_run(r3.id)
+    assert cancelled.status == "cancelled" and cancelled.cancelled_at is not None
+
+
+# -- active-run lookup --------------------------------------------------
+
+
+def test_active_run_lookup_returns_only_active():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+
+    assert db.get_active_run_for_conversation(conv.id) is None
+
+    queued = db.create_chat_run(_run(conv, ChatRunStatus.QUEUED))
+    active = db.get_active_run_for_conversation(conv.id)
+    assert active.id == queued.id
+
+    db.update_chat_run_status(queued.id, ChatRunStatus.RUNNING)
+    assert db.get_active_run_for_conversation(conv.id).id == queued.id
+
+
+@pytest.mark.parametrize("terminal", [
+    ChatRunStatus.COMPLETED, ChatRunStatus.FAILED, ChatRunStatus.CANCELLED,
+])
+def test_terminal_runs_are_not_active(terminal):
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.update_chat_run_status(run.id, terminal)
+
+    assert db.get_active_run_for_conversation(conv.id) is None
+    assert run.id not in [r.id for r in db.list_active_runs()]
+
+
+def test_active_run_picks_most_recent():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    old = db.create_chat_run(ChatRun(id="aaa-old", conversation_id=conv.id,
+                                     status=ChatRunStatus.QUEUED))
+    new = db.create_chat_run(ChatRun(id="zzz-new", conversation_id=conv.id,
+                                     status=ChatRunStatus.RUNNING))
+    # Same created_at second in a fast test; the id tiebreaker keeps it
+    # deterministic. Both are active here; lookup returns one, deterministically.
+    active = db.get_active_run_for_conversation(conv.id)
+    assert active.id in {old.id, new.id}
+
+
+def test_list_active_runs_spans_conversations():
+    db = ChatDB(":memory:")
+    c1, c2 = _conv(db), _conv(db)
+    db.create_chat_run(_run(c1, ChatRunStatus.QUEUED))
+    db.create_chat_run(_run(c2, ChatRunStatus.RUNNING))
+    db.create_chat_run(_run(c2, ChatRunStatus.COMPLETED))  # not active
+
+    active = db.list_active_runs()
+    assert len(active) == 2
+    assert {r.conversation_id for r in active} == {c1.id, c2.id}
+
+
+# -- conversation payload enrichment ------------------------------------
+
+
+def test_conversation_list_includes_active_run_null_when_none():
+    db = ChatDB(":memory:")
+    _conv(db)
+    convs, _ = db.list_conversations()
+    assert len(convs) == 1
+    assert convs[0].active_run is None
+    assert convs[0].to_dict()["active_run"] is None
+
+
+def test_conversation_list_surfaces_active_run_metadata():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.update_chat_run_status(run.id, ChatRunStatus.RUNNING, active_step="generating")
+
+    convs, _ = db.list_conversations()
+    ar = convs[0].to_dict()["active_run"]
+    assert ar == {
+        "id": run.id,
+        "status": "running",
+        "active_step": "generating",
+        "started_at": convs[0].active_run["started_at"],
+    }
+    assert ar["started_at"] is not None
+    # Trimmed shape: no error/timestamps beyond started_at.
+    assert set(ar.keys()) == {"id", "status", "active_step", "started_at"}
+
+
+def test_get_conversation_includes_active_run():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    db.create_chat_run(_run(conv, ChatRunStatus.QUEUED))
+    fetched = db.get_conversation(conv.id)
+    assert fetched.active_run is not None
+    assert fetched.active_run["status"] == "queued"
+
+
+def test_completed_run_clears_active_run_in_list():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.complete_chat_run(run.id)
+
+    convs, _ = db.list_conversations()
+    assert convs[0].active_run is None
+
+
+# -- deletion cleanup ---------------------------------------------------
+
+
+def test_deleting_conversation_removes_its_runs():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+
+    assert db.delete_conversation(conv.id) is True
+    # Run is gone, and nothing surfaces a broken active-run response.
+    assert db.get_chat_run(run.id) is None
+    assert db.list_active_runs() == []
+    convs, total = db.list_conversations()
+    assert total == 0 and convs == []


### PR DESCRIPTION
## Phase 2 of #58 — `chat_runs` storage (no background execution)

Adds run tracking that lives independently of any HTTP response. **No background runner yet** — that's Phase 3+. This phase is storage + conversation-payload enrichment only.

### New / changed

- **`chat/runs.py`** — `ChatRunStatus` vocabulary (`queued`/`running`/`completed`/`failed`/`cancelled`), `ACTIVE_STATUSES` / `TERMINAL_STATUSES` sets, `is_active()`. Kept import-free so both the DB layer and the future runner can share it without cycles.
- **`models.py`** — `ChatRun` dataclass (`to_dict` + trimmed `active_run_dict`). `Conversation` gains a **non-persisted** `active_run` field, populated by the DB layer and included in `to_dict` (`null` when none).
- **`db.py`**:
  - `chat_runs` table via `CREATE TABLE IF NOT EXISTS` in `SCHEMA_SQL` — idempotent on existing DBs, no `_migrate` change needed for a new table. FK to `conversations` (CASCADE) and `messages` (SET NULL).
  - Methods: `create_chat_run`, `get_chat_run`, `get_active_run_for_conversation`, `list_active_runs`, `update_chat_run_status`, `complete/fail/cancel_chat_run`.
  - `update_chat_run_status` stamps the matching lifecycle timestamp (`running`→`started_at` via `COALESCE` so re-running doesn't move it; `completed`/`failed`→`completed_at`; `cancelled`→`cancelled_at`) and only writes `active_step`/`error` when provided.
  - `list_conversations` (batch, one query) and `get_conversation` enriched with `active_run`.
  - Deletion **explicitly** clears `chat_runs` for the removed conversations — the FK is `ON DELETE CASCADE`, but the in-memory persistent test connection doesn't enable `PRAGMA foreign_keys`, so cleanup can't rely on it.

### Acceptance

- DB migration idempotent (re-running `_init_db` is a no-op for the table). ✅
- Conversation deletion cleans up related runs. ✅
- Existing conversation APIs backward compatible (additive `active_run` key). ✅
- Conversation list includes `active_run: null` when no run is active. ✅

### Tests

```
cd dashboard
pytest tests/test_chat_runs.py tests/test_chat_settings_routes.py   # 40 passed
pytest tests/   # full suite: 256 passed
```

`test_chat_runs.py` covers create/get/update, started_at COALESCE, the complete/fail/cancel helpers, active-run lookup returning only queued/running, terminal runs not active (parametrized), `list_active_runs` across conversations, the `active_run` payload shape (null + populated), and deletion cleanup.

Refs #58 (Phase 2).
