### PR TITLE
Phase 7 (#58): sidebar active-run indicators + failed-run surfacing

### DIFF
--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -176,6 +176,8 @@ class ChatDB:
             conv.messages = self.get_messages(conv_id, conn=conn)
             run = self._active_run_for(conn, conv_id)
             conv.active_run = run.active_run_dict() if run else None
+            last = self._latest_run_for(conn, conv_id)
+            conv.last_run = last.last_run_dict() if last else None
             return conv
         finally:
             self._close_conn(conn)
@@ -518,6 +520,20 @@ class ChatDB:
                 WHERE conversation_id = ? AND status IN ({placeholders})
                 ORDER BY created_at DESC, rowid DESC LIMIT 1""",
             (conv_id, *sorted(ACTIVE_STATUSES)),
+        ).fetchone()
+        return self._row_to_chat_run(row) if row else None
+
+    def _latest_run_for(self, conn: sqlite3.Connection, conv_id: str) -> Optional[ChatRun]:
+        """Most recent run for a conversation regardless of status, or None.
+
+        Unlike _active_run_for this includes terminal runs, so the caller can
+        surface a failed background run's error after the fact. Same
+        created_at/rowid ordering as _active_run_for for a consistent tiebreak.
+        """
+        row = conn.execute(
+            """SELECT * FROM chat_runs WHERE conversation_id = ?
+               ORDER BY created_at DESC, rowid DESC LIMIT 1""",
+            (conv_id,),
         ).fetchone()
         return self._row_to_chat_run(row) if row else None
 

--- a/dashboard/chat/models.py
+++ b/dashboard/chat/models.py
@@ -123,6 +123,18 @@ class ChatRun:
             "started_at": self.started_at,
         }
 
+    def last_run_dict(self):
+        """Trimmed shape for the most-recent run on a single conversation load.
+
+        Carries `error` (unlike active_run_dict) so the chat area can surface a
+        background run that failed while the user was elsewhere.
+        """
+        return {
+            "id": self.id,
+            "status": self.status,
+            "error": self.error,
+        }
+
 
 @dataclass
 class Conversation:
@@ -141,6 +153,11 @@ class Conversation:
     # Populated by the DB layer from chat_runs (not a stored column). The
     # active_run_dict() shape of the conversation's queued/running run, or None.
     active_run: Optional[dict] = None
+    # last_run_dict() of the most recent run regardless of status, or None.
+    # Only populated on single-conversation loads; lets the chat area surface a
+    # failed run's error after refetch. Distinct from active_run, which is the
+    # trimmed shape for queued/running runs in list payloads.
+    last_run: Optional[dict] = None
 
     def to_dict(self, include_messages=False):
         d = {
@@ -154,6 +171,7 @@ class Conversation:
             "selected_text": self.selected_text,
             "mcp_servers": json.loads(self.mcp_servers_json) if self.mcp_servers_json else [],
             "active_run": self.active_run,
+            "last_run": self.last_run,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -78,6 +78,14 @@ export default function ChatPage() {
     }
   }, [streaming]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Refresh the list when a run starts (runReady) so the sidebar's active-run
+  // indicator appears for the active conversation, not only after it finishes.
+  useEffect(() => {
+    if (runReady) {
+      refresh()
+    }
+  }, [runReady]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleCreate = useCallback(async () => {
     // Default the main model to the first running service. When exactly
     // one model is up this preselects it; the backend requires a non-empty

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -80,6 +80,12 @@ export default function useChat({ onConversationUpdated } = {}) {
       setMessages(data.messages || [])
       setCritiques(data.critiques || {})
       setArtifacts(data.artifacts || {})
+      // Surface a run that failed while we weren't observing (e.g. a background
+      // run that errored after the browser disconnected). active_run is only
+      // queued/running, so a failure shows up via last_run instead.
+      if (data.last_run?.status === 'failed' && data.last_run.error) {
+        setError(data.last_run.error)
+      }
     } catch (err) {
       if (observedConvIdRef.current !== convId) return
       setError(err.message)

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -340,6 +340,40 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.runReady).toBe(true)
   })
 
+  it('surfaces a failed background run error on load via last_run', async () => {
+    // Phase 7: a run that failed while we weren't observing shows up as
+    // last_run (active_run is only queued/running). loadConversation must
+    // surface its error in the chat area.
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      active_run: null,
+      last_run: { id: 'r1', status: 'failed', error: 'model exploded' },
+      messages: [],
+      critiques: {},
+      artifacts: {},
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+
+    expect(result.current.error).toBe('model exploded')
+  })
+
+  it('does not surface an error when the last run completed', async () => {
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      last_run: { id: 'r1', status: 'completed', error: null },
+      messages: [],
+      critiques: {},
+      artifacts: {},
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+
+    expect(result.current.error).toBeNull()
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/tests/test_chat_runs.py
+++ b/dashboard/tests/test_chat_runs.py
@@ -232,6 +232,46 @@ def test_completed_run_clears_active_run_in_list():
     assert convs[0].active_run is None
 
 
+# -- last_run on single-conversation load (Phase 7) ---------------------
+
+
+def test_get_conversation_includes_last_run_none_when_no_runs():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    fetched = db.get_conversation(conv.id)
+    assert fetched.last_run is None
+    assert fetched.to_dict()["last_run"] is None
+
+
+def test_get_conversation_last_run_surfaces_failed_error():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    run = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.fail_chat_run(run.id, "model exploded")
+
+    fetched = db.get_conversation(conv.id)
+    # active_run is cleared (failed is terminal), but last_run carries the error.
+    assert fetched.active_run is None
+    assert fetched.last_run["status"] == "failed"
+    assert fetched.last_run["error"] == "model exploded"
+    assert fetched.to_dict()["last_run"]["error"] == "model exploded"
+
+
+def test_get_conversation_last_run_is_most_recent_by_insertion():
+    db = ChatDB(":memory:")
+    conv = _conv(db)
+    older = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.fail_chat_run(older.id, "old failure")
+    newer = db.create_chat_run(_run(conv, ChatRunStatus.RUNNING))
+    db.complete_chat_run(newer.id)
+
+    fetched = db.get_conversation(conv.id)
+    # Most recent run wins, so a later success hides the earlier failure.
+    assert fetched.last_run["id"] == newer.id
+    assert fetched.last_run["status"] == "completed"
+    assert fetched.last_run["error"] is None
+
+
 # -- deletion cleanup ---------------------------------------------------
 
 


### PR DESCRIPTION
Part of #58. Completes Phase 7 (the queued/running sidebar badges already landed with Phase 6 #65).

## Changes
- **Failed background run surfacing.** `active_run` only covers queued/running, so a run that failed while the user was elsewhere had no channel to the UI. `get_conversation` now also attaches `last_run` — the most recent run of any status (`_latest_run_for`), carrying its `error` — serialized in `Conversation.to_dict`. `useChat.refetchMessages` sets the chat-area error from `last_run` when its status is `failed`, so returning to the conversation shows what went wrong. A later successful run hides the earlier failure (most-recent wins).
- **Indicators update on run start.** `ChatPage` now refreshes the conversation list on `runReady` (the run is in the DB and active), in addition to the existing refresh on stream completion — so the sidebar spinner appears when a run starts, not only after it finishes.

## Tests
- Backend (`test_chat_runs.py`): `last_run` is null with no runs; surfaces a failed run's error; most-recent run wins (later success hides earlier failure).
- Frontend (`useChat.test.jsx`): a failed `last_run` surfaces its error on load; a completed `last_run` leaves the error clean.

113 frontend + 304 backend tests pass; `npm run build` clean; lint unchanged (8 pre-existing errors, 0 new).

## Acceptance criteria (#58 Phase 7)
- ✅ Conversation list shows active state without loading the full conversation (`_attach_active_runs`, Phase 6).
- ✅ Active indicators update after a run starts (new `runReady` refresh) and after it completes (existing).
- ✅ Failed run on the active conversation shows the error in the chat area after refetch.
- ✅ Indicator does not shift row layout (flex + truncate, Phase 6).