### PR TITLE
Phase 6 (#58): frontend session refactor — background-run aware UI

### DIFF
--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -381,6 +381,26 @@ def cancel_run(run_id):
     return jsonify(run.to_dict())
 
 
+@chat_bp.route("/api/chat/conversations/<conv_id>/cancel-active-run", methods=["POST"])
+@require_auth
+def cancel_active_run(conv_id):
+    """Cancel whatever run is active for a conversation, by conversation id.
+
+    The Stop button uses this so cancellation never depends on the client
+    having captured the run id from the run_started frame: the server creates
+    the run when the turn starts, so it is always findable from the
+    conversation. Returns {"run": <run>} when a run was cancelled, or
+    {"run": null} (still 200) when the conversation has no active run — a
+    harmless no-op (e.g. it already finished). 404 only if the conversation
+    does not exist.
+    """
+    db = _get_db()
+    if db.get_conversation(conv_id) is None:
+        return jsonify({"error": "Conversation not found"}), 404
+    run = _get_run_manager().request_cancel_for_conversation(conv_id)
+    return jsonify({"run": run.to_dict() if run is not None else None})
+
+
 # -- Critique --
 
 @chat_bp.route("/api/chat/messages/<msg_id>/critique", methods=["POST"])

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -389,15 +389,25 @@ def cancel_active_run(conv_id):
     The Stop button uses this so cancellation never depends on the client
     having captured the run id from the run_started frame: the server creates
     the run when the turn starts, so it is always findable from the
-    conversation. Returns {"run": <run>} when a run was cancelled, or
-    {"run": null} (still 200) when the conversation has no active run — a
-    harmless no-op (e.g. it already finished). 404 only if the conversation
+    conversation.
+
+    An optional {"expected_run_id": "<id>"} body guards against a stale Stop:
+    if the run the client meant to stop has already finished and a newer run is
+    active in this conversation, the cancel is a no-op rather than killing the
+    newer run.
+
+    Returns {"run": <run>} when a run was cancelled, or {"run": null} (still
+    200) when the conversation has no active run, or its active run does not
+    match expected_run_id — both harmless no-ops. 404 only if the conversation
     does not exist.
     """
     db = _get_db()
     if db.get_conversation(conv_id) is None:
         return jsonify({"error": "Conversation not found"}), 404
-    run = _get_run_manager().request_cancel_for_conversation(conv_id)
+    body = request.get_json(silent=True) or {}
+    expected_run_id = body.get("expected_run_id")
+    run = _get_run_manager().request_cancel_for_conversation(
+        conv_id, expected_run_id=expected_run_id)
     return jsonify({"run": run.to_dict() if run is not None else None})
 
 

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -119,6 +119,21 @@ class ChatRunManager:
             ev.set()
         return self.db.cancel_chat_run(run_id)
 
+    def request_cancel_for_conversation(self, conversation_id):
+        """Cancel a conversation's active (queued/running) run by conversation id.
+
+        The Stop button uses this so it never depends on the client having
+        captured the run id: the server already created the run when the turn
+        started, so it can always be found from the conversation. Returns the
+        cancelled run, or None if the conversation has no active run (a harmless
+        no-op — e.g. the run already finished). Delegates to request_cancel so
+        the cooperative flag is set and the DB update stays terminal-guarded.
+        """
+        run = self.db.get_active_run_for_conversation(conversation_id)
+        if run is None:
+            return None
+        return self.request_cancel(run.id)
+
     def _execute(self, conv, run, mcp_manager, is_first, first_user_content):
         cancel_event = threading.Event()
         with self._flags_lock:

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -119,7 +119,7 @@ class ChatRunManager:
             ev.set()
         return self.db.cancel_chat_run(run_id)
 
-    def request_cancel_for_conversation(self, conversation_id):
+    def request_cancel_for_conversation(self, conversation_id, expected_run_id=None):
         """Cancel a conversation's active (queued/running) run by conversation id.
 
         The Stop button uses this so it never depends on the client having
@@ -128,9 +128,20 @@ class ChatRunManager:
         cancelled run, or None if the conversation has no active run (a harmless
         no-op — e.g. the run already finished). Delegates to request_cancel so
         the cooperative flag is set and the DB update stays terminal-guarded.
+
+        expected_run_id guards against a stale Stop cancelling the wrong run: if
+        the caller knows which run it meant to stop (captured from the
+        run_started frame), a late-arriving cancel whose target has since
+        finished — with a *newer* run now active in the same conversation — must
+        not cancel that newer run. When expected_run_id is given and the active
+        run is a different one, this is a no-op. When it's omitted (a genuine
+        early Stop before run_started), the active run is provably still the one
+        the user meant, so "cancel whatever is active" is safe.
         """
         run = self.db.get_active_run_for_conversation(conversation_id)
         if run is None:
+            return None
+        if expected_run_id is not None and run.id != expected_run_id:
             return None
         return self.request_cancel(run.id)
 

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -143,6 +143,15 @@ export default function ChatArea({
 
   const targetMessage = critiqueTarget ? messages.find(m => m.id === critiqueTarget) : null
 
+  // A background run can still be active for this conversation even when we
+  // have no local SSE stream (the user navigated away and back, so `streaming`
+  // is false but the run kept going server-side). Treat it as an in-pane busy
+  // state: block the composer/model/MCP controls and surface Stop, which
+  // cancels by conversation id regardless of whether we hold the run stream.
+  const activeRun = conversation.active_run
+  const hasActiveRun = !!activeRun && (activeRun.status === 'running' || activeRun.status === 'queued')
+  const busy = streaming || cancelling || hasActiveRun
+
   function handleOpenCritique(msgId) {
     setCritiqueTarget(msgId)
   }
@@ -198,16 +207,16 @@ export default function ChatArea({
               sidekickService={conversation.sidekick_service}
               onChangeMain={v => handleModelChange('main_service', v)}
               onChangeSidekick={v => handleModelChange('sidekick_service', v)}
-              disabled={streaming || cancelling}
+              disabled={busy}
             />
             <McpToggle
               conversationId={conversation.id}
               enabledServers={conversation.mcp_servers}
               onUpdate={() => onReloadConversation?.(conversation.id)}
-              disabled={streaming || cancelling}
+              disabled={busy}
             />
           </div>
-          {streaming && (
+          {(streaming || hasActiveRun) && !cancelling && (
             <button
               onClick={onStopStreaming}
               className="text-xs px-3 py-1 bg-danger-subtle text-danger-fg border border-danger rounded hover:bg-danger-subtle"
@@ -258,7 +267,7 @@ export default function ChatArea({
           ref={composerRef}
           focusKey={conversation.id}
           onSend={handleSend}
-          disabled={streaming || cancelling || !conversation.main_service}
+          disabled={busy || !conversation.main_service}
           pendingInserts={pendingInserts}
           onClearInsert={(idx) => setPendingInserts(prev => prev.filter((_, i) => i !== idx))}
         />

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -32,6 +32,7 @@ export default function ChatArea({
   streamingParseWarning,
   error,
   cancelling,
+  runReady,
   onSend,
   onEdit,
   onStopStreaming,
@@ -216,7 +217,12 @@ export default function ChatArea({
               disabled={busy}
             />
           </div>
-          {(streaming || hasActiveRun) && !cancelling && (
+          {/* Gate the live-stream Stop on runReady: it must not appear until
+              run_started has delivered the run id, so Stop always cancels with
+              an expected-run guard rather than an unguarded "cancel whatever is
+              active" that a concurrently-started run could be hit by. The
+              returned-to active_run path already has an id (active_run.id). */}
+          {(((streaming && runReady) || hasActiveRun) && !cancelling) && (
             <button
               onClick={onStopStreaming}
               className="text-xs px-3 py-1 bg-danger-subtle text-danger-fg border border-danger rounded hover:bg-danger-subtle"

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -250,6 +250,7 @@ export default function ChatArea({
           hasSidekick={!!conversation.sidekick_service}
           onCritique={handleOpenCritique}
           onEdit={onEdit}
+          disableEdit={busy}
           streaming={streaming}
           streamingContent={streamingContent}
           streamingReasoning={streamingReasoning}

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -31,6 +31,7 @@ export default function ChatArea({
   streamingArtifacts,
   streamingParseWarning,
   error,
+  cancelling,
   onSend,
   onEdit,
   onStopStreaming,
@@ -197,13 +198,13 @@ export default function ChatArea({
               sidekickService={conversation.sidekick_service}
               onChangeMain={v => handleModelChange('main_service', v)}
               onChangeSidekick={v => handleModelChange('sidekick_service', v)}
-              disabled={streaming}
+              disabled={streaming || cancelling}
             />
             <McpToggle
               conversationId={conversation.id}
               enabledServers={conversation.mcp_servers}
               onUpdate={() => onReloadConversation?.(conversation.id)}
-              disabled={streaming}
+              disabled={streaming || cancelling}
             />
           </div>
           {streaming && (
@@ -257,7 +258,7 @@ export default function ChatArea({
           ref={composerRef}
           focusKey={conversation.id}
           onSend={handleSend}
-          disabled={streaming || !conversation.main_service}
+          disabled={streaming || cancelling || !conversation.main_service}
           pendingInserts={pendingInserts}
           onClearInsert={(idx) => setPendingInserts(prev => prev.filter((_, i) => i !== idx))}
         />

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -236,3 +236,57 @@ describe('ChatArea — send gating on a pending system-prompt save', () => {
     expect(onSend).toHaveBeenCalledWith('first', undefined)
   })
 })
+
+describe('ChatArea — active background run on return', () => {
+  // Regression for codex iteration 7 P2: returning to a conversation whose run
+  // is still going (streaming false, but conversation.active_run set) must keep
+  // the composer blocked and offer Stop — otherwise the run is uncontrollable
+  // and a send just hits the backend 409 active-run guard.
+  function renderWith(activeRun, onStopStreaming = () => {}) {
+    return render(
+      <ChatArea
+        conversation={{
+          id: 'conv-1',
+          main_service: 'vllm-test',
+          main_system_prompt: '',
+          mcp_servers: [],
+          active_run: activeRun,
+        }}
+        awaitingConversation={false}
+        defaultModelName="vllm-test"
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+        streaming={false}
+        onStopStreaming={onStopStreaming}
+      />
+    )
+  }
+
+  it('disables the composer and shows Stop for a running active_run with no local stream', () => {
+    const onStop = vi.fn()
+    const { container } = renderWith({ status: 'running' }, onStop)
+    expect(container.querySelector('textarea').disabled).toBe(true)
+    const stop = screen.getByRole('button', { name: /Stop/ })
+    fireEvent.click(stop)
+    expect(onStop).toHaveBeenCalledTimes(1)
+  })
+
+  it('also blocks for a queued active_run', () => {
+    const { container } = renderWith({ status: 'queued' })
+    expect(container.querySelector('textarea').disabled).toBe(true)
+    expect(screen.getByRole('button', { name: /Stop/ })).toBeTruthy()
+  })
+
+  it('enables the composer and hides Stop when there is no active run', () => {
+    const { container } = renderWith(null)
+    expect(container.querySelector('textarea').disabled).toBe(false)
+    expect(screen.queryByRole('button', { name: /Stop/ })).toBeNull()
+  })
+
+  it('does not block for a terminal active_run', () => {
+    const { container } = renderWith({ status: 'completed' })
+    expect(container.querySelector('textarea').disabled).toBe(false)
+    expect(screen.queryByRole('button', { name: /Stop/ })).toBeNull()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatArea.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.test.jsx
@@ -290,3 +290,34 @@ describe('ChatArea — active background run on return', () => {
     expect(screen.queryByRole('button', { name: /Stop/ })).toBeNull()
   })
 })
+
+describe('ChatArea — Stop gating on runReady', () => {
+  // Regression for codex iter 9 P2: while streaming but before run_started has
+  // delivered the run id (runReady false), Stop must be hidden so the UI can't
+  // issue an unguarded cancel. Once runReady is true, Stop appears.
+  function renderStreaming(runReady) {
+    return render(
+      <ChatArea
+        conversation={{ id: 'conv-1', main_service: 'vllm-test', main_system_prompt: '', mcp_servers: [], active_run: null }}
+        awaitingConversation={false}
+        defaultModelName="vllm-test"
+        messages={[]}
+        critiques={{}}
+        setCritiques={() => {}}
+        streaming={true}
+        runReady={runReady}
+        onStopStreaming={() => {}}
+      />
+    )
+  }
+
+  it('hides Stop while streaming until the run id is known', () => {
+    renderStreaming(false)
+    expect(screen.queryByRole('button', { name: /Stop/ })).toBeNull()
+  })
+
+  it('shows Stop once runReady is true', () => {
+    renderStreaming(true)
+    expect(screen.getByRole('button', { name: /Stop/ })).toBeTruthy()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -29,6 +29,7 @@ export default function ChatPage() {
     streamingArtifacts,
     streamingParseWarning,
     error,
+    runReady,
     cancelling,
     loadConversation,
     sendMessage,
@@ -166,6 +167,7 @@ export default function ChatPage() {
         streamingParseWarning={streamingParseWarning}
         error={error}
         cancelling={cancelling}
+        runReady={runReady}
         onSend={sendMessage}
         onEdit={editMessage}
         onStopStreaming={stopStreaming}

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -29,6 +29,7 @@ export default function ChatPage() {
     streamingArtifacts,
     streamingParseWarning,
     error,
+    cancelling,
     loadConversation,
     sendMessage,
     editMessage,
@@ -164,6 +165,7 @@ export default function ChatPage() {
         streamingArtifacts={streamingArtifacts}
         streamingParseWarning={streamingParseWarning}
         error={error}
+        cancelling={cancelling}
         onSend={sendMessage}
         onEdit={editMessage}
         onStopStreaming={stopStreaming}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -64,7 +64,19 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
         </label>
       )}
       <div className="flex-1 min-w-0">
-        <div className="text-sm truncate">{conv.title}</div>
+        <div className="text-sm flex items-center gap-1.5 min-w-0">
+          {conv.active_run && (conv.active_run.status === 'running' || conv.active_run.status === 'queued') && (
+            <i
+              className={`fa-solid fa-circle-notch fa-spin text-[10px] flex-shrink-0 ${
+                conv.active_run.status === 'running' ? 'text-accent' : 'text-fg-faint'
+              }`}
+              title={conv.active_run.status === 'running' ? 'Generating…' : 'Queued…'}
+              aria-label={conv.active_run.status === 'running' ? 'Run in progress' : 'Run queued'}
+              data-testid="active-run-indicator"
+            ></i>
+          )}
+          <span className="truncate">{conv.title}</span>
+        </div>
         <div className="text-[10px] text-fg-faint">
           {new Date(conv.updated_at).toLocaleDateString()}
         </div>

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -116,3 +116,52 @@ describe('ChatSidebar shift-click range selection', () => {
     expect(selectedTitles()).toEqual(['D'])
   })
 })
+
+describe('ChatSidebar active-run indicator', () => {
+  function renderWith(convs) {
+    return render(
+      <ChatSidebar
+        conversations={convs}
+        activeId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+      />
+    )
+  }
+
+  function indicatorFor(title) {
+    const row = screen.getByText(title).closest('.group')
+    return within(row).queryByTestId('active-run-indicator')
+  }
+
+  it('shows a running indicator when a conversation has a running active_run', () => {
+    renderWith([
+      { id: 'A', title: 'A', parent_conversation_id: null, updated_at: '2026-01-01', active_run: { status: 'running' } },
+    ])
+    const badge = indicatorFor('A')
+    expect(badge).not.toBeNull()
+    expect(badge.getAttribute('aria-label')).toBe('Run in progress')
+  })
+
+  it('shows a queued indicator when a conversation has a queued active_run', () => {
+    renderWith([
+      { id: 'A', title: 'A', parent_conversation_id: null, updated_at: '2026-01-01', active_run: { status: 'queued' } },
+    ])
+    const badge = indicatorFor('A')
+    expect(badge).not.toBeNull()
+    expect(badge.getAttribute('aria-label')).toBe('Run queued')
+  })
+
+  it('shows no indicator when active_run is null or terminal', () => {
+    renderWith([
+      { id: 'A', title: 'A', parent_conversation_id: null, updated_at: '2026-01-01', active_run: null },
+      { id: 'B', title: 'B', parent_conversation_id: null, updated_at: '2026-01-01' },
+      { id: 'C', title: 'C', parent_conversation_id: null, updated_at: '2026-01-01', active_run: { status: 'completed' } },
+    ])
+    expect(indicatorFor('A')).toBeNull()
+    expect(indicatorFor('B')).toBeNull()
+    expect(indicatorFor('C')).toBeNull()
+  })
+})

--- a/dashboard/frontend/src/components/chat/McpToggle.jsx
+++ b/dashboard/frontend/src/components/chat/McpToggle.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { fetchAPI } from '../../api'
 import { updateConversation } from '../../services/chat'
 
-export default function McpToggle({ conversationId, enabledServers, onUpdate, disabled }) {
+export default function McpToggle({ conversationId, enabledServers, onUpdate, onChange, disabled }) {
   const [available, setAvailable] = useState([])
 
   useEffect(() => {
@@ -18,6 +18,13 @@ export default function McpToggle({ conversationId, enabledServers, onUpdate, di
     const next = current.includes(serverId)
       ? current.filter(s => s !== serverId)
       : [...current, serverId]
+    // Controlled / in-memory mode (e.g. Ghost Chat): hand the new list to the
+    // caller, persist nothing. Without onChange we fall back to the persisted
+    // behavior — write mcp_servers_json on the conversation, then refetch.
+    if (onChange) {
+      onChange(next)
+      return
+    }
     await updateConversation(conversationId, { mcp_servers_json: JSON.stringify(next) })
     onUpdate?.()
   }

--- a/dashboard/frontend/src/components/chat/McpToggle.test.jsx
+++ b/dashboard/frontend/src/components/chat/McpToggle.test.jsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import McpToggle from './McpToggle'
+
+// The available-servers list comes from GET /chat/mcp-servers via fetchAPI.
+const { mockFetchAPI } = vi.hoisted(() => ({ mockFetchAPI: vi.fn() }))
+vi.mock('../../api', () => ({
+  fetchAPI: (...args) => mockFetchAPI(...args),
+}))
+
+// updateConversation is the persisted-mode side effect we assert is NOT
+// taken in controlled mode.
+const { mockUpdateConversation } = vi.hoisted(() => ({ mockUpdateConversation: vi.fn() }))
+vi.mock('../../services/chat', () => ({
+  updateConversation: (...args) => mockUpdateConversation(...args),
+}))
+
+const SERVERS = [
+  { id: 'sympy-math', name: 'Sympy', description: 'math', icon: 'fa-calculator' },
+  { id: 'websearch', name: 'Web', description: 'search', icon: 'fa-globe' },
+]
+
+beforeEach(() => {
+  mockFetchAPI.mockReset()
+  mockUpdateConversation.mockReset()
+  mockFetchAPI.mockResolvedValue({ servers: SERVERS })
+})
+
+afterEach(() => cleanup())
+
+async function renderToggle(props) {
+  render(<McpToggle conversationId="conv-1" enabledServers={[]} {...props} />)
+  // Wait for the async server-list fetch to populate the buttons.
+  await screen.findByText('Sympy')
+}
+
+describe('McpToggle controlled mode (onChange)', () => {
+  it('calls onChange with the next server list and does NOT persist', async () => {
+    const onChange = vi.fn()
+    const onUpdate = vi.fn()
+    await renderToggle({ onChange, onUpdate })
+
+    fireEvent.click(screen.getByText('Sympy'))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(['sympy-math'])
+    // Controlled mode is in-memory only: no PUT to the conversation, and the
+    // persisted-mode refetch callback must not fire.
+    expect(mockUpdateConversation).not.toHaveBeenCalled()
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('toggling an already-enabled server hands back the list with it removed', async () => {
+    const onChange = vi.fn()
+    render(<McpToggle conversationId="conv-1" enabledServers={['sympy-math']} onChange={onChange} />)
+    await screen.findByText('Sympy')
+
+    fireEvent.click(screen.getByText('Sympy'))
+
+    expect(onChange).toHaveBeenCalledWith([])
+    expect(mockUpdateConversation).not.toHaveBeenCalled()
+  })
+})
+
+describe('McpToggle persisted mode (no onChange)', () => {
+  it('persists via updateConversation and refetches when onChange is absent', async () => {
+    const onUpdate = vi.fn()
+    mockUpdateConversation.mockResolvedValue({})
+    render(<McpToggle conversationId="conv-1" enabledServers={[]} onUpdate={onUpdate} />)
+    await screen.findByText('Sympy')
+
+    fireEvent.click(screen.getByText('Sympy'))
+
+    await waitFor(() => expect(mockUpdateConversation).toHaveBeenCalledTimes(1))
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+      mcp_servers_json: JSON.stringify(['sympy-math']),
+    })
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
+  })
+})

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -27,7 +27,7 @@ const MD_COMPONENTS = {
   },
 }
 
-export default function MessageBubble({ message, critique, critiqueLoading, hasSidekick, onCritique, onEdit, isActiveCritique, artifacts }) {
+export default function MessageBubble({ message, critique, critiqueLoading, hasSidekick, onCritique, onEdit, isActiveCritique, artifacts, disableEdit }) {
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(message.content)
   const proseClass = useProseClass('max-w-none', 'text-[15px]', 'leading-relaxed', 'font-serif', '[&>*:first-child]:mt-0', '[&>*:last-child]:mb-0')
@@ -176,7 +176,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
         {/* Action buttons */}
         {!isTemp && (
           <div className={`flex gap-2 mt-1 opacity-0 group-hover:opacity-100 transition-opacity ${isUser ? 'justify-end' : ''}`}>
-            {isUser && !editing && (
+            {isUser && !editing && !disableEdit && (
               <button
                 onClick={() => setEditing(true)}
                 className="text-xs text-fg-subtle hover:text-fg-muted"

--- a/dashboard/frontend/src/components/chat/MessageList.jsx
+++ b/dashboard/frontend/src/components/chat/MessageList.jsx
@@ -32,6 +32,7 @@ export default function MessageList({
   hasSidekick,
   onCritique,
   onEdit,
+  disableEdit,
   streaming,
   streamingContent,
   streamingReasoning,
@@ -90,6 +91,7 @@ export default function MessageList({
             hasSidekick={hasSidekick}
             onCritique={onCritique}
             onEdit={onEdit}
+            disableEdit={disableEdit}
             isActiveCritique={activeCritiqueId === msg.id}
             artifacts={artifacts[msg.id]}
           />

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -36,12 +36,16 @@ export default function useChat({ onConversationUpdated } = {}) {
   // running on purpose (post-message_saved drain phase). Entries are
   // removed in the streamChat `finally` block when the stream resolves.
   const liveControllersRef = useRef(new Set())
-  // Mirror of the latest committed `conversation` for use in async callbacks
-  // (the cancel finally) whose closures would otherwise capture a stale value.
-  // Used to gate the post-cancel reconciliation so it can't clobber a
-  // conversation the user has since navigated to.
-  const conversationRef = useRef(null)
-  useEffect(() => { conversationRef.current = conversation }, [conversation])
+  // The conversation the hook currently INTENDS to show. Set synchronously at
+  // the start of loadConversation (before the fetch resolves) and mirrored from
+  // committed `conversation` for the setConversation paths. Used to request-
+  // sequence conversation fetches: any refetch (navigation, post-message_saved,
+  // post-cancel reconcile) only applies if this still names the conversation it
+  // fetched, so a late-resolving fetch can't clobber a conversation the user
+  // navigated to. Must be the intended id, NOT the committed one — during
+  // loadConversation(B) the committed conversation is still A until B resolves.
+  const observedConvIdRef = useRef(null)
+  useEffect(() => { observedConvIdRef.current = conversation?.id ?? null }, [conversation])
   // Backend run id for the in-flight stream, captured from the run_started SSE
   // frame. Stop cancels by conversation id (so it works even before this lands)
   // but passes this as an expected-run guard when known, so a late cancel can't
@@ -56,11 +60,16 @@ export default function useChat({ onConversationUpdated } = {}) {
   const refetchMessages = useCallback(async (convId) => {
     try {
       const data = await getConversation(convId)
+      // Drop the result if the user navigated to a different conversation while
+      // this fetch was in flight — otherwise a late resolve writes stale
+      // conversation/messages over the one now intended (request-sequencing).
+      if (observedConvIdRef.current !== convId) return
       setConversation(data)
       setMessages(data.messages || [])
       setCritiques(data.critiques || {})
       setArtifacts(data.artifacts || {})
     } catch (err) {
+      if (observedConvIdRef.current !== convId) return
       setError(err.message)
     }
   }, [])
@@ -89,9 +98,10 @@ export default function useChat({ onConversationUpdated } = {}) {
     cancelActiveRun(convId, expectedRunId)
       .catch(() => { /* no active run / already terminal — harmless */ })
       .then(() => {
-        // Reconcile only if still observing this conversation (the user may
-        // have navigated away while the cancel was in flight).
-        if (conversationRef.current?.id === convId) return refetchMessages(convId)
+        // Reconcile only if still intending this conversation (the user may
+        // have navigated away — even into a still-pending load — while the
+        // cancel was in flight). refetchMessages re-checks at resolution too.
+        if (observedConvIdRef.current === convId) return refetchMessages(convId)
       })
       .finally(() => {
         cancellingRef.current = false
@@ -100,6 +110,12 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [refetchMessages])
 
   const loadConversation = useCallback(async (convId) => {
+    // Claim the intended conversation synchronously, before awaiting the fetch.
+    // This is what makes a concurrent post-cancel reconcile for the PREVIOUS
+    // conversation skip: it gates on observedConvIdRef, which now already names
+    // the conversation we're navigating to even though `conversation` state
+    // still holds the old one until this fetch resolves.
+    observedConvIdRef.current = convId
     // Abort any in-flight stream before switching, UNLESS it's draining the
     // post-message_saved title tail (see drainingRef). Aborting that tail
     // would cancel auto-title generation server-side and drop the trailing

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { getConversation } from '../services/chat'
+import { getConversation, cancelRun } from '../services/chat'
 import { streamChat } from '../services/sse'
 
 export default function useChat({ onConversationUpdated } = {}) {
@@ -29,6 +29,10 @@ export default function useChat({ onConversationUpdated } = {}) {
   // running on purpose (post-message_saved drain phase). Entries are
   // removed in the streamChat `finally` block when the stream resolves.
   const liveControllersRef = useRef(new Set())
+  // Backend run id for the in-flight stream, captured from the run_started
+  // SSE frame. Lets Stop cancel the SERVER run (not just abort the SSE fetch,
+  // which — since Phase 4 — leaves the run going). Reset on each send/edit.
+  const runIdRef = useRef(null)
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -95,6 +99,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    runIdRef.current = null
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -173,6 +178,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           // Will be followed by message_saved
         },
         onConversationUpdated,
+        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -245,6 +251,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    runIdRef.current = null
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -311,6 +318,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onDone: () => {},
           onConversationUpdated,
+        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
@@ -340,6 +348,16 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
+    // Explicit Stop must cancel the SERVER run, not just abort the SSE fetch:
+    // since Phase 4 the run continues in the background after the fetch closes.
+    // Fire-and-forget; the run is terminal-guarded server-side. Navigation
+    // (loadConversation / unmount) deliberately does NOT call this — it only
+    // detaches the observer, leaving the run to finish and persist.
+    const runId = runIdRef.current
+    if (runId) {
+      runIdRef.current = null
+      cancelRun(runId).catch(() => { /* already terminal / gone — harmless */ })
+    }
     if (abortRef.current) {
       abortRef.current.abort()
       abortRef.current = null

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -14,6 +14,11 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [messages, setMessages] = useState([])
   const [critiques, setCritiques] = useState({})
   const [streaming, setStreaming] = useState(false)
+  // True once the run id for the in-flight stream is known (run_started parsed).
+  // The Stop control is gated on this so it is never offered without a run id —
+  // every Stop therefore sends an expected-run guard, never an unguarded cancel
+  // that a concurrently-started run (another tab/client) could be hit by.
+  const [runReady, setRunReady] = useState(false)
   // True from Stop until the cancel POST (and its reconcile) settle. Blocks a
   // new send/edit during that window so an unguarded cancel can't be processed
   // against a run the user started after Stop — closing the early-Stop
@@ -135,6 +140,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     }
     drainingRef.current = false
     runIdRef.current = null
+    setRunReady(false)
     setStreaming(false)
     setStreamingContent('')
     setStreamingReasoning('')
@@ -176,6 +182,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     abortRef.current = controller
     drainingRef.current = false
     runIdRef.current = null
+    setRunReady(false)
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -254,7 +261,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           // Will be followed by message_saved
         },
         onConversationUpdated,
-        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
+        onRunStarted: (evt) => { runIdRef.current = evt.run_id; setRunReady(true) },
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -332,6 +339,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     abortRef.current = controller
     drainingRef.current = false
     runIdRef.current = null
+    setRunReady(false)
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -398,7 +406,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onDone: () => {},
           onConversationUpdated,
-          onRunStarted: (evt) => { runIdRef.current = evt.run_id },
+          onRunStarted: (evt) => { runIdRef.current = evt.run_id; setRunReady(true) },
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
@@ -444,6 +452,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const expectedRunId = runIdRef.current || conversation?.active_run?.id || null
     cancelAndReconcile(conversation?.id, expectedRunId)
     runIdRef.current = null
+    setRunReady(false)
     if (abortRef.current) {
       abortRef.current.abort()
       abortRef.current = null
@@ -474,6 +483,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     critiques,
     setCritiques,
     streaming,
+    runReady,
     cancelling,
     streamingContent,
     streamingReasoning,

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -7,6 +7,13 @@ export default function useChat({ onConversationUpdated } = {}) {
   const [messages, setMessages] = useState([])
   const [critiques, setCritiques] = useState({})
   const [streaming, setStreaming] = useState(false)
+  // True from Stop until the cancel POST (and its reconcile) settle. Blocks a
+  // new send/edit during that window so an unguarded cancel can't be processed
+  // against a run the user started after Stop — closing the early-Stop
+  // (no run id) stale-cancel race. Mirrored into cancellingRef for the
+  // synchronous guard in send/edit.
+  const [cancelling, setCancelling] = useState(false)
+  const cancellingRef = useRef(false)
   const [streamingContent, setStreamingContent] = useState('')
   const [streamingReasoning, setStreamingReasoning] = useState('')
   const [toolEvents, setToolEvents] = useState([])
@@ -72,10 +79,23 @@ export default function useChat({ onConversationUpdated } = {}) {
   // the conversation they moved to.
   const cancelAndReconcile = useCallback((convId, expectedRunId) => {
     if (!convId) return
+    // Hold the cancelling flag across BOTH the cancel POST and its reconcile so
+    // send/edit stay blocked until the server has processed the cancel. This is
+    // what makes the no-id (early Stop) path safe: a new run can't be created
+    // while an unguarded cancel is in flight, so the cancel can only ever apply
+    // to the run the user actually stopped.
+    cancellingRef.current = true
+    setCancelling(true)
     cancelActiveRun(convId, expectedRunId)
       .catch(() => { /* no active run / already terminal — harmless */ })
+      .then(() => {
+        // Reconcile only if still observing this conversation (the user may
+        // have navigated away while the cancel was in flight).
+        if (conversationRef.current?.id === convId) return refetchMessages(convId)
+      })
       .finally(() => {
-        if (conversationRef.current?.id === convId) refetchMessages(convId)
+        cancellingRef.current = false
+        setCancelling(false)
       })
   }, [refetchMessages])
 
@@ -105,7 +125,7 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [refetchMessages])
 
   const sendMessage = useCallback(async (content, images) => {
-    if (!conversation || streaming) return
+    if (!conversation || streaming || cancellingRef.current) return
     setError(null)
     setStreaming(true)
     setStreamingContent('')
@@ -258,7 +278,7 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
-    if (!conversation || streaming) return
+    if (!conversation || streaming || cancellingRef.current) return
     const msg = messages.find(m => m.id === msgId)
     if (!msg || msg.role !== 'user') return
 
@@ -419,6 +439,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     critiques,
     setCritiques,
     streaming,
+    cancelling,
     streamingContent,
     streamingReasoning,
     toolEvents,

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -2,6 +2,13 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { getConversation, cancelActiveRun } from '../services/chat'
 import { streamChat } from '../services/sse'
 
+// A conversation has a live background run when its active_run is queued or
+// running. Used to block send/edit (and to find the run id for Stop) when we
+// returned to a conversation whose run is still going but we hold no SSE stream.
+function isRunActive(run) {
+  return !!run && (run.status === 'running' || run.status === 'queued')
+}
+
 export default function useChat({ onConversationUpdated } = {}) {
   const [conversation, setConversation] = useState(null)
   const [messages, setMessages] = useState([])
@@ -141,7 +148,10 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [refetchMessages])
 
   const sendMessage = useCallback(async (content, images) => {
-    if (!conversation || streaming || cancellingRef.current) return
+    // Block a send while a run is active for this conversation (including a
+    // returned-to background run, active_run set but streaming false) — mirrors
+    // the composer's disabled state and the backend active-run 409 guard.
+    if (!conversation || streaming || cancellingRef.current || isRunActive(conversation.active_run)) return
     setError(null)
     setStreaming(true)
     setStreamingContent('')
@@ -294,7 +304,11 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
-    if (!conversation || streaming || cancellingRef.current) return
+    // Block edits while a run is active for this conversation — including a
+    // background run we returned to (active_run set, streaming false). Without
+    // this the edit optimistically truncates the transcript, then the backend
+    // rejects the PUT with the active-run 409.
+    if (!conversation || streaming || cancellingRef.current || isRunActive(conversation.active_run)) return
     const msg = messages.find(m => m.id === msgId)
     if (!msg || msg.role !== 'user') return
 
@@ -423,7 +437,12 @@ export default function useChat({ onConversationUpdated } = {}) {
     // run started after this one. Navigation (loadConversation / unmount)
     // deliberately does NOT call this — it only detaches the observer, leaving
     // the run to finish and persist.
-    cancelAndReconcile(conversation?.id, runIdRef.current)
+    // Prefer the locally-captured run id; fall back to the conversation's
+    // active_run id for a run we returned to (no local stream, so runIdRef is
+    // null) — still passing an expected-run guard so a late cancel can't kill a
+    // newer run.
+    const expectedRunId = runIdRef.current || conversation?.active_run?.id || null
+    cancelAndReconcile(conversation?.id, expectedRunId)
     runIdRef.current = null
     if (abortRef.current) {
       abortRef.current.abort()

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -35,6 +35,12 @@ export default function useChat({ onConversationUpdated } = {}) {
   // conversation the user has since navigated to.
   const conversationRef = useRef(null)
   useEffect(() => { conversationRef.current = conversation }, [conversation])
+  // Backend run id for the in-flight stream, captured from the run_started SSE
+  // frame. Stop cancels by conversation id (so it works even before this lands)
+  // but passes this as an expected-run guard when known, so a late cancel can't
+  // kill a newer run that started after the one the user stopped. Reset at the
+  // start of each send/edit/load so it never carries a stale run's id.
+  const runIdRef = useRef(null)
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -64,9 +70,9 @@ export default function useChat({ onConversationUpdated } = {}) {
   // while the cancel POST is in flight, and refetchMessages writes
   // conversation/messages directly, so an ungated late refetch could clobber
   // the conversation they moved to.
-  const cancelAndReconcile = useCallback((convId) => {
+  const cancelAndReconcile = useCallback((convId, expectedRunId) => {
     if (!convId) return
-    cancelActiveRun(convId)
+    cancelActiveRun(convId, expectedRunId)
       .catch(() => { /* no active run / already terminal — harmless */ })
       .finally(() => {
         if (conversationRef.current?.id === convId) refetchMessages(convId)
@@ -85,6 +91,7 @@ export default function useChat({ onConversationUpdated } = {}) {
       abortRef.current = null
     }
     drainingRef.current = false
+    runIdRef.current = null
     setStreaming(false)
     setStreamingContent('')
     setStreamingReasoning('')
@@ -122,6 +129,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    runIdRef.current = null
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -200,6 +208,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           // Will be followed by message_saved
         },
         onConversationUpdated,
+        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -272,6 +281,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
+    runIdRef.current = null
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -338,6 +348,7 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onDone: () => {},
           onConversationUpdated,
+          onRunStarted: (evt) => { runIdRef.current = evt.run_id },
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
@@ -371,10 +382,13 @@ export default function useChat({ onConversationUpdated } = {}) {
     // since Phase 4 the run continues in the background after the fetch closes.
     // Cancel by conversation id so this works even if run_started has not yet
     // delivered the run id — the server created the run when the turn started,
-    // so it is always findable from the conversation. Navigation
-    // (loadConversation / unmount) deliberately does NOT call this — it only
-    // detaches the observer, leaving the run to finish and persist.
-    cancelAndReconcile(conversation?.id)
+    // so it is always findable from the conversation. Pass the captured run id
+    // (when known) as an expected-run guard so a late cancel can't kill a newer
+    // run started after this one. Navigation (loadConversation / unmount)
+    // deliberately does NOT call this — it only detaches the observer, leaving
+    // the run to finish and persist.
+    cancelAndReconcile(conversation?.id, runIdRef.current)
+    runIdRef.current = null
     if (abortRef.current) {
       abortRef.current.abort()
       abortRef.current = null

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { getConversation, cancelRun } from '../services/chat'
+import { getConversation, cancelActiveRun } from '../services/chat'
 import { streamChat } from '../services/sse'
 
 export default function useChat({ onConversationUpdated } = {}) {
@@ -29,17 +29,8 @@ export default function useChat({ onConversationUpdated } = {}) {
   // running on purpose (post-message_saved drain phase). Entries are
   // removed in the streamChat `finally` block when the stream resolves.
   const liveControllersRef = useRef(new Set())
-  // Backend run id for the in-flight stream, captured from the run_started
-  // SSE frame. Lets Stop cancel the SERVER run (not just abort the SSE fetch,
-  // which — since Phase 4 — leaves the run going). Reset on each send/edit.
-  const runIdRef = useRef(null)
-  // Set when Stop is pressed BEFORE run_started arrived — the server already
-  // created the run but we don't yet know its id, so we can't target the
-  // cancel and must not abort the fetch (that would drop the run_started frame
-  // and orphan the background run). onRunStarted consumes this and cancels.
-  const pendingStopRef = useRef(false)
   // Mirror of the latest committed `conversation` for use in async callbacks
-  // (cancel finallys) whose closures would otherwise capture a stale value.
+  // (the cancel finally) whose closures would otherwise capture a stale value.
   // Used to gate the post-cancel reconciliation so it can't clobber a
   // conversation the user has since navigated to.
   const conversationRef = useRef(null)
@@ -61,17 +52,22 @@ export default function useChat({ onConversationUpdated } = {}) {
     }
   }, [])
 
-  // Cancel a backend run, then reconcile local state with SQLite. The user
-  // message was persisted at run creation, but our optimistic { id: 'temp-user' }
-  // row is still in `messages`; without this refetch the next send's save
-  // handler — which strips every temp-user row before appending — drops the
-  // stopped prompt from the transcript. The refetch is gated on still observing
-  // the same conversation: the user may navigate away while the cancel POST is
-  // in flight, and refetchMessages writes conversation/messages directly, so an
-  // ungated late refetch could clobber the conversation they moved to.
-  const cancelAndReconcile = useCallback((runId, convId) => {
-    cancelRun(runId)
-      .catch(() => { /* already terminal / gone — harmless */ })
+  // Cancel a conversation's active run, then reconcile local state with SQLite.
+  // Cancellation is by conversation id (not run id) so Stop works even before
+  // the run_started frame has delivered the id — the server creates the run
+  // when the turn starts, so it is always findable from the conversation. The
+  // user message was persisted at run creation, but our optimistic
+  // { id: 'temp-user' } row is still in `messages`; without this refetch the
+  // next send's save handler — which strips every temp-user row before
+  // appending — drops the stopped prompt from the transcript. The refetch is
+  // gated on still observing the same conversation: the user may navigate away
+  // while the cancel POST is in flight, and refetchMessages writes
+  // conversation/messages directly, so an ungated late refetch could clobber
+  // the conversation they moved to.
+  const cancelAndReconcile = useCallback((convId) => {
+    if (!convId) return
+    cancelActiveRun(convId)
+      .catch(() => { /* no active run / already terminal — harmless */ })
       .finally(() => {
         if (conversationRef.current?.id === convId) refetchMessages(convId)
       })
@@ -126,8 +122,6 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
-    runIdRef.current = null
-    pendingStopRef.current = false
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -206,22 +200,6 @@ export default function useChat({ onConversationUpdated } = {}) {
           // Will be followed by message_saved
         },
         onConversationUpdated,
-        onRunStarted: (evt) => {
-          runIdRef.current = evt.run_id
-          // A Stop pressed before the id arrived deferred cancellation to here:
-          // we couldn't target the server run, and aborting the fetch then would
-          // have killed the very frame carrying this id. Cancel + tear down now.
-          if (pendingStopRef.current) {
-            pendingStopRef.current = false
-            runIdRef.current = null
-            cancelAndReconcile(evt.run_id, conversation.id)
-            if (abortRef.current) {
-              abortRef.current.abort()
-              abortRef.current = null
-            }
-            drainingRef.current = false
-          }
-        },
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -268,7 +246,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, refetchMessages, cancelAndReconcile, onConversationUpdated])
+  }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
     if (!conversation || streaming) return
@@ -294,8 +272,6 @@ export default function useChat({ onConversationUpdated } = {}) {
     const controller = new AbortController()
     abortRef.current = controller
     drainingRef.current = false
-    runIdRef.current = null
-    pendingStopRef.current = false
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -362,19 +338,6 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onDone: () => {},
           onConversationUpdated,
-          onRunStarted: (evt) => {
-            runIdRef.current = evt.run_id
-            if (pendingStopRef.current) {
-              pendingStopRef.current = false
-              runIdRef.current = null
-              cancelAndReconcile(evt.run_id, conversation.id)
-              if (abortRef.current) {
-                abortRef.current.abort()
-                abortRef.current = null
-              }
-              drainingRef.current = false
-            }
-          },
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
@@ -401,30 +364,20 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, loadConversation, refetchMessages, cancelAndReconcile, onConversationUpdated])
+  }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
     // Explicit Stop must cancel the SERVER run, not just abort the SSE fetch:
     // since Phase 4 the run continues in the background after the fetch closes.
-    // Navigation (loadConversation / unmount) deliberately does NOT call this —
-    // it only detaches the observer, leaving the run to finish and persist.
-    const runId = runIdRef.current
-    const convId = conversation?.id
-    if (runId) {
-      // Id known: cancel the server run now (and reconcile after it settles),
-      // then abort our observer.
-      runIdRef.current = null
-      cancelAndReconcile(runId, convId)
-      if (abortRef.current) {
-        abortRef.current.abort()
-        abortRef.current = null
-      }
-    } else if (abortRef.current) {
-      // Stop pressed before run_started: the server already created the run but
-      // we don't know its id yet. Aborting now would drop the run_started frame
-      // and leave the background run executing. Defer the abort + cancel to
-      // onRunStarted, which consumes this flag the moment the id arrives.
-      pendingStopRef.current = true
+    // Cancel by conversation id so this works even if run_started has not yet
+    // delivered the run id — the server created the run when the turn started,
+    // so it is always findable from the conversation. Navigation
+    // (loadConversation / unmount) deliberately does NOT call this — it only
+    // detaches the observer, leaving the run to finish and persist.
+    cancelAndReconcile(conversation?.id)
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
     }
     drainingRef.current = false
     setStreaming(false)

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -33,6 +33,17 @@ export default function useChat({ onConversationUpdated } = {}) {
   // SSE frame. Lets Stop cancel the SERVER run (not just abort the SSE fetch,
   // which — since Phase 4 — leaves the run going). Reset on each send/edit.
   const runIdRef = useRef(null)
+  // Set when Stop is pressed BEFORE run_started arrived — the server already
+  // created the run but we don't yet know its id, so we can't target the
+  // cancel and must not abort the fetch (that would drop the run_started frame
+  // and orphan the background run). onRunStarted consumes this and cancels.
+  const pendingStopRef = useRef(false)
+  // Mirror of the latest committed `conversation` for use in async callbacks
+  // (cancel finallys) whose closures would otherwise capture a stale value.
+  // Used to gate the post-cancel reconciliation so it can't clobber a
+  // conversation the user has since navigated to.
+  const conversationRef = useRef(null)
+  useEffect(() => { conversationRef.current = conversation }, [conversation])
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -49,6 +60,22 @@ export default function useChat({ onConversationUpdated } = {}) {
       setError(err.message)
     }
   }, [])
+
+  // Cancel a backend run, then reconcile local state with SQLite. The user
+  // message was persisted at run creation, but our optimistic { id: 'temp-user' }
+  // row is still in `messages`; without this refetch the next send's save
+  // handler — which strips every temp-user row before appending — drops the
+  // stopped prompt from the transcript. The refetch is gated on still observing
+  // the same conversation: the user may navigate away while the cancel POST is
+  // in flight, and refetchMessages writes conversation/messages directly, so an
+  // ungated late refetch could clobber the conversation they moved to.
+  const cancelAndReconcile = useCallback((runId, convId) => {
+    cancelRun(runId)
+      .catch(() => { /* already terminal / gone — harmless */ })
+      .finally(() => {
+        if (conversationRef.current?.id === convId) refetchMessages(convId)
+      })
+  }, [refetchMessages])
 
   const loadConversation = useCallback(async (convId) => {
     // Abort any in-flight stream before switching, UNLESS it's draining the
@@ -100,6 +127,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     abortRef.current = controller
     drainingRef.current = false
     runIdRef.current = null
+    pendingStopRef.current = false
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -178,7 +206,22 @@ export default function useChat({ onConversationUpdated } = {}) {
           // Will be followed by message_saved
         },
         onConversationUpdated,
-        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
+        onRunStarted: (evt) => {
+          runIdRef.current = evt.run_id
+          // A Stop pressed before the id arrived deferred cancellation to here:
+          // we couldn't target the server run, and aborting the fetch then would
+          // have killed the very frame carrying this id. Cancel + tear down now.
+          if (pendingStopRef.current) {
+            pendingStopRef.current = false
+            runIdRef.current = null
+            cancelAndReconcile(evt.run_id, conversation.id)
+            if (abortRef.current) {
+              abortRef.current.abort()
+              abortRef.current = null
+            }
+            drainingRef.current = false
+          }
+        },
         onMessageSaved: (data) => {
           const assistantMsg = {
             id: data.message_id,
@@ -225,7 +268,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
+  }, [conversation, messages, streaming, refetchMessages, cancelAndReconcile, onConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
     if (!conversation || streaming) return
@@ -252,6 +295,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     abortRef.current = controller
     drainingRef.current = false
     runIdRef.current = null
+    pendingStopRef.current = false
     liveControllersRef.current.add(controller)
 
     let fullContent = ''
@@ -318,7 +362,19 @@ export default function useChat({ onConversationUpdated } = {}) {
           },
           onDone: () => {},
           onConversationUpdated,
-        onRunStarted: (evt) => { runIdRef.current = evt.run_id },
+          onRunStarted: (evt) => {
+            runIdRef.current = evt.run_id
+            if (pendingStopRef.current) {
+              pendingStopRef.current = false
+              runIdRef.current = null
+              cancelAndReconcile(evt.run_id, conversation.id)
+              if (abortRef.current) {
+                abortRef.current.abort()
+                abortRef.current = null
+              }
+              drainingRef.current = false
+            }
+          },
           onMessageSaved: () => {
             setStreamingContent('')
             setStreamingReasoning('')
@@ -345,40 +401,36 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
+  }, [conversation, messages, streaming, loadConversation, refetchMessages, cancelAndReconcile, onConversationUpdated])
 
   const stopStreaming = useCallback(() => {
     // Explicit Stop must cancel the SERVER run, not just abort the SSE fetch:
     // since Phase 4 the run continues in the background after the fetch closes.
-    // Fire-and-forget; the run is terminal-guarded server-side. Navigation
-    // (loadConversation / unmount) deliberately does NOT call this — it only
-    // detaches the observer, leaving the run to finish and persist.
+    // Navigation (loadConversation / unmount) deliberately does NOT call this —
+    // it only detaches the observer, leaving the run to finish and persist.
     const runId = runIdRef.current
     const convId = conversation?.id
     if (runId) {
+      // Id known: cancel the server run now (and reconcile after it settles),
+      // then abort our observer.
       runIdRef.current = null
-      cancelRun(runId)
-        .catch(() => { /* already terminal / gone — harmless */ })
-        // Reconcile local state with SQLite. The user message was persisted
-        // when the run was created, but our optimistic { id: 'temp-user' } row
-        // is still in `messages`. Without this refetch the next send's save
-        // handler — which strips every temp-user row before appending — drops
-        // the stopped prompt from the transcript (and it stays dropped if that
-        // trailing refetch ever fails). Refetch swaps the optimistic row for
-        // the persisted one with a real id, which the strip no longer touches.
-        // Runs after cancel settles so it also reflects the rare case where the
-        // run completed in the same instant Stop was pressed.
-        .finally(() => { if (convId) refetchMessages(convId) })
-    }
-    if (abortRef.current) {
-      abortRef.current.abort()
-      abortRef.current = null
+      cancelAndReconcile(runId, convId)
+      if (abortRef.current) {
+        abortRef.current.abort()
+        abortRef.current = null
+      }
+    } else if (abortRef.current) {
+      // Stop pressed before run_started: the server already created the run but
+      // we don't know its id yet. Aborting now would drop the run_started frame
+      // and leave the background run executing. Defer the abort + cancel to
+      // onRunStarted, which consumes this flag the moment the id arrives.
+      pendingStopRef.current = true
     }
     drainingRef.current = false
     setStreaming(false)
     setHeartbeat(null)
     setPendingToolCalls([])
-  }, [conversation, refetchMessages])
+  }, [conversation, cancelAndReconcile])
 
   // Abort streaming on unmount (e.g. navigating away). Aborts BOTH the
   // active stream (abortRef) and any detached draining streams whose

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -354,9 +354,21 @@ export default function useChat({ onConversationUpdated } = {}) {
     // (loadConversation / unmount) deliberately does NOT call this — it only
     // detaches the observer, leaving the run to finish and persist.
     const runId = runIdRef.current
+    const convId = conversation?.id
     if (runId) {
       runIdRef.current = null
-      cancelRun(runId).catch(() => { /* already terminal / gone — harmless */ })
+      cancelRun(runId)
+        .catch(() => { /* already terminal / gone — harmless */ })
+        // Reconcile local state with SQLite. The user message was persisted
+        // when the run was created, but our optimistic { id: 'temp-user' } row
+        // is still in `messages`. Without this refetch the next send's save
+        // handler — which strips every temp-user row before appending — drops
+        // the stopped prompt from the transcript (and it stays dropped if that
+        // trailing refetch ever fails). Refetch swaps the optimistic row for
+        // the persisted one with a real id, which the strip no longer touches.
+        // Runs after cancel settles so it also reflects the rare case where the
+        // run completed in the same instant Stop was pressed.
+        .finally(() => { if (convId) refetchMessages(convId) })
     }
     if (abortRef.current) {
       abortRef.current.abort()
@@ -366,7 +378,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreaming(false)
     setHeartbeat(null)
     setPendingToolCalls([])
-  }, [])
+  }, [conversation, refetchMessages])
 
   // Abort streaming on unmount (e.g. navigating away). Aborts BOTH the
   // active stream (abortRef) and any detached draining streams whose

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -313,6 +313,33 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.messages.some(m => m.id === 'temp-edit')).toBe(false)
   })
 
+  it('runReady stays false until run_started, gating an unguarded Stop', async () => {
+    // Regression for codex iter 9 P2: the Stop control must not be exposed
+    // before the run id is known, so the UI can never issue an unguarded
+    // cancel. runReady is the gate; it flips true only on run_started.
+    let handlers
+    mockStreamChat.mockImplementation((_url, _body, h) => {
+      handlers = h
+      return new Promise(() => {}) // no run_started yet
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hi')
+      await Promise.resolve()
+    })
+    expect(result.current.streaming).toBe(true)
+    expect(result.current.runReady).toBe(false)
+
+    await act(async () => {
+      handlers.onRunStarted({ type: 'run_started', run_id: 'run-x' })
+      await Promise.resolve()
+    })
+    expect(result.current.runReady).toBe(true)
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -231,6 +231,53 @@ describe('useChat stop/cancel wiring', () => {
     expect(mockStreamChat.mock.calls.length).toBe(callsAfterA + 1)
   })
 
+  it('a Stop reconcile is dropped when its cancel settles during an in-flight navigation', async () => {
+    // Regression for codex iter 6 P2: the reconcile gate must use the INTENDED
+    // conversation (set synchronously at loadConversation), not the committed
+    // one. Repro: Stop A, navigate to B while B's fetch is still pending, then
+    // A's cancel settles — the reconcile for A must be gated out (we already
+    // intend B), so A is never refetched and can't clobber B.
+    installInFlightStream()
+    let resolveCancel
+    mockCancelActiveRun.mockImplementation(() => new Promise((res) => { resolveCancel = res }))
+    let resolveB
+    mockGetConversation.mockImplementation((id) => {
+      if (id === 'conv-2') return new Promise((res) => { resolveB = res })
+      return Promise.resolve({ ...CONV, messages: [{ id: 'a1', role: 'user', content: 'A', seq: 1 }], critiques: {}, artifacts: {} })
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('A')
+      await Promise.resolve()
+    })
+
+    // Stop A (cancel POST held open).
+    act(() => { result.current.stopStreaming() })
+
+    // Begin navigation to B; B's fetch stays pending.
+    let loadPromise
+    act(() => { loadPromise = result.current.loadConversation('conv-2') })
+
+    // A's cancel settles WHILE B is still loading.
+    await act(async () => {
+      resolveCancel({ run: null })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // The reconcile for A must have been gated out — A is never refetched.
+    expect(mockGetConversation).not.toHaveBeenCalledWith('conv-1')
+
+    // B finally resolves and wins.
+    await act(async () => {
+      resolveB({ id: 'conv-2', main_service: 'svc', messages: [{ id: 'b1', role: 'user', content: 'B', seq: 1 }], critiques: {}, artifacts: {} })
+      await loadPromise
+    })
+    expect(result.current.conversation.id).toBe('conv-2')
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -190,6 +190,47 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.conversation.id).toBe('conv-2')
   })
 
+  it('blocks a new send until the cancel settles, closing the unguarded race', async () => {
+    // Regression for codex iter 5 P2: when Stop is pressed before run_started,
+    // the cancel is unguarded (no expected_run_id). A new run must not be able
+    // to start while that cancel is in flight, or the server could cancel the
+    // NEW run instead. The hook blocks send/edit until the cancel settles.
+    installInFlightStream(null) // early Stop: no run id captured
+    let resolveCancel
+    mockCancelActiveRun.mockImplementation(() => new Promise((res) => { resolveCancel = res }))
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('A')
+      await Promise.resolve()
+    })
+    const callsAfterA = mockStreamChat.mock.calls.length
+
+    act(() => { result.current.stopStreaming() })
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1', null)
+
+    // Attempt to send B while the cancel is unresolved — must be blocked.
+    await act(async () => {
+      result.current.sendMessage('B')
+      await Promise.resolve()
+    })
+    expect(mockStreamChat.mock.calls.length).toBe(callsAfterA)
+
+    // Cancel settles → the block lifts and B can start.
+    await act(async () => {
+      resolveCancel({ run: null })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await act(async () => {
+      result.current.sendMessage('B')
+      await Promise.resolve()
+    })
+    expect(mockStreamChat.mock.calls.length).toBe(callsAfterA + 1)
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useChat from './useChat'
+
+// streamChat is the SSE driver. We replace it with a controllable fake that
+// captures the handlers, fires onRunStarted (so the hook learns the backend
+// run id), and then leaves the stream "in-flight" via a promise we resolve
+// from the test.
+const { mockStreamChat } = vi.hoisted(() => ({ mockStreamChat: vi.fn() }))
+vi.mock('../services/sse', () => ({
+  streamChat: (...args) => mockStreamChat(...args),
+}))
+
+const { mockCancelRun, mockGetConversation } = vi.hoisted(() => ({
+  mockCancelRun: vi.fn(),
+  mockGetConversation: vi.fn(),
+}))
+vi.mock('../services/chat', () => ({
+  cancelRun: (...args) => mockCancelRun(...args),
+  getConversation: (...args) => mockGetConversation(...args),
+}))
+
+const CONV = { id: 'conv-1', main_service: 'vllm-test' }
+
+// streamChat fake: synchronously emit run_started, then return a promise that
+// only resolves when the test calls the stored resolver. Returns that resolver
+// via the `pending` ref so the test can end the stream deterministically.
+function installInFlightStream(runId = 'run-123') {
+  let resolveStream
+  const streamDone = new Promise((res) => { resolveStream = res })
+  mockStreamChat.mockImplementation((_url, _body, handlers) => {
+    handlers.onRunStarted?.({ type: 'run_started', run_id: runId })
+    return streamDone
+  })
+  return { end: () => resolveStream() }
+}
+
+beforeEach(() => {
+  mockStreamChat.mockReset()
+  mockCancelRun.mockReset()
+  mockGetConversation.mockReset()
+  mockCancelRun.mockResolvedValue({})
+  mockGetConversation.mockResolvedValue({ ...CONV, messages: [], critiques: {}, artifacts: {} })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useChat stop/cancel wiring', () => {
+  it('stopStreaming cancels the backend run captured from run_started', async () => {
+    installInFlightStream('run-123')
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hello')
+      await Promise.resolve()
+    })
+
+    expect(result.current.streaming).toBe(true)
+
+    act(() => { result.current.stopStreaming() })
+
+    expect(mockCancelRun).toHaveBeenCalledTimes(1)
+    expect(mockCancelRun).toHaveBeenCalledWith('run-123')
+    expect(result.current.streaming).toBe(false)
+  })
+
+  it('switching conversation during a run does NOT cancel the backend run', async () => {
+    // Background-run semantics: navigating away leaves the run going so it
+    // finishes and persists. Only an explicit Stop cancels it.
+    installInFlightStream('run-456')
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hello')
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      await result.current.loadConversation('conv-2')
+    })
+
+    expect(mockCancelRun).not.toHaveBeenCalled()
+    // The observer detaches locally (streaming flips off) but the server run
+    // is untouched.
+    expect(result.current.streaming).toBe(false)
+  })
+
+  it('stopStreaming is a no-op for cancel when no run id was captured', async () => {
+    // Stream that never emits run_started (e.g. an early HTTP error path).
+    let resolveStream
+    mockStreamChat.mockImplementation(() => new Promise((res) => { resolveStream = res }))
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hello')
+      await Promise.resolve()
+    })
+
+    act(() => { result.current.stopStreaming() })
+
+    expect(mockCancelRun).not.toHaveBeenCalled()
+    if (resolveStream) resolveStream()
+  })
+})

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -21,13 +21,16 @@ vi.mock('../services/chat', () => ({
 
 const CONV = { id: 'conv-1', main_service: 'vllm-test' }
 
-// streamChat fake: stay open until the test resolves it. Stop/navigation no
-// longer depend on a run_started frame (cancellation is by conversation id),
-// so the fake doesn't need to emit one.
-function installInFlightStream() {
+// streamChat fake: stay open until the test resolves it. Emits a run_started
+// frame (so the hook captures the run id used as the cancel guard) unless runId
+// is null, which models the early-Stop window before run_started arrives.
+function installInFlightStream(runId = 'run-123') {
   let resolveStream
   const streamDone = new Promise((res) => { resolveStream = res })
-  mockStreamChat.mockImplementation(() => streamDone)
+  mockStreamChat.mockImplementation((_url, _body, handlers) => {
+    if (runId) handlers.onRunStarted?.({ type: 'run_started', run_id: runId })
+    return streamDone
+  })
   return { end: () => resolveStream() }
 }
 
@@ -60,7 +63,9 @@ describe('useChat stop/cancel wiring', () => {
     act(() => { result.current.stopStreaming() })
 
     expect(mockCancelActiveRun).toHaveBeenCalledTimes(1)
-    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
+    // Cancel targets the conversation, guarded by the captured run id so a late
+    // cancel can't kill a newer run.
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1', 'run-123')
     expect(result.current.streaming).toBe(false)
   })
 
@@ -68,8 +73,9 @@ describe('useChat stop/cancel wiring', () => {
     // The whole point of cancel-by-conversation: the server creates the run
     // when the turn starts, so Stop works without the client first capturing a
     // run id. Earlier (run-id-keyed) designs could orphan the run in this
-    // window; this asserts the cancel POST always fires.
-    installInFlightStream()
+    // window; this asserts the cancel POST always fires (with no guard, since
+    // the active run is provably still the one the user meant).
+    installInFlightStream(null)
     const { result } = renderHook(() => useChat({}))
 
     act(() => { result.current.setConversation(CONV) })
@@ -81,7 +87,7 @@ describe('useChat stop/cancel wiring', () => {
 
     act(() => { result.current.stopStreaming() })
 
-    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1', null)
   })
 
   it('switching conversation during a run does NOT cancel the backend run', async () => {
@@ -134,7 +140,7 @@ describe('useChat stop/cancel wiring', () => {
       await Promise.resolve()
     })
 
-    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1', 'run-123')
     // The stopped prompt now carries the persisted id, not 'temp-user', so the
     // next send's `filter(m => m.id !== 'temp-user')` can no longer drop it.
     expect(result.current.messages.some(m => m.id === 'temp-user')).toBe(false)

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -91,6 +91,44 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.streaming).toBe(false)
   })
 
+  it('Stop reconciles the optimistic row so a later send keeps the stopped prompt', async () => {
+    // Regression for codex iter 1 P1: the user message is persisted at run
+    // creation, but the optimistic temp-user row would be stripped by the next
+    // send's save handler. Stop must refetch so the stopped prompt survives
+    // with a real (non-temp) id.
+    installInFlightStream('run-1')
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      messages: [{ id: 'msg-1', role: 'user', content: 'first', seq: 1 }],
+      critiques: {},
+      artifacts: {},
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('first')
+      await Promise.resolve()
+    })
+    // Optimistic row is present and temporary at this point.
+    expect(result.current.messages.some(m => m.id === 'temp-user')).toBe(true)
+
+    await act(async () => {
+      result.current.stopStreaming()
+      // Let cancelRun resolve and the trailing refetch settle.
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockCancelRun).toHaveBeenCalledWith('run-1')
+    // The stopped prompt now carries the persisted id, not 'temp-user', so the
+    // next send's `filter(m => m.id !== 'temp-user')` can no longer drop it.
+    expect(result.current.messages.some(m => m.id === 'temp-user')).toBe(false)
+    expect(result.current.messages.some(m => m.id === 'msg-1' && m.content === 'first')).toBe(true)
+  })
+
   it('stopStreaming is a no-op for cancel when no run id was captured', async () => {
     // Stream that never emits run_started (e.g. an early HTTP error path).
     let resolveStream

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -129,8 +129,86 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.messages.some(m => m.id === 'msg-1' && m.content === 'first')).toBe(true)
   })
 
-  it('stopStreaming is a no-op for cancel when no run id was captured', async () => {
+  it('Stop pressed before run_started defers cancellation until the run id arrives', async () => {
+    // Regression for codex iter 2 P2: the server creates the run before
+    // emitting run_started. A Stop in that window has no id to target; aborting
+    // the fetch then would drop the run_started frame and orphan the background
+    // run. Stop must defer and cancel once the id lands.
+    let handlers
+    mockStreamChat.mockImplementation((_url, _body, h) => {
+      handlers = h
+      // No run_started yet; stream stays open.
+      return new Promise(() => {})
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hello')
+      await Promise.resolve()
+    })
+
+    // Stop before the id is known: UI reflects stopped immediately, but we
+    // can't cancel the server run yet.
+    act(() => { result.current.stopStreaming() })
+    expect(mockCancelRun).not.toHaveBeenCalled()
+    expect(result.current.streaming).toBe(false)
+
+    // The id finally arrives — deferred cancel fires now.
+    await act(async () => {
+      handlers.onRunStarted({ type: 'run_started', run_id: 'run-late' })
+      await Promise.resolve()
+    })
+    expect(mockCancelRun).toHaveBeenCalledWith('run-late')
+  })
+
+  it('a late Stop refetch does not clobber a conversation the user navigated to', async () => {
+    // Regression for codex iter 2 P2: stopStreaming refetches after cancel
+    // settles. If the user navigates A -> B while the cancel POST is in flight,
+    // the A refetch must NOT overwrite B (refetchMessages writes conversation
+    // /messages directly).
+    installInFlightStream('run-A')
+    // Hold the cancel POST open so its reconcile finally runs LAST.
+    let resolveCancel
+    mockCancelRun.mockImplementation(() => new Promise((res) => { resolveCancel = res }))
+    mockGetConversation.mockImplementation((id) =>
+      Promise.resolve(
+        id === 'conv-2'
+          ? { id: 'conv-2', main_service: 'svc', messages: [{ id: 'b1', role: 'user', content: 'B', seq: 1 }], critiques: {}, artifacts: {} }
+          : { ...CONV, messages: [{ id: 'a1', role: 'user', content: 'A', seq: 1 }], critiques: {}, artifacts: {} }
+      )
+    )
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('A')
+      await Promise.resolve()
+    })
+
+    // Stop A (cancel POST is now pending, reconcile finally not yet run).
+    act(() => { result.current.stopStreaming() })
+
+    // Navigate to B; B loads fully.
+    await act(async () => {
+      await result.current.loadConversation('conv-2')
+    })
+    expect(result.current.conversation.id).toBe('conv-2')
+
+    // A's cancel resolves LAST — its reconcile must be gated out.
+    await act(async () => {
+      resolveCancel()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.conversation.id).toBe('conv-2')
+  })
+
+  it('stopStreaming does not cancel when run_started never arrives', async () => {
     // Stream that never emits run_started (e.g. an early HTTP error path).
+    // Stop defers, but with no id ever delivered there is nothing to cancel.
     let resolveStream
     mockStreamChat.mockImplementation(() => new Promise((res) => { resolveStream = res }))
     const { result } = renderHook(() => useChat({}))

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -278,6 +278,41 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.conversation.id).toBe('conv-2')
   })
 
+  it('Stop on a returned-to background run uses active_run.id as the cancel guard', async () => {
+    // Regression for codex iter 8 P2: after navigating back there is no local
+    // stream (runIdRef is null), but the loaded conversation carries active_run.
+    // Stop must still send an expected-run guard so a late cancel can't kill a
+    // newer run.
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => {
+      result.current.setConversation({ ...CONV, active_run: { id: 'run-bg', status: 'running' } })
+    })
+
+    act(() => { result.current.stopStreaming() })
+
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1', 'run-bg')
+  })
+
+  it('editMessage is blocked while the conversation has an active background run', async () => {
+    // Regression for codex iter 8 P3: editing during a reattached active run
+    // must not optimistically truncate the transcript only to hit the 409.
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      active_run: { id: 'run-bg', status: 'running' },
+      messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }],
+      critiques: {},
+      artifacts: {},
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+    await act(async () => { await result.current.editMessage('u1', 'edited') })
+
+    expect(mockStreamChat).not.toHaveBeenCalled()
+    expect(result.current.messages.some(m => m.id === 'temp-edit')).toBe(false)
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -3,43 +3,39 @@ import { renderHook, act } from '@testing-library/react'
 import useChat from './useChat'
 
 // streamChat is the SSE driver. We replace it with a controllable fake that
-// captures the handlers, fires onRunStarted (so the hook learns the backend
-// run id), and then leaves the stream "in-flight" via a promise we resolve
-// from the test.
+// leaves the stream "in-flight" via a promise the test resolves, so we can
+// exercise Stop / navigate while a turn is mid-flight.
 const { mockStreamChat } = vi.hoisted(() => ({ mockStreamChat: vi.fn() }))
 vi.mock('../services/sse', () => ({
   streamChat: (...args) => mockStreamChat(...args),
 }))
 
-const { mockCancelRun, mockGetConversation } = vi.hoisted(() => ({
-  mockCancelRun: vi.fn(),
+const { mockCancelActiveRun, mockGetConversation } = vi.hoisted(() => ({
+  mockCancelActiveRun: vi.fn(),
   mockGetConversation: vi.fn(),
 }))
 vi.mock('../services/chat', () => ({
-  cancelRun: (...args) => mockCancelRun(...args),
+  cancelActiveRun: (...args) => mockCancelActiveRun(...args),
   getConversation: (...args) => mockGetConversation(...args),
 }))
 
 const CONV = { id: 'conv-1', main_service: 'vllm-test' }
 
-// streamChat fake: synchronously emit run_started, then return a promise that
-// only resolves when the test calls the stored resolver. Returns that resolver
-// via the `pending` ref so the test can end the stream deterministically.
-function installInFlightStream(runId = 'run-123') {
+// streamChat fake: stay open until the test resolves it. Stop/navigation no
+// longer depend on a run_started frame (cancellation is by conversation id),
+// so the fake doesn't need to emit one.
+function installInFlightStream() {
   let resolveStream
   const streamDone = new Promise((res) => { resolveStream = res })
-  mockStreamChat.mockImplementation((_url, _body, handlers) => {
-    handlers.onRunStarted?.({ type: 'run_started', run_id: runId })
-    return streamDone
-  })
+  mockStreamChat.mockImplementation(() => streamDone)
   return { end: () => resolveStream() }
 }
 
 beforeEach(() => {
   mockStreamChat.mockReset()
-  mockCancelRun.mockReset()
+  mockCancelActiveRun.mockReset()
   mockGetConversation.mockReset()
-  mockCancelRun.mockResolvedValue({})
+  mockCancelActiveRun.mockResolvedValue({ run: null })
   mockGetConversation.mockResolvedValue({ ...CONV, messages: [], critiques: {}, artifacts: {} })
 })
 
@@ -48,8 +44,8 @@ afterEach(() => {
 })
 
 describe('useChat stop/cancel wiring', () => {
-  it('stopStreaming cancels the backend run captured from run_started', async () => {
-    installInFlightStream('run-123')
+  it('stopStreaming cancels the conversation\'s active run by conversation id', async () => {
+    installInFlightStream()
     const { result } = renderHook(() => useChat({}))
 
     act(() => { result.current.setConversation(CONV) })
@@ -63,15 +59,35 @@ describe('useChat stop/cancel wiring', () => {
 
     act(() => { result.current.stopStreaming() })
 
-    expect(mockCancelRun).toHaveBeenCalledTimes(1)
-    expect(mockCancelRun).toHaveBeenCalledWith('run-123')
+    expect(mockCancelActiveRun).toHaveBeenCalledTimes(1)
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
     expect(result.current.streaming).toBe(false)
+  })
+
+  it('Stop cancels even when no run_started frame has been received yet', async () => {
+    // The whole point of cancel-by-conversation: the server creates the run
+    // when the turn starts, so Stop works without the client first capturing a
+    // run id. Earlier (run-id-keyed) designs could orphan the run in this
+    // window; this asserts the cancel POST always fires.
+    installInFlightStream()
+    const { result } = renderHook(() => useChat({}))
+
+    act(() => { result.current.setConversation(CONV) })
+
+    await act(async () => {
+      result.current.sendMessage('hello')
+      await Promise.resolve()
+    })
+
+    act(() => { result.current.stopStreaming() })
+
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
   })
 
   it('switching conversation during a run does NOT cancel the backend run', async () => {
     // Background-run semantics: navigating away leaves the run going so it
     // finishes and persists. Only an explicit Stop cancels it.
-    installInFlightStream('run-456')
+    installInFlightStream()
     const { result } = renderHook(() => useChat({}))
 
     act(() => { result.current.setConversation(CONV) })
@@ -85,9 +101,7 @@ describe('useChat stop/cancel wiring', () => {
       await result.current.loadConversation('conv-2')
     })
 
-    expect(mockCancelRun).not.toHaveBeenCalled()
-    // The observer detaches locally (streaming flips off) but the server run
-    // is untouched.
+    expect(mockCancelActiveRun).not.toHaveBeenCalled()
     expect(result.current.streaming).toBe(false)
   })
 
@@ -96,7 +110,7 @@ describe('useChat stop/cancel wiring', () => {
     // creation, but the optimistic temp-user row would be stripped by the next
     // send's save handler. Stop must refetch so the stopped prompt survives
     // with a real (non-temp) id.
-    installInFlightStream('run-1')
+    installInFlightStream()
     mockGetConversation.mockResolvedValue({
       ...CONV,
       messages: [{ id: 'msg-1', role: 'user', content: 'first', seq: 1 }],
@@ -111,56 +125,20 @@ describe('useChat stop/cancel wiring', () => {
       result.current.sendMessage('first')
       await Promise.resolve()
     })
-    // Optimistic row is present and temporary at this point.
     expect(result.current.messages.some(m => m.id === 'temp-user')).toBe(true)
 
     await act(async () => {
       result.current.stopStreaming()
-      // Let cancelRun resolve and the trailing refetch settle.
       await Promise.resolve()
       await Promise.resolve()
       await Promise.resolve()
     })
 
-    expect(mockCancelRun).toHaveBeenCalledWith('run-1')
+    expect(mockCancelActiveRun).toHaveBeenCalledWith('conv-1')
     // The stopped prompt now carries the persisted id, not 'temp-user', so the
     // next send's `filter(m => m.id !== 'temp-user')` can no longer drop it.
     expect(result.current.messages.some(m => m.id === 'temp-user')).toBe(false)
     expect(result.current.messages.some(m => m.id === 'msg-1' && m.content === 'first')).toBe(true)
-  })
-
-  it('Stop pressed before run_started defers cancellation until the run id arrives', async () => {
-    // Regression for codex iter 2 P2: the server creates the run before
-    // emitting run_started. A Stop in that window has no id to target; aborting
-    // the fetch then would drop the run_started frame and orphan the background
-    // run. Stop must defer and cancel once the id lands.
-    let handlers
-    mockStreamChat.mockImplementation((_url, _body, h) => {
-      handlers = h
-      // No run_started yet; stream stays open.
-      return new Promise(() => {})
-    })
-    const { result } = renderHook(() => useChat({}))
-
-    act(() => { result.current.setConversation(CONV) })
-
-    await act(async () => {
-      result.current.sendMessage('hello')
-      await Promise.resolve()
-    })
-
-    // Stop before the id is known: UI reflects stopped immediately, but we
-    // can't cancel the server run yet.
-    act(() => { result.current.stopStreaming() })
-    expect(mockCancelRun).not.toHaveBeenCalled()
-    expect(result.current.streaming).toBe(false)
-
-    // The id finally arrives — deferred cancel fires now.
-    await act(async () => {
-      handlers.onRunStarted({ type: 'run_started', run_id: 'run-late' })
-      await Promise.resolve()
-    })
-    expect(mockCancelRun).toHaveBeenCalledWith('run-late')
   })
 
   it('a late Stop refetch does not clobber a conversation the user navigated to', async () => {
@@ -168,10 +146,10 @@ describe('useChat stop/cancel wiring', () => {
     // settles. If the user navigates A -> B while the cancel POST is in flight,
     // the A refetch must NOT overwrite B (refetchMessages writes conversation
     // /messages directly).
-    installInFlightStream('run-A')
+    installInFlightStream()
     // Hold the cancel POST open so its reconcile finally runs LAST.
     let resolveCancel
-    mockCancelRun.mockImplementation(() => new Promise((res) => { resolveCancel = res }))
+    mockCancelActiveRun.mockImplementation(() => new Promise((res) => { resolveCancel = res }))
     mockGetConversation.mockImplementation((id) =>
       Promise.resolve(
         id === 'conv-2'
@@ -199,30 +177,18 @@ describe('useChat stop/cancel wiring', () => {
 
     // A's cancel resolves LAST — its reconcile must be gated out.
     await act(async () => {
-      resolveCancel()
+      resolveCancel({ run: null })
       await Promise.resolve()
       await Promise.resolve()
     })
     expect(result.current.conversation.id).toBe('conv-2')
   })
 
-  it('stopStreaming does not cancel when run_started never arrives', async () => {
-    // Stream that never emits run_started (e.g. an early HTTP error path).
-    // Stop defers, but with no id ever delivered there is nothing to cancel.
-    let resolveStream
-    mockStreamChat.mockImplementation(() => new Promise((res) => { resolveStream = res }))
+  it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
-
-    act(() => { result.current.setConversation(CONV) })
-
-    await act(async () => {
-      result.current.sendMessage('hello')
-      await Promise.resolve()
-    })
-
+    // No conversation loaded.
     act(() => { result.current.stopStreaming() })
-
-    expect(mockCancelRun).not.toHaveBeenCalled()
-    if (resolveStream) resolveStream()
+    expect(mockCancelActiveRun).not.toHaveBeenCalled()
+    expect(result.current.streaming).toBe(false)
   })
 })

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -57,3 +57,12 @@ export async function cancelRun(runId) {
     method: 'POST',
   })
 }
+
+// Cancel a conversation's active run by conversation id. The Stop button uses
+// this so cancellation never depends on having captured the run id from the
+// run_started frame — the server can always find the run from the conversation.
+export async function cancelActiveRun(conversationId) {
+  return fetchAPI(`/chat/conversations/${conversationId}/cancel-active-run`, {
+    method: 'POST',
+  })
+}

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -61,8 +61,11 @@ export async function cancelRun(runId) {
 // Cancel a conversation's active run by conversation id. The Stop button uses
 // this so cancellation never depends on having captured the run id from the
 // run_started frame — the server can always find the run from the conversation.
-export async function cancelActiveRun(conversationId) {
+// expectedRunId, when known, is sent as a guard so a late-arriving cancel can't
+// kill a newer run that started after the one the user actually stopped.
+export async function cancelActiveRun(conversationId, expectedRunId = null) {
   return fetchAPI(`/chat/conversations/${conversationId}/cancel-active-run`, {
     method: 'POST',
+    body: JSON.stringify(expectedRunId ? { expected_run_id: expectedRunId } : {}),
   })
 }

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -45,3 +45,15 @@ export async function requestCritique(messageId, { contextWindow = 10, extraInst
 export async function getCritique(messageId) {
   return fetchAPI(`/chat/messages/${messageId}/critique`)
 }
+
+// -- Runs (background-run observation + cancellation, issue #58) --
+
+export async function getRun(runId) {
+  return fetchAPI(`/chat/runs/${runId}`)
+}
+
+export async function cancelRun(runId) {
+  return fetchAPI(`/chat/runs/${runId}/cancel`, {
+    method: 'POST',
+  })
+}

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -8,7 +8,7 @@ const API_BASE = window.location.hostname === 'localhost' || window.location.hos
  * Stream a chat completion via SSE.
  * Uses fetch + ReadableStream because EventSource doesn't support auth headers.
  */
-export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, onParseWarning, signal, method = 'POST' }) {
+export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, onParseWarning, onRunStarted, signal, method = 'POST' }) {
   const token = getToken()
   if (!token) throw new Error('Not authenticated')
 
@@ -59,6 +59,13 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
           const parsed = JSON.parse(data)
 
           // Custom events from backend
+          if (parsed.type === 'run_started') {
+            // Background run id, emitted first — lets the client cancel the
+            // backend run (POST /chat/runs/<id>/cancel) instead of only
+            // aborting the SSE fetch.
+            onRunStarted?.(parsed)
+            continue
+          }
           if (parsed.type === 'message_saved') {
             onMessageSaved?.(parsed)
             continue

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -195,6 +195,37 @@ def test_cancel_active_run_by_conversation_no_active_run_is_noop(ctx):
     assert db.get_chat_run(run.id).status == "completed"  # untouched
 
 
+def test_cancel_active_run_by_conversation_expected_run_id_matches(ctx):
+    # When the expected run id matches the active run, it cancels normally.
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run",
+        json={"expected_run_id": run.id}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["run"]["id"] == run.id
+    assert db.get_chat_run(run.id).status == "cancelled"
+
+
+def test_cancel_active_run_by_conversation_stale_expected_run_id_is_noop(ctx):
+    # The iter-4 race: a Stop meant for run A arrives after A finished and a
+    # newer run B is active. With expected_run_id=A, B must NOT be cancelled.
+    app, db, _ = ctx
+    conv = _conv(db)
+    run_a = _run_row(db, conv, ChatRunStatus.RUNNING)
+    db.complete_chat_run(run_a.id)
+    run_b = _run_row(db, conv, ChatRunStatus.RUNNING)  # newer active run
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run",
+        json={"expected_run_id": run_a.id}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["run"] is None
+    # B is untouched; A stays completed.
+    assert db.get_chat_run(run_b.id).status == "running"
+    assert db.get_chat_run(run_a.id).status == "completed"
+
+
 def test_cancel_active_run_by_conversation_unknown_conversation_404(ctx):
     r = ctx[0].test_client().post(
         "/api/chat/conversations/nope/cancel-active-run", headers=_auth())

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -152,6 +152,91 @@ def test_cancel_not_found(ctx):
     assert r.status_code == 404
 
 
+# -- Cancel active run by conversation (Stop button, Phase 6) ------------
+
+
+def test_cancel_active_run_by_conversation(ctx):
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run", headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["run"]["id"] == run.id
+    assert body["run"]["status"] == "cancelled"
+    assert db.get_chat_run(run.id).status == "cancelled"
+    assert db.get_active_run_for_conversation(conv.id) is None
+
+
+def test_cancel_active_run_by_conversation_cancels_queued(ctx):
+    # Stop must work before the run starts executing (queued), not only while
+    # running — the early-Stop window the cancel-by-conversation path closes.
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _seed_queued(db, conv)
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["run"]["id"] == run.id
+    assert db.get_chat_run(run.id).status == "cancelled"
+
+
+def test_cancel_active_run_by_conversation_no_active_run_is_noop(ctx):
+    # No active run (e.g. it already finished) → 200 with run: null, no error.
+    app, db, _ = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    db.complete_chat_run(run.id)
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["run"] is None
+    assert db.get_chat_run(run.id).status == "completed"  # untouched
+
+
+def test_cancel_active_run_by_conversation_unknown_conversation_404(ctx):
+    r = ctx[0].test_client().post(
+        "/api/chat/conversations/nope/cancel-active-run", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_cancel_active_run_by_conversation_requires_auth(ctx):
+    r = ctx[0].test_client().post("/api/chat/conversations/x/cancel-active-run")
+    assert r.status_code == 401
+
+
+def test_cancel_active_run_by_conversation_stops_run_midstream(ctx, monkeypatch):
+    """Cancel-by-conversation during streaming stops the model and writes no
+    assistant message — same cooperative cancellation as the run-id path, but
+    targeted without the client ever knowing the run id."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _seed_queued(db, conv)
+
+    midstream = threading.Event()
+
+    def stub():
+        for i in range(100000):
+            yield _delta(f"t{i}")
+            if i == 2:
+                midstream.set()
+            time.sleep(0.002)
+        yield ("done", {"content": "should not finish", "reasoning_content": None})
+
+    _patch(monkeypatch, stub)
+    manager.start(conv, run, is_first=False, first_user_content="hi")
+    assert midstream.wait(2), "stream never reached mid-flight"
+
+    r = app.test_client().post(
+        f"/api/chat/conversations/{conv.id}/cancel-active-run", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["run"]["id"] == run.id
+
+    assert wait_for(lambda: db.get_chat_run(run.id).status == "cancelled")
+    assert [m.role for m in db.get_messages(conv.id)] == ["user"]  # no assistant
+
+
 def test_cancel_stops_run_midstream(ctx, monkeypatch):
     """A cancel during streaming stops the model and writes no assistant
     message (cooperative cancellation)."""


### PR DESCRIPTION
Part of #58 (rearchitect chat runtime for background runs).

Decouples the chat UI from the SSE response so it **observes** a server-side run rather than owning it. Builds on the Phase 5 run-observation/cancellation APIs.

## Changes
- **services/sse.js** — dispatch the `run_started` frame via `onRunStarted`, so the client learns the backend run id.
- **services/chat.js** — `getRun()` / `cancelRun()` against the Phase 5 endpoints.
- **hooks/useChat.js** — capture the run id from `run_started`; `stopStreaming` now cancels the **server** run (`POST /runs/<id>/cancel`) before aborting the fetch. Navigation (`loadConversation` / unmount) deliberately does **not** cancel — the run finishes and persists in the background.
- **ChatSidebar.jsx** — spinner badge on rows whose conversation has a queued/running `active_run` (data already supplied by `_attach_active_runs`).
- **McpToggle.jsx** — controlled mode: with an `onChange` prop the toggle returns the next server list in-memory and persists nothing (clears the way for non-persisted modes like Ghost Chat #57); otherwise falls back to the persisted PUT path.

## Tests
- `ChatSidebar.test.jsx` — active-run badge for running / queued / none.
- `McpToggle.test.jsx` — controlled (`onChange`) vs persisted (`updateConversation`) modes.
- `useChat.test.jsx` — Stop cancels the captured run; switching conversation does **not** cancel; no-run-id Stop is a cancel no-op.

97 frontend tests pass; `npm run build` clean. Lint unchanged (8 pre-existing errors on base, 0 new).

## Out of scope (Phase 7)
Live sidebar refresh of `active_run` and failed-run error surfacing after refetch.