### PR TITLE
Phase 3 (#58): background ChatRunner callable without Flask

### DIFF
--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -334,8 +334,13 @@ class ChatDB:
             if should_close:
                 self._close_conn(conn)
 
-    def add_message(self, msg: Message) -> Message:
-        conn = self._get_conn()
+    def add_message(self, msg: Message, conn: sqlite3.Connection = None) -> Message:
+        """Insert a message. When `conn` is passed, the caller owns the
+        transaction (no commit/close here) so the insert can be part of a
+        larger atomic unit; otherwise this commits on its own."""
+        should_close = conn is None
+        if conn is None:
+            conn = self._get_conn()
         try:
             conn.execute(
                 """INSERT INTO messages
@@ -345,10 +350,15 @@ class ChatDB:
                  msg.reasoning_content, msg.model_service, msg.images_json, msg.tool_calls_json,
                  msg.parse_warning_json, msg.seq),
             )
-            conn.commit()
-            return self.get_message(msg.id)
+            if should_close:
+                conn.commit()
+                return self.get_message(msg.id)
+            # Shared transaction not yet committed — a re-fetch on a fresh
+            # connection wouldn't see the row, so return the object as-is.
+            return msg
         finally:
-            self._close_conn(conn)
+            if should_close:
+                self._close_conn(conn)
 
     def delete_messages_from_seq(self, conv_id: str, from_seq: int) -> int:
         conn = self._get_conn()
@@ -433,8 +443,12 @@ class ChatDB:
             created_at=row["created_at"],
         )
 
-    def save_artifact(self, artifact: Artifact) -> Artifact:
-        conn = self._get_conn()
+    def save_artifact(self, artifact: Artifact, conn: sqlite3.Connection = None) -> Artifact:
+        """Insert an artifact. When `conn` is passed, the caller owns the
+        transaction (no commit/close) so it can be batched atomically."""
+        should_close = conn is None
+        if conn is None:
+            conn = self._get_conn()
         try:
             conn.execute(
                 """INSERT INTO artifacts
@@ -443,10 +457,12 @@ class ChatDB:
                 (artifact.id, artifact.message_id, artifact.artifact_type,
                  artifact.content, artifact.title, artifact.language),
             )
-            conn.commit()
+            if should_close:
+                conn.commit()
             return artifact
         finally:
-            self._close_conn(conn)
+            if should_close:
+                self._close_conn(conn)
 
     def get_artifacts_for_conversation(self, conv_id: str) -> dict:
         """Returns a dict of message_id -> [Artifact] for all messages in a conversation."""
@@ -615,6 +631,52 @@ class ChatDB:
             )
             conn.commit()
             return self.get_chat_run(run_id)
+        finally:
+            self._close_conn(conn)
+
+    def complete_run_with_message(self, run_id: str, assistant_msg: Message,
+                                  artifacts: List[Artifact] = None) -> Optional[Message]:
+        """Atomically finish a run: assign the message's seq, insert it and its
+        artifacts, mark the run completed, and touch the conversation — all in
+        one transaction.
+
+        Terminal-guarded and all-or-nothing:
+        - If the run is already terminal (e.g. cancelled mid-stream), the
+          guarded UPDATE changes 0 rows; the whole transaction is rolled back
+          and None is returned — no assistant message is written.
+        - If any insert raises, the transaction is rolled back (re-raising) so
+          a failed run never leaves an orphan completed assistant message.
+
+        On success returns the persisted assistant_msg (with seq assigned).
+        """
+        artifacts = artifacts or []
+        terminal_ph = ",".join("?" for _ in TERMINAL_STATUSES)
+        now = "strftime('%Y-%m-%dT%H:%M:%SZ','now')"
+        conn = self._get_conn()
+        try:
+            assistant_msg.seq = self.next_seq(assistant_msg.conversation_id, conn=conn)
+            self.add_message(assistant_msg, conn=conn)
+            for art in artifacts:
+                self.save_artifact(art, conn=conn)
+            cur = conn.execute(
+                f"""UPDATE chat_runs SET status = ?, completed_at = {now}
+                    WHERE id = ? AND status NOT IN ({terminal_ph})""",
+                (ChatRunStatus.COMPLETED, run_id, *sorted(TERMINAL_STATUSES)),
+            )
+            if cur.rowcount == 0:
+                # Run went terminal (cancelled) before we could complete it —
+                # discard the assistant message and artifacts entirely.
+                conn.rollback()
+                return None
+            conn.execute(
+                f"UPDATE conversations SET updated_at = {now} WHERE id = ?",
+                (assistant_msg.conversation_id,),
+            )
+            conn.commit()
+            return assistant_msg
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             self._close_conn(conn)
 

