### PR TITLE
Phase 5 (#58): run observation + cancellation APIs

### DIFF
--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -134,6 +134,7 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
     pending_emitted = set()    # tool-call indices we've already announced via tool_call_pending
     finish_reason = None
 
+    resp = None
     try:
         resp = requests.post(url, json=payload, headers=headers, stream=True, timeout=300)
         resp.encoding = "utf-8"
@@ -228,3 +229,10 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
     except Exception as e:
         logger.exception("Unexpected error during streaming")
         yield ("error", {"message": f"Unexpected error: {str(e)}"})
+    finally:
+        # Always release the upstream socket — including when the generator is
+        # closed early (cooperative cancellation calls stream.close(), which
+        # raises GeneratorExit here). Without this, a cancelled run leaves the
+        # model-server connection alive until garbage collection.
+        if resp is not None:
+            resp.close()

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -12,10 +12,10 @@ from .constants import DEFAULT_MAIN_SYSTEM_PROMPT, DEFAULT_SIDEKICK_SYSTEM_PROMP
 from .llm_proxy import stream_chat_completion
 from .critique import build_critique_context, request_critique, validate_annotations
 from .mcp_registry import list_available_servers
-from .event_codec import DONE, encode_sse, encode_sse_delta
+from .event_codec import DONE, encode_sse, encode_sse_event, encode_sse_delta
 from .event_bus import EventBus
 from .run_manager import ChatRunManager
-from .runs import ChatRunStatus
+from .runs import ChatRunStatus, TERMINAL_STATUSES
 from . import settings_store
 
 logger = logging.getLogger(__name__)
@@ -324,6 +324,61 @@ def edit_message(conv_id, msg_id):
     # replaces an existing turn, so it never triggers auto-title.
     return _start_run_response(db, conv, new_msg, mcp_mgr, is_first=False,
                                first_user_content=content, delete_from_seq=msg.seq)
+
+
+# -- Runs (observation + cancellation, issue #58) --
+
+
+@chat_bp.route("/api/chat/runs/<run_id>", methods=["GET"])
+@require_auth
+def get_run(run_id):
+    run = _get_db().get_chat_run(run_id)
+    if run is None:
+        return jsonify({"error": "Run not found"}), 404
+    return jsonify(run.to_dict())
+
+
+@chat_bp.route("/api/chat/runs/<run_id>/stream", methods=["GET"])
+@require_auth
+def stream_run(run_id):
+    """Reattach to a run's live event stream.
+
+    If the run is already terminal, emit a single run_status frame and close
+    (there is nothing live to replay — the conversation refetch carries the
+    saved content). Otherwise subscribe to the bus and observe like the send
+    path; the observer's DB backstop closes the stream even if the run finishes
+    between this check and the subscribe.
+    """
+    db = _get_db()
+    manager = _get_run_manager()
+    run = db.get_chat_run(run_id)
+    if run is None:
+        return jsonify({"error": "Run not found"}), 404
+
+    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+
+    if run.status in TERMINAL_STATUSES:
+        def terminal():
+            yield encode_sse_event("run_status", {"status": run.status, "error": run.error})
+        return Response(terminal(), mimetype="text/event-stream", headers=headers)
+
+    q = manager.subscribe(run_id)
+    return Response(stream_with_context(manager.observe(run_id, q)),
+                    mimetype="text/event-stream", headers=headers)
+
+
+@chat_bp.route("/api/chat/runs/<run_id>/cancel", methods=["POST"])
+@require_auth
+def cancel_run(run_id):
+    """Cancel a run's server-side work, independent of any SSE observer.
+
+    Cancelling an already-terminal run is a harmless no-op that returns 200
+    with the run's existing status (terminal-guarded in the DB).
+    """
+    run = _get_run_manager().request_cancel(run_id)
+    if run is None:
+        return jsonify({"error": "Run not found"}), 404
+    return jsonify(run.to_dict())
 
 
 # -- Critique --

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -37,6 +37,10 @@ def _sse_frames_for(event: ChatRuntimeEvent):
     legacy wire format. Internal events (run_started, run_cancelled,
     stream_end) produce no frame."""
     t, d = event.type, event.data
+    if t == "run_started":
+        # Expose the run id to the client so it can POST /runs/<id>/cancel.
+        # (Current frontend ignores unknown SSE types; wired up in Phase 6.)
+        return [encode_sse_event("run_started", {"run_id": d["run_id"]})]
     if t == "delta":
         return [encode_sse_delta(d["raw"])]
     if t == "tool_call_pending":

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -15,10 +15,12 @@ The observer translates runtime events back into the existing SSE wire format
 """
 import logging
 import queue
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
 from .event_codec import DONE, encode_sse, encode_sse_event, encode_sse_delta
+from .runs import TERMINAL_STATUSES
 from .runtime import ChatRunner, ChatRuntimeEvent, ChatTurnRequest, auto_generate_title
 
 logger = logging.getLogger(__name__)
@@ -62,6 +64,10 @@ class ChatRunManager:
         self.event_bus = event_bus
         self.runner = ChatRunner(db, event_bus=event_bus)
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="chat-run")
+        # run_id -> threading.Event, present only while a worker is executing
+        # that run. Set to request cooperative mid-stream cancellation.
+        self._cancel_flags = {}
+        self._flags_lock = threading.Lock()
 
     # -- lifecycle --------------------------------------------------------
 