--- a/dashboard/chat/event_bus.py
+++ b/dashboard/chat/event_bus.py
@@ -1,0 +1,54 @@
+"""In-memory pub/sub for live run observers (Phase 3 of #58).
+
+This is NOT a source of truth — it only fans out live runtime events from a
+background run to whoever is currently watching (an SSE response, a reattached
+stream). Completed data always comes from SQLite; if the process restarts, the
+bus is empty and that's fine.
+
+One bus instance is shared per dashboard process. Observers subscribe by
+run_id and get a Queue they drain; publishers push events to every current
+subscriber of that run. Thread-safe: the background runner publishes from a
+worker thread while SSE generators drain from request threads.
+"""
+import queue
+import threading
+
+
+class EventBus:
+    def __init__(self):
+        self._subscribers = {}  # run_id -> list[queue.Queue]
+        self._lock = threading.Lock()
+
+    def subscribe(self, run_id: str) -> "queue.Queue":
+        """Register an observer for a run and return its event queue."""
+        q = queue.Queue()
+        with self._lock:
+            self._subscribers.setdefault(run_id, []).append(q)
+        return q
+
+    def unsubscribe(self, run_id: str, q: "queue.Queue") -> None:
+        with self._lock:
+            subs = self._subscribers.get(run_id)
+            if not subs:
+                return
+            try:
+                subs.remove(q)
+            except ValueError:
+                pass
+            if not subs:
+                del self._subscribers[run_id]
+
+    def publish(self, run_id: str, event) -> None:
+        """Fan an event out to every current subscriber of run_id.
+
+        No-op when nobody is listening — the run keeps going regardless; the
+        event is simply not replayed (the DB holds the durable result).
+        """
+        with self._lock:
+            subs = list(self._subscribers.get(run_id, ()))
+        for q in subs:
+            q.put(event)
+
+    def subscriber_count(self, run_id: str) -> int:
+        with self._lock:
+            return len(self._subscribers.get(run_id, ()))

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -1,0 +1,181 @@
+"""Chat turn runtime (Phase 3 of #58).
+
+ChatRunner is the background job-runner core: it executes one model/tool turn
+and persists the result, decoupled from any Flask SSE response. It can be
+called directly (a unit test, a background thread in Phase 4) — it never reads
+Flask globals and never depends on a live SSE client.
+
+Responsibilities (mirrors the persistence the old routes._stream_response did
+inline, minus the SSE framing and the partial-save-on-disconnect logic, which
+is obsolete once a run completes in the background):
+
+  - mark the run running
+  - build the prompt from persisted conversation state
+  - drive the plain model stream or the MCP tool loop
+  - accumulate content / reasoning / tool calls / artifacts / parse warning
+  - on completion: persist the assistant message + artifacts, mark run completed
+  - on model/tool error: mark run failed with useful error text, persist no
+    completed assistant message
+  - publish runtime events to the in-memory event bus for any live observer
+
+The user message is assumed to be already persisted (the caller creates it and
+the run before invoking the runner); the runner builds messages from
+db.get_messages().
+"""
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .models import Message, Artifact, Conversation
+from .runs import ChatRunStatus
+from .llm_proxy import stream_chat_completion
+from .tool_loop import stream_with_tools
+from .prompt_builder import build_chat_messages
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatRuntimeEvent:
+    """A normalized event published to the bus during a run.
+
+    `type` is one of the runtime event types (#58): run_started, delta,
+    tool_call_pending, tool_call, tool_result, artifact, parse_warning,
+    run_completed, run_failed. SSE encoding of these lives in event_codec.
+    """
+    type: str
+    data: dict = field(default_factory=dict)
+
+
+@dataclass
+class ChatTurnRequest:
+    """Everything the runner needs to execute a turn, passed explicitly rather
+    than read from Flask globals."""
+    conversation: Conversation
+    mcp_manager: object = None
+
+
+class ChatRunner:
+    def __init__(self, db, event_bus=None):
+        self.db = db
+        self.event_bus = event_bus
+
+    def _emit(self, run_id: str, type: str, data: dict = None):
+        if self.event_bus is not None:
+            self.event_bus.publish(run_id, ChatRuntimeEvent(type, data or {}))
+
+    def _build_stream(self, conv: Conversation, mcp_manager):
+        messages = self.db.get_messages(conv.id)
+        enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
+        messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
+        tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None
+        if tools:
+            return stream_with_tools(conv.main_service, messages_array, tools, mcp_manager)
+        return stream_chat_completion(conv.main_service, messages_array)
+
+    def run(self, run, request: ChatTurnRequest) -> Optional[Message]:
+        """Execute the turn for an existing (queued) run.
+
+        Returns the persisted assistant Message on success, or None on failure
+        (the run is marked failed). Never raises for model/tool errors — they
+        are recorded on the run.
+        """
+        db = self.db
+        conv = request.conversation
+        mcp_manager = request.mcp_manager
+        run_id = run.id
+
+        db.update_chat_run_status(run_id, ChatRunStatus.RUNNING, active_step="generating")
+        self._emit(run_id, "run_started", {"run_id": run_id, "conversation_id": conv.id})
+
+        assistant_msg_id = str(uuid.uuid4())
+        accumulated_content = ""
+        accumulated_reasoning = ""
+        collected_tool_calls = []
+        collected_artifacts = []
+        last_parse_warning = None
+
+        try:
+            stream = self._build_stream(conv, mcp_manager)
+            for event_type, data in stream:
+                if event_type == "delta":
+                    accumulated_content += data.get("content", "") or ""
+                    accumulated_reasoning += data.get("reasoning_content", "") or ""
+                    self._emit(run_id, "delta", data)
+                elif event_type == "tool_call_pending":
+                    self._emit(run_id, "tool_call_pending", {"index": data["index"], "name": data["name"]})
+                elif event_type == "parse_warning":
+                    last_parse_warning = data
+                    self._emit(run_id, "parse_warning", data)
+                elif event_type == "tool_call":
+                    collected_tool_calls.append({
+                        "name": data["name"],
+                        "arguments": data["arguments"],
+                        "server_id": data["server_id"],
+                    })
+                    self._emit(run_id, "tool_call", {"name": data["name"], "arguments": data["arguments"], "server_id": data["server_id"]})
+                elif event_type == "tool_result":
+                    for tc in reversed(collected_tool_calls):
+                        if tc["name"] == data["name"] and "result" not in tc:
+                            tc["result"] = data["result"]
+                            break
+                    self._emit(run_id, "tool_result", {"name": data["name"], "result": data["result"], "server_id": data["server_id"]})
+                elif event_type == "artifact":
+                    collected_artifacts.append(data)
+                    self._emit(run_id, "artifact", {"artifact_type": data["type"], "title": data.get("title"), "content": data["content"]})
+                elif event_type == "done":
+                    msg = self._persist_completion(
+                        conv, assistant_msg_id, data,
+                        accumulated_reasoning, collected_tool_calls,
+                        collected_artifacts, last_parse_warning,
+                    )
+                    db.complete_chat_run(run_id)
+                    self._emit(run_id, "run_completed", {"message_id": msg.id, "seq": msg.seq})
+                    return msg
+                elif event_type == "error":
+                    return self._fail(run_id, data["message"])
+
+            # Stream exhausted without a `done` event.
+            return self._fail(run_id, "Stream ended unexpectedly")
+        except Exception as exc:
+            logger.exception("Chat run %s crashed", run_id)
+            return self._fail(run_id, str(exc) or "internal error")
+
+    def _persist_completion(self, conv, assistant_msg_id, done_data,
+                            accumulated_reasoning, collected_tool_calls,
+                            collected_artifacts, last_parse_warning) -> Message:
+        db = self.db
+        next_seq = db.next_seq(conv.id)
+        assistant_msg = Message(
+            id=assistant_msg_id,
+            conversation_id=conv.id,
+            role="assistant",
+            content=done_data["content"],
+            # Full cross-round reasoning the user saw wins over the final
+            # round's reasoning (matches _stream_response); falls back to the
+            # done payload for the single-round case.
+            reasoning_content=(accumulated_reasoning or done_data["reasoning_content"]) or None,
+            model_service=conv.main_service,
+            tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
+            parse_warning_json=json.dumps(last_parse_warning) if last_parse_warning else None,
+            seq=next_seq,
+        )
+        db.add_message(assistant_msg)
+        for art_data in collected_artifacts:
+            db.save_artifact(Artifact(
+                id=str(uuid.uuid4()),
+                message_id=assistant_msg_id,
+                artifact_type=art_data["type"],
+                content=art_data["content"],
+                title=art_data.get("title"),
+                language=art_data.get("language"),
+            ))
+        db.touch_conversation(conv.id)
+        return assistant_msg
+
+    def _fail(self, run_id: str, error: str) -> None:
+        self.db.fail_chat_run(run_id, error)
+        self._emit(run_id, "run_failed", {"error": error})
+        return None

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -87,7 +87,14 @@ class ChatRunner:
         mcp_manager = request.mcp_manager
         run_id = run.id
 