@@ -93,9 +99,30 @@ class ChatRunManager:
             self._execute, conv, run, mcp_manager, is_first, first_user_content,
         )
 
+    def request_cancel(self, run_id):
+        """Cancel a run independently of any observer (the Stop button path).
+
+        Sets the cooperative cancel flag (so an executing worker stops at its
+        next stream event) AND marks the run cancelled in the DB. The DB update
+        is terminal-guarded, so cancelling an already-finished run is a harmless
+        no-op that returns the run with its existing status. Returns the run, or
+        None if it does not exist.
+        """
+        with self._flags_lock:
+            ev = self._cancel_flags.get(run_id)
+        if ev is not None:
+            ev.set()
+        return self.db.cancel_chat_run(run_id)
+
     def _execute(self, conv, run, mcp_manager, is_first, first_user_content):
+        cancel_event = threading.Event()
+        with self._flags_lock:
+            self._cancel_flags[run.id] = cancel_event
         try:
-            msg = self.runner.run(run, ChatTurnRequest(conversation=conv, mcp_manager=mcp_manager))
+            msg = self.runner.run(
+                run, ChatTurnRequest(conversation=conv, mcp_manager=mcp_manager),
+                cancel_check=cancel_event.is_set,
+            )
             # Auto-title runs here (not in the SSE response) so a first-message
             # title is generated and persisted even if the client disconnected.
             if msg is not None and is_first:
@@ -110,6 +137,8 @@ class ChatRunManager:
             # against anything unexpected so the observer is always released.
             logger.exception("chat run %s crashed in executor", run.id)
         finally:
+            with self._flags_lock:
+                self._cancel_flags.pop(run.id, None)
             self.event_bus.publish(run.id, ChatRuntimeEvent(STREAM_END, {}))
 
     # -- observing a run --------------------------------------------------
@@ -131,6 +160,13 @@ class ChatRunManager:
                 try:
                     event = q.get(timeout=HEARTBEAT_INTERVAL_S)
                 except queue.Empty:
+                    # Backstop for a reattaching observer that subscribed after
+                    # the run already published STREAM_END: close on the durable
+                    # DB state instead of heartbeating forever.
+                    run = self.db.get_chat_run(run_id)
+                    if run is None or run.status in TERMINAL_STATUSES:
+                        yield encode_sse_event("run_status", {"status": run.status if run else "unknown"})
+                        return
                     yield encode_sse_event("heartbeat", {"elapsed_s": round(time.monotonic() - start, 1)})
                     continue
                 for frame in _sse_frames_for(event):

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -38,9 +38,10 @@ def _sse_frames_for(event: ChatRuntimeEvent):
     stream_end) produce no frame."""
     t, d = event.type, event.data
     if t == "run_started":
-        # Expose the run id to the client so it can POST /runs/<id>/cancel.
-        # (Current frontend ignores unknown SSE types; wired up in Phase 6.)
-        return [encode_sse_event("run_started", {"run_id": d["run_id"]})]
+        # Suppressed here: observe() synthesizes run_started up front from the
+        # run id it already has, so the client gets the id as the first frame
+        # even when a saturated worker pool delays the worker's own publish.
+        return []
     if t == "delta":
         return [encode_sse_delta(d["raw"])]
     if t == "tool_call_pending":
@@ -160,6 +161,12 @@ class ChatRunManager:
         """
         start = time.monotonic()
         try:
+            # Expose the run id to the client as the very first frame, before
+            # any heartbeat — independent of when the (possibly queued) worker
+            # actually starts and publishes its own run_started (suppressed in
+            # _sse_frames_for to avoid a duplicate). Lets the client POST
+            # /runs/<id>/cancel even for a still-queued run.
+            yield encode_sse_event("run_started", {"run_id": run_id})
             while True:
                 try:
                     event = q.get(timeout=HEARTBEAT_INTERVAL_S)

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -124,12 +124,19 @@ class ChatRunner:
             return stream_with_tools(conv.main_service, messages_array, tools, mcp_manager)
         return stream_chat_completion(conv.main_service, messages_array)
 
-    def run(self, run, request: ChatTurnRequest) -> Optional[Message]:
+    def run(self, run, request: ChatTurnRequest, cancel_check=None) -> Optional[Message]:
         """Execute the turn for an existing (queued) run.
 
         Returns the persisted assistant Message on success, or None on failure
-        (the run is marked failed). Never raises for model/tool errors — they
-        are recorded on the run.
+        / cancellation (the run is marked failed or cancelled). Never raises for
+        model/tool errors — they are recorded on the run.
+
+        cancel_check, if given, is a zero-arg callable polled between stream
+        events; when it returns True the runner closes the upstream stream
+        (stopping the model / tool loop at its next yield) and cancels the run
+        without persisting an assistant message. Cancellation is cooperative:
+        a fully-silent generation is only interrupted once the next event or
+        chunk arrives.
         """
         db = self.db
         conv = request.conversation
@@ -156,6 +163,17 @@ class ChatRunner:
         try:
             stream = self._build_stream(conv, mcp_manager)
             for event_type, data in stream:
+                if cancel_check is not None and cancel_check():
+                    # Stop the model/tool loop promptly: closing the generator
+                    # raises GeneratorExit into stream_chat_completion /
+                    # stream_with_tools at their next yield.
+                    try:
+                        stream.close()
+                    except Exception:
+                        logger.exception("error closing stream on cancel for run %s", run_id)
+                    db.cancel_chat_run(run_id)  # idempotent if already cancelled
+                    self._emit(run_id, "run_cancelled", {"run_id": run_id})
+                    return None
                 if event_type == "delta":
                     accumulated_content += data.get("content", "") or ""
                     accumulated_reasoning += data.get("reasoning_content", "") or ""

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -212,6 +212,8 @@ def test_observe_backstop_closes_when_run_goes_terminal(ctx, monkeypatch):
     q = manager.subscribe(run.id)
     gen = manager.observe(run.id, q)
 
+    started = next(gen)  # synthetic run_started always comes first
+    assert "run_started" in started and run.id in started
     first = next(gen)  # active, no events -> heartbeat
     assert "heartbeat" in first
 
@@ -220,3 +222,37 @@ def test_observe_backstop_closes_when_run_goes_terminal(ctx, monkeypatch):
     assert "run_status" in nxt and "completed" in nxt
     with pytest.raises(StopIteration):
         next(gen)