-        db.update_chat_run_status(run_id, ChatRunStatus.RUNNING, active_step="generating")
+        # Claim the run. update_chat_run_status no-ops on a terminal row, so if
+        # the run was cancelled before the worker picked it up, the transition
+        # doesn't win — do no work and surface the terminal state.
+        started = db.update_chat_run_status(run_id, ChatRunStatus.RUNNING, active_step="generating")
+        if started is None or started.status != ChatRunStatus.RUNNING:
+            status = started.status if started else "cancelled"
+            self._emit(run_id, f"run_{status}", {"run_id": run_id})
+            return None
         self._emit(run_id, "run_started", {"run_id": run_id, "conversation_id": conv.id})
 
         assistant_msg_id = str(uuid.uuid4())
@@ -126,14 +133,40 @@ class ChatRunner:
                     collected_artifacts.append(data)
                     self._emit(run_id, "artifact", {"artifact_type": data["type"], "title": data.get("title"), "content": data["content"]})
                 elif event_type == "done":
-                    msg = self._persist_completion(
-                        conv, assistant_msg_id, data,
-                        accumulated_reasoning, collected_tool_calls,
-                        collected_artifacts, last_parse_warning,
+                    assistant_msg = Message(
+                        id=assistant_msg_id,
+                        conversation_id=conv.id,
+                        role="assistant",
+                        content=data["content"],
+                        # Full cross-round reasoning the user saw wins over the
+                        # final round's reasoning (matches _stream_response);
+                        # falls back to the done payload for the single round.
+                        reasoning_content=(accumulated_reasoning or data["reasoning_content"]) or None,
+                        model_service=conv.main_service,
+                        tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
+                        parse_warning_json=json.dumps(last_parse_warning) if last_parse_warning else None,
+                        seq=0,  # assigned inside the atomic completion
                     )
-                    db.complete_chat_run(run_id)
-                    self._emit(run_id, "run_completed", {"message_id": msg.id, "seq": msg.seq})
-                    return msg
+                    artifacts = [
+                        Artifact(
+                            id=str(uuid.uuid4()),
+                            message_id=assistant_msg_id,
+                            artifact_type=art["type"],
+                            content=art["content"],
+                            title=art.get("title"),
+                            language=art.get("language"),
+                        )
+                        for art in collected_artifacts
+                    ]
+                    # Atomic + terminal-guarded: writes the message, artifacts,
+                    # and the completed status together, or nothing if the run
+                    # was cancelled mid-stream.
+                    saved = db.complete_run_with_message(run_id, assistant_msg, artifacts)
+                    if saved is None:
+                        self._emit(run_id, "run_cancelled", {"run_id": run_id})
+                        return None
+                    self._emit(run_id, "run_completed", {"message_id": saved.id, "seq": saved.seq})
+                    return saved
                 elif event_type == "error":
                     return self._fail(run_id, data["message"])
 
@@ -142,38 +175,6 @@ class ChatRunner:
         except Exception as exc:
             logger.exception("Chat run %s crashed", run_id)
             return self._fail(run_id, str(exc) or "internal error")
-
-    def _persist_completion(self, conv, assistant_msg_id, done_data,
-                            accumulated_reasoning, collected_tool_calls,
-                            collected_artifacts, last_parse_warning) -> Message:
-        db = self.db
-        next_seq = db.next_seq(conv.id)
-        assistant_msg = Message(
-            id=assistant_msg_id,
-            conversation_id=conv.id,
-            role="assistant",
-            content=done_data["content"],
-            # Full cross-round reasoning the user saw wins over the final
-            # round's reasoning (matches _stream_response); falls back to the
-            # done payload for the single-round case.
-            reasoning_content=(accumulated_reasoning or done_data["reasoning_content"]) or None,
-            model_service=conv.main_service,
-            tool_calls_json=json.dumps(collected_tool_calls) if collected_tool_calls else None,
-            parse_warning_json=json.dumps(last_parse_warning) if last_parse_warning else None,
-            seq=next_seq,
-        )
-        db.add_message(assistant_msg)
-        for art_data in collected_artifacts:
-            db.save_artifact(Artifact(
-                id=str(uuid.uuid4()),
-                message_id=assistant_msg_id,
-                artifact_type=art_data["type"],
-                content=art_data["content"],
-                title=art_data.get("title"),
-                language=art_data.get("language"),
-            ))
-        db.touch_conversation(conv.id)
-        return assistant_msg
 
     def _fail(self, run_id: str, error: str) -> None:
         self.db.fail_chat_run(run_id, error)

--- a/dashboard/tests/test_chat_job_runner.py
+++ b/dashboard/tests/test_chat_job_runner.py
@@ -224,6 +224,79 @@ def test_exception_in_stream_marks_failed(db, monkeypatch):
     assert "kaboom" in failed.error
 
 
+def test_persistence_exception_rolls_back_no_assistant(db, monkeypatch):
+    """If artifact persistence throws after the message insert, the whole
+    completion rolls back: no orphan assistant message on the failed run."""
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield ("artifact", {"type": "code", "title": "t", "content": "x", "language": "py"})
+        yield _delta("answer")
+        yield ("done", {"content": "answer", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+
+    real_save = db.save_artifact
+
+    def boom(artifact, conn=None):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(db, "save_artifact", boom)
+
+    result = ChatRunner(db).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    # The assistant insert was rolled back with the failed artifact.
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+    failed = db.get_chat_run(run.id)
+    assert failed.status == "failed"
+    assert "disk full" in failed.error
+
+
+def test_cancelled_before_start_does_no_work(db, monkeypatch):
+    """A run cancelled before the worker picks it up must not run the model
+    or write an assistant message."""
+    conv, user_msg, run = _seed(db)
+    db.cancel_chat_run(run.id)
+
+    started = {"n": 0}
+
+    def stub():
+        started["n"] += 1
+        yield ("done", {"content": "should not run", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+    result = ChatRunner(db).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    assert started["n"] == 0  # the stream was never built/consumed
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+    assert db.get_chat_run(run.id).status == "cancelled"
+
+
+def test_cancelled_mid_stream_writes_no_completed_message(db, monkeypatch):
+    """If the run is cancelled while streaming, the done handler's atomic
+    completion loses the terminal guard and writes nothing."""
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("partial ")
+        # Simulate another thread cancelling the run mid-stream.
+        db.cancel_chat_run(run.id)
+        yield _delta("more")
+        yield ("done", {"content": "partial more", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+    bus = EventBus()
+    read_events = _drain(bus, run.id)
+    result = ChatRunner(db, event_bus=bus).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+    assert db.get_chat_run(run.id).status == "cancelled"
+    assert [e.type for e in read_events()][-1] == "run_cancelled"
+
+
 def test_runner_works_without_event_bus(db, monkeypatch):
     """The bus is optional; a None bus must not break persistence."""
     conv, user_msg, run = _seed(db)

--- a/dashboard/tests/test_chat_job_runner.py
+++ b/dashboard/tests/test_chat_job_runner.py
@@ -1,0 +1,238 @@
+"""Tests for the background ChatRunner (Phase 3 of #58).
+
+The runner executes a turn and persists the result without any Flask SSE
+response. Model/tool streams are monkeypatched — no Docker, GPU, or model.
+
+These use a temp FILE-backed ChatDB (not :memory:) so the persistence path
+matches Phase 4, where the runner executes on a background thread and the
+shared :memory: connection (check_same_thread=True) would break.
+"""
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import runtime
+from chat.db import ChatDB
+from chat.event_bus import EventBus
+from chat.models import Conversation, Message, ChatRun
+from chat.runs import ChatRunStatus
+from chat.runtime import ChatRunner, ChatTurnRequest
+
+
+@pytest.fixture
+def db(tmp_path):
+    return ChatDB(str(tmp_path / "chat.db"))
+
+
+def _seed(db, mcp_servers_json=None):
+    """Create a conversation + a persisted user message + a queued run."""
+    conv = Conversation(id=str(uuid.uuid4()), title="t", main_service="svc",
+                        mcp_servers_json=mcp_servers_json)
+    db.create_conversation(conv)
+    user_msg = Message(id=str(uuid.uuid4()), conversation_id=conv.id, role="user",
+                       content="hi", seq=db.next_seq(conv.id))
+    db.add_message(user_msg)
+    run = db.create_chat_run(ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                                     status=ChatRunStatus.QUEUED, user_message_id=user_msg.id))
+    return conv, user_msg, run
+
+
+def _delta(content, reasoning=""):
+    return ("delta", {"content": content, "reasoning_content": reasoning,
+                      "raw": json.dumps({"choices": [{"delta": {"content": content}}]})})
+
+
+def _patch_stream(monkeypatch, factory):
+    """Patch both stream functions in the runtime module namespace."""
+    def _wrap(*a, **k):
+        return factory()
+    monkeypatch.setattr(runtime, "stream_chat_completion", _wrap)
+    monkeypatch.setattr(runtime, "stream_with_tools", _wrap)
+
+
+class _FakeMCPManager:
+    def __init__(self):
+        self.tools_requested = None
+
+    def get_all_tools(self, servers):
+        self.tools_requested = list(servers)
+        return [{"type": "function", "function": {"name": "solve"}}]
+
+
+def _drain(bus, run_id):
+    """Subscribe and return a function that reads everything published so far."""
+    q = bus.subscribe(run_id)
+
+    def read():
+        out = []
+        while not q.empty():
+            out.append(q.get_nowait())
+        return out
+
+    return read
+
+
+# -- Successful plain run -----------------------------------------------
+
+
+def test_plain_run_persists_reply_and_completes(db, monkeypatch):
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("Hello ", reasoning="thinking ")
+        yield _delta("world")
+        yield ("done", {"content": "Hello world", "reasoning_content": "ignored final"})
+
+    _patch_stream(monkeypatch, stub)
+    bus = EventBus()
+    read_events = _drain(bus, run.id)
+
+    result = ChatRunner(db, event_bus=bus).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is not None
+    msgs = db.get_messages(conv.id)
+    assert [m.role for m in msgs] == ["user", "assistant"]
+    assistant = msgs[1]
+    assert assistant.content == "Hello world"
+    # Accumulated reasoning wins over the final round's reasoning.
+    assert assistant.reasoning_content == "thinking "
+    assert assistant.model_service == "svc"
+
+    finished = db.get_chat_run(run.id)
+    assert finished.status == "completed"
+    assert finished.started_at is not None and finished.completed_at is not None
+
+    types = [e.type for e in read_events()]
+    assert types[0] == "run_started"
+    assert "delta" in types
+    assert types[-1] == "run_completed"
+
+
+# -- Tool run -----------------------------------------------------------
+
+
+def test_tool_run_persists_calls_results_artifacts_and_reply(db, monkeypatch):
+    conv, user_msg, run = _seed(db, mcp_servers_json=json.dumps(["sympy-math"]))
+
+    def stub():
+        yield ("tool_call_pending", {"index": 0, "name": "solve"})
+        yield ("tool_call", {"name": "solve", "arguments": {"x": 1}, "server_id": "sympy-math"})
+        yield ("tool_result", {"name": "solve", "result": "x = 1", "server_id": "sympy-math"})
+        yield ("artifact", {"type": "code", "title": "snip", "content": "print(1)", "language": "python"})
+        yield _delta("The answer is 1.")
+        yield ("done", {"content": "The answer is 1.", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+    mgr = _FakeMCPManager()
+    result = ChatRunner(db).run(run, ChatTurnRequest(conversation=conv, mcp_manager=mgr))
+
+    assert mgr.tools_requested == ["sympy-math"]  # routed through the tool loop
+    assert result.content == "The answer is 1."
+
+    assistant = db.get_messages(conv.id)[1]
+    calls = json.loads(assistant.tool_calls_json)
+    assert calls[0]["name"] == "solve"
+    assert calls[0]["result"] == "x = 1"  # matched-back result
+
+    arts = db.get_artifacts_for_conversation(conv.id)
+    assert arts[assistant.id][0].content == "print(1)"
+    assert db.get_chat_run(run.id).status == "completed"
+
+
+# -- Parse warning ------------------------------------------------------
+
+
+def test_parse_warning_persisted_on_assistant_message(db, monkeypatch):
+    conv, user_msg, run = _seed(db)
+    warning = {"kind": "json_codeblock_call", "snippet": "```json", "description": "drift"}
+
+    def stub():
+        yield _delta("partial ")
+        yield ("parse_warning", dict(warning))
+        yield _delta("answer")
+        yield ("done", {"content": "partial answer", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+    ChatRunner(db).run(run, ChatTurnRequest(conversation=conv))
+
+    assistant = db.get_messages(conv.id)[1]
+    assert json.loads(assistant.parse_warning_json) == warning
+
+
+# -- Model error --------------------------------------------------------
+
+
+def test_model_error_marks_run_failed_and_persists_no_assistant(db, monkeypatch):
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("partial answer")
+        yield ("error", {"message": "model exploded"})
+
+    _patch_stream(monkeypatch, stub)
+    bus = EventBus()
+    read_events = _drain(bus, run.id)
+    result = ChatRunner(db, event_bus=bus).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    # No completed assistant message was written.
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+
+    failed = db.get_chat_run(run.id)
+    assert failed.status == "failed"
+    assert failed.error == "model exploded"
+
+    types = [e.type for e in read_events()]
+    assert types[-1] == "run_failed"
+
+
+def test_stream_without_done_marks_failed(db, monkeypatch):
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("incomplete")
+        # generator ends with no done/error
+
+    _patch_stream(monkeypatch, stub)
+    result = ChatRunner(db).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+    failed = db.get_chat_run(run.id)
+    assert failed.status == "failed"
+    assert "unexpectedly" in failed.error.lower()
+
+
+def test_exception_in_stream_marks_failed(db, monkeypatch):
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("boom incoming")
+        raise RuntimeError("kaboom")
+
+    _patch_stream(monkeypatch, stub)
+    result = ChatRunner(db).run(run, ChatTurnRequest(conversation=conv))
+
+    assert result is None
+    failed = db.get_chat_run(run.id)
+    assert failed.status == "failed"
+    assert "kaboom" in failed.error
+
+
+def test_runner_works_without_event_bus(db, monkeypatch):
+    """The bus is optional; a None bus must not break persistence."""
+    conv, user_msg, run = _seed(db)
+
+    def stub():
+        yield _delta("ok")
+        yield ("done", {"content": "ok", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, stub)
+    result = ChatRunner(db, event_bus=None).run(run, ChatTurnRequest(conversation=conv))
+    assert result.content == "ok"
+    assert db.get_chat_run(run.id).status == "completed"


### PR DESCRIPTION
## Phase 3 of #58 — Background `ChatRunner` callable without Flask

Adds the job-runner core that executes one model/tool turn and persists the result, fully decoupled from any SSE response. **Additive** — `routes._stream_response` is untouched; Phase 4 wires the runner into the send route.

### New modules

- **`chat/event_bus.py`** — `EventBus`, an in-memory per-run pub/sub for live observers. Thread-safe (worker publishes, request threads drain). **NOT a source of truth** — the DB is. `publish()` is a no-op when nobody is subscribed, so a disconnected observer never affects the run.
- **`chat/runtime.py`** — `ChatRuntimeEvent`, `ChatTurnRequest`, and `ChatRunner`:
  - `run()` marks the run `running` (`active_step="generating"`), builds the prompt from persisted state via `prompt_builder`, drives the plain stream or the MCP tool loop, accumulates content/reasoning/tool-calls/artifacts/parse-warning, and on `done` persists the assistant message + artifacts and marks the run `completed`.
  - Produces the **same final assistant message shape** as `_stream_response` (including the `accumulated_reasoning or done.reasoning_content` rule and the matched-back tool-call results), minus SSE framing and the now-obsolete partial-save-on-disconnect.
  - Model/tool `error`, a stream that ends without `done`, or any exception → run marked `failed` with useful error text, **no completed assistant message** persisted.
  - Runtime events published to the optional event bus.

The user message is assumed already persisted (the caller creates it + the run before invoking the runner); the runner builds messages from `db.get_messages()`.

### Acceptance

- Runner invocable directly from a unit test, no live SSE client. ✅
- Same final assistant message shape; artifacts + parse warnings persisted. ✅
- Failed runs recorded with useful error text; no completed assistant on failure. ✅

### Tests

`tests/test_chat_job_runner.py` uses a **temp file-backed `ChatDB`** (not `:memory:`) per the Phase-3/4 decision — the runner runs on a background thread in Phase 4 and the shared `:memory:` connection (`check_same_thread=True`) would break. Covers: plain success (+ reasoning rule + event order), tool run (calls/results/artifacts/routing), parse-warning persistence, model error → failed, no-`done` → failed, exception → failed, and the optional-bus path.

```
cd dashboard
pytest tests/test_chat_job_runner.py tests/test_partial_save.py   # 12 passed
pytest tests/   # full suite: 266 passed
```

Refs #58 (Phase 3).