+
+
+def test_run_started_emitted_first_even_when_workers_saturated(tmp_path, monkeypatch):
+    """run_started reaches the client immediately even if the run's worker is
+    still queued behind a saturated pool (the observer synthesizes it)."""
+    db = ChatDB(str(tmp_path / "chat.db"))
+    manager = ChatRunManager(db, EventBus(), max_workers=1)
+    try:
+        block = threading.Event()
+
+        def stub():
+            block.wait(2)
+            yield ("done", {"content": "x", "reasoning_content": None})
+
+        monkeypatch.setattr(runtime, "stream_chat_completion", lambda *a, **k: stub())
+        monkeypatch.setattr(runtime, "stream_with_tools", lambda *a, **k: stub())
+
+        # Occupy the single worker with run A (different conversation).
+        conv_a = _conv(db, "a")
+        run_a = _seed_queued(db, conv_a)
+        manager.start(conv_a, run_a, is_first=False, first_user_content="a")
+
+        # Run B is queued behind A; its worker hasn't started.
+        conv_b = _conv(db, "b")
+        run_b = _seed_queued(db, conv_b)
+        q = manager.subscribe(run_b.id)
+        manager.start(conv_b, run_b, is_first=False, first_user_content="b")
+
+        gen = manager.observe(run_b.id, q)
+        first = next(gen)  # must be run_started, NOT a heartbeat
+        assert "run_started" in first and run_b.id in first
+    finally:
+        block.set()
+        manager.shutdown()

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -1,0 +1,222 @@
+"""Run observation + cancellation APIs (Phase 5 of #58).
+
+Covers GET /api/chat/runs/<id>, GET /api/chat/runs/<id>/stream, and
+POST /api/chat/runs/<id>/cancel, plus cooperative mid-stream cancellation and
+the observe() DB backstop. File-backed ChatDB (worker thread); streams
+monkeypatched.
+"""
+import json
+import os
+import sys
+import threading
+import time
+import uuid
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-run-routes")
+
+from chat import runtime
+from chat import run_manager as run_manager_module
+from chat.db import ChatDB
+from chat.event_bus import EventBus
+from chat.run_manager import ChatRunManager
+from chat.models import Conversation, Message, ChatRun
+from chat.runs import ChatRunStatus
+from chat.routes import chat_bp
+
+TOKEN = "test-token-run-routes"
+
+
+def wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    db = ChatDB(str(tmp_path / "chat.db"))
+    app = Flask(__name__)
+    app.config["DASHBOARD_TOKEN"] = TOKEN
+    app.config["CHAT_DB"] = db
+    bus = EventBus()
+    manager = ChatRunManager(db, bus, max_workers=2)
+    app.config["CHAT_EVENT_BUS"] = bus
+    app.config["CHAT_RUN_MANAGER"] = manager
+    app.register_blueprint(chat_bp)
+    app.testing = True
+    try:
+        yield app, db, manager
+    finally:
+        manager.shutdown()
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _conv(db, title="t"):
+    conv = Conversation(id=str(uuid.uuid4()), title=title, main_service="svc")
+    db.create_conversation(conv)
+    return conv
+
+
+def _run_row(db, conv, status=ChatRunStatus.RUNNING):
+    return db.create_chat_run(ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                                      status=status))
+
+
+def _seed_queued(db, conv):
+    user = Message(id=str(uuid.uuid4()), conversation_id=conv.id, role="user",
+                   content="hi", seq=db.next_seq(conv.id))
+    db.add_message(user)
+    return db.create_chat_run(ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                                      status=ChatRunStatus.QUEUED, user_message_id=user.id))
+
+
+def _delta(content):
+    return ("delta", {"content": content, "reasoning_content": "",
+                      "raw": json.dumps({"choices": [{"delta": {"content": content}}]})})
+
+
+def _patch(monkeypatch, factory):
+    def _wrap(*a, **k):
+        return factory()
+    monkeypatch.setattr(runtime, "stream_chat_completion", _wrap)
+    monkeypatch.setattr(runtime, "stream_with_tools", _wrap)
+
+
+# -- Auth ---------------------------------------------------------------
+
+
+def test_run_routes_require_auth(ctx):
+    client = ctx[0].test_client()
+    assert client.get("/api/chat/runs/x").status_code == 401
+    assert client.get("/api/chat/runs/x/stream").status_code == 401
+    assert client.post("/api/chat/runs/x/cancel").status_code == 401
+
+
+# -- GET run ------------------------------------------------------------
+
+
+def test_get_run_returns_metadata(ctx):
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    r = app.test_client().get(f"/api/chat/runs/{run.id}", headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["id"] == run.id
+    assert body["status"] == "running"
+    assert body["conversation_id"] == conv.id
+
+
+def test_get_run_not_found(ctx):
+    r = ctx[0].test_client().get("/api/chat/runs/nope", headers=_auth())
+    assert r.status_code == 404
+
+
+# -- Cancel -------------------------------------------------------------
+
+
+def test_cancel_active_run_marks_cancelled(ctx):
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    r = app.test_client().post(f"/api/chat/runs/{run.id}/cancel", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "cancelled"
+    assert db.get_chat_run(run.id).status == "cancelled"
+    assert db.get_active_run_for_conversation(conv.id) is None
+
+
+def test_cancel_completed_run_is_noop(ctx):
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    db.complete_chat_run(run.id)
+    r = app.test_client().post(f"/api/chat/runs/{run.id}/cancel", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "completed"  # unchanged, harmless no-op
+
+
+def test_cancel_not_found(ctx):
+    r = ctx[0].test_client().post("/api/chat/runs/nope/cancel", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_cancel_stops_run_midstream(ctx, monkeypatch):
+    """A cancel during streaming stops the model and writes no assistant
+    message (cooperative cancellation)."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _seed_queued(db, conv)
+
+    midstream = threading.Event()
+
+    def stub():
+        for i in range(100000):
+            yield _delta(f"t{i}")
+            if i == 2:
+                midstream.set()
+            time.sleep(0.002)
+        yield ("done", {"content": "should not finish", "reasoning_content": None})
+
+    _patch(monkeypatch, stub)
+    manager.start(conv, run, is_first=False, first_user_content="hi")
+    assert midstream.wait(2), "stream never reached mid-flight"
+
+    manager.request_cancel(run.id)
+
+    assert wait_for(lambda: db.get_chat_run(run.id).status == "cancelled")
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]  # no assistant
+
+
+# -- Stream -------------------------------------------------------------
+
+
+def test_stream_terminal_run_emits_status_and_closes(ctx):
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    db.fail_chat_run(run.id, "boom")
+
+    r = app.test_client().get(f"/api/chat/runs/{run.id}/stream", headers=_auth())
+    assert r.status_code == 200
+    body = r.get_data(as_text=True)
+    assert '"type": "run_status"' in body
+    assert '"status": "failed"' in body
+    assert '"error": "boom"' in body
+
+
+def test_stream_run_not_found(ctx):
+    r = ctx[0].test_client().get("/api/chat/runs/nope/stream", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_observe_backstop_closes_when_run_goes_terminal(ctx, monkeypatch):
+    """A reattached observer that never receives STREAM_END still closes once
+    the run is terminal in the DB (the heartbeat-path backstop)."""
+    app, db, manager = ctx
+    monkeypatch.setattr(run_manager_module, "HEARTBEAT_INTERVAL_S", 0.02)
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)  # active in DB, no worker
+
+    q = manager.subscribe(run.id)
+    gen = manager.observe(run.id, q)
+
+    first = next(gen)  # active, no events -> heartbeat
+    assert "heartbeat" in first
+
+    db.complete_chat_run(run.id)
+    nxt = next(gen)  # backstop detects terminal
+    assert "run_status" in nxt and "completed" in nxt
+    with pytest.raises(StopIteration):
+        next(gen)

--- a/dashboard/tests/test_chat_stream_events.py
+++ b/dashboard/tests/test_chat_stream_events.py
@@ -114,7 +114,8 @@ def _kinds(payloads):
     for kind, v in payloads:
         if kind == "done":
             kinds.append("[DONE]")
-        elif kind == "json" and v.get("type") == "heartbeat":
+        elif kind == "json" and v.get("type") in ("heartbeat", "run_started"):
+            # Structural frames (keepalive / run-id exposure), not content.
             continue
         elif kind == "json" and "type" in v:
             kinds.append(v["type"])
@@ -132,6 +133,28 @@ def _by_type(payloads, t):
 
 
 # -- Plain stream -------------------------------------------------------
+
+
+def test_send_emits_run_started_with_run_id_first(ctx, monkeypatch):
+    """The stream leads with a run_started frame carrying the run id so the
+    client can POST /runs/<id>/cancel (frontend wiring is Phase 6)."""
+    app, db = ctx[0], ctx[1]
+    conv = _conv(db)
+
+    def stub():
+        yield _delta("hi")
+        yield ("done", {"content": "hi", "reasoning_content": None})
+
+    _patch(monkeypatch, stub)
+    payloads = _payloads(_send(app, conv.id))
+
+    rs = _by_type(payloads, "run_started")
+    assert rs["run_id"]
+    # It is the first frame.
+    first_typed = next(v for kind, v in payloads if kind == "json" and "type" in v)
+    assert first_typed["type"] == "run_started"
+    # And the run id matches a real run row.
+    assert db.get_chat_run(rs["run_id"]) is not None
 
 
 def test_plain_send_emits_raw_deltas_then_handshake(ctx, monkeypatch):

--- a/dashboard/tests/test_llm_proxy_stream.py
+++ b/dashboard/tests/test_llm_proxy_stream.py
@@ -1,0 +1,58 @@
+"""stream_chat_completion upstream-connection teardown (Phase 5 of #58).
+
+Cooperative cancellation closes the generator (GeneratorExit); the streaming
+`requests` response must be released in a finally either way, so a cancelled
+run doesn't leak the model-server socket.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import llm_proxy
+
+
+class _FakeResp:
+    def __init__(self, lines):
+        self.status_code = 200
+        self.encoding = None
+        self._lines = lines
+        self.closed = False
+
+    def iter_lines(self, decode_unicode=True):
+        for line in self._lines:
+            yield line
+
+    def close(self):
+        self.closed = True
+
+
+def _patch(monkeypatch, resp):
+    monkeypatch.setattr(llm_proxy, "resolve_service",
+                        lambda name: {"host_port": 1234, "api_key": "k"})
+    monkeypatch.setattr(llm_proxy.requests, "post", lambda *a, **k: resp)
+
+
+def test_response_closed_on_normal_completion(monkeypatch):
+    resp = _FakeResp([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}',
+        '',
+        'data: [DONE]',
+    ])
+    _patch(monkeypatch, resp)
+
+    events = list(llm_proxy.stream_chat_completion("svc", []))
+    assert any(e[0] == "done" for e in events)
+    assert resp.closed
+
+
+def test_response_closed_on_early_generator_close(monkeypatch):
+    # A long stream the consumer abandons mid-way (cooperative cancel).
+    resp = _FakeResp([f'data: {{"choices":[{{"delta":{{"content":"t{i}"}}}}]}}'
+                      for i in range(1000)])
+    _patch(monkeypatch, resp)
+
+    gen = llm_proxy.stream_chat_completion("svc", [])
+    assert next(gen)[0] == "delta"   # consume one event, leaving the stream open
+    gen.close()                      # GeneratorExit -> finally -> resp.close()
+    assert resp.closed


### PR DESCRIPTION
## Phase 5 of #58 — Run observation + cancellation APIs

Adds navigation-independent run APIs and **cooperative mid-stream cancellation** so Stop actually halts the model — not just a frontend `AbortController.abort()` that leaves the run going.

### Routes

- **`GET /api/chat/runs/<id>`** — run status + metadata (404 if missing).
- **`GET /api/chat/runs/<id>/stream`** — reattach to a run. A terminal run emits a single `run_status` frame and closes (nothing live to replay — the conversation refetch carries the saved content); an active run subscribes to the bus and observes like the send path.
- **`POST /api/chat/runs/<id>/cancel`** — cancel server work. Cancelling an already-terminal run is a harmless **200 no-op** with the existing status (terminal-guarded in the DB). *(Chose 200-no-op over 409, per the issue's "choose one".)*

### Mechanism

- **`ChatRunManager.request_cancel`** sets a per-run cooperative cancel flag (a `threading.Event` registered for the worker's lifetime) **and** marks the run cancelled in the DB. Even if the worker doesn't check in time, the existing terminal-guarded completion (Phase 3) guarantees no assistant message is persisted for a cancelled run.
- **`ChatRunner.run(cancel_check=...)`** polls between stream events; on cancel it `stream.close()`s the upstream generator (GeneratorExit stops `stream_chat_completion`/`stream_with_tools` and the tool loop at the next yield), marks the run cancelled, and persists nothing. Cancellation is **cooperative** — a fully-silent generation is interrupted only once the next chunk/event arrives (same caveat the old `_with_heartbeat` had; true interruption would need a cancel token inside the HTTP read).
- **`observe()` DB-terminal backstop** — a reattaching observer that subscribed *after* `STREAM_END` was published would otherwise heartbeat forever; it now closes on the durable run status when idle.

### Acceptance

- Stop calls cancel (backend), not just `abort()`. ✅
- Cancelling marks the run `cancelled`; it clears `active_run` (no stuck sidebar). ✅
- Cancelling an already-completed run is harmless (200 no-op). ✅

### Tests (`test_chat_run_routes.py`)

auth on all three routes; GET metadata / 404; cancel active → cancelled (+ clears `active_run`); cancel completed → 200 no-op; cancel 404; **cooperative mid-stream cancel** stops the model and writes no assistant message; terminal-stream `run_status` frame; observe backstop closes on terminal.

```
cd dashboard
pytest tests/test_chat_run_routes.py tests/test_chat_background_runs.py   # green
pytest tests/   # full suite: 289 passed
```

Refs #58 (Phase 5).
