### PR TITLE
Phase 8 (#58): persistence-policy seam to prepare for Ghost Chat (#57)

### DIFF
--- a/dashboard/chat/persistence.py
+++ b/dashboard/chat/persistence.py
@@ -1,0 +1,115 @@
+"""Persistence policy seam for the chat runtime (Phase 8 of #58).
+
+The runtime (ChatRunner) drives the model/tool stream and publishes events; how
+— or whether — a turn is durably stored is delegated to a PersistencePolicy.
+This is the architectural hook Ghost Chat (#57) needs: the same model/tool
+stream can run DB-backed or fully ephemeral by swapping the policy, with no
+change to the runtime or the SSE-encoding layer.
+
+Two policies ship here:
+
+  - DbPersistencePolicy wraps a ChatDB and reproduces the previous inline
+    behavior exactly (claim → complete/fail/cancel against chat_runs, message +
+    artifacts written atomically).
+  - NullPersistencePolicy performs no durable writes. It keeps the transcript in
+    memory so a multi-turn ephemeral session stays coherent, and returns
+    synthetic run/message objects whose shape matches the DB path so the
+    runtime's control flow is identical either way.
+
+The policy intentionally covers only the per-turn runtime writes. Run-manager
+orchestration (recovery, the cancel registry, list/active lookups) stays on the
+DB directly — those are durable-coordination concerns, not part of running a
+single stream, and an ephemeral mode wires up its own (or no) manager.
+"""
+from .models import ChatRun
+from .runs import ChatRunStatus
+
+
+class PersistencePolicy:
+    """Interface the runtime uses to read prior turns and record this one.
+
+    Implementations must be safe to call from the runner's worker thread.
+    """
+
+    def load_messages(self, conv):
+        """Return the ordered message history used to build the prompt."""
+        raise NotImplementedError
+
+    def claim_running(self, run_id):
+        """Transition the run to RUNNING and return it (with a `.status`), or
+        return a non-running run / None to signal the claim was lost (e.g. the
+        run was cancelled before the worker picked it up)."""
+        raise NotImplementedError
+
+    def complete(self, run_id, assistant_msg, artifacts):
+        """Persist the assistant message + artifacts and mark the run completed,
+        atomically. Return the saved message (with `.id` and `.seq`), or None if
+        the run was already terminal (cancelled mid-stream)."""
+        raise NotImplementedError
+
+    def fail(self, run_id, error):
+        """Mark the run failed with the given error text."""
+        raise NotImplementedError
+
+    def cancel(self, run_id):
+        """Mark the run cancelled (idempotent)."""
+        raise NotImplementedError
+
+
+class DbPersistencePolicy(PersistencePolicy):
+    """The durable policy: every operation goes to ChatDB exactly as the runtime
+    did inline before this seam existed."""
+
+    def __init__(self, db):
+        self.db = db
+
+    def load_messages(self, conv):
+        return self.db.get_messages(conv.id)
+
+    def claim_running(self, run_id):
+        return self.db.update_chat_run_status(
+            run_id, ChatRunStatus.RUNNING, active_step="generating")
+
+    def complete(self, run_id, assistant_msg, artifacts):
+        return self.db.complete_run_with_message(run_id, assistant_msg, artifacts)
+
+    def fail(self, run_id, error):
+        self.db.fail_chat_run(run_id, error)
+
+    def cancel(self, run_id):
+        self.db.cancel_chat_run(run_id)
+
+
+class NullPersistencePolicy(PersistencePolicy):
+    """The ephemeral policy: no durable writes (Ghost Chat, #57).
+
+    Holds the transcript in memory so prompts build correctly across turns and a
+    completed assistant turn is visible to the next one. Lifecycle transitions
+    are no-ops that return synthetic objects shaped like the DB path's, so the
+    runtime takes the same branches.
+    """
+
+    def __init__(self, messages=None):
+        # The in-memory transcript. Seed it with the prior turns (including the
+        # current user message) the way the DB path would have persisted them.
+        self.messages = list(messages) if messages else []
+
+    def load_messages(self, conv):
+        return self.messages
+
+    def claim_running(self, run_id):
+        # No row to transition; synthesize a RUNNING run so the runner proceeds.
+        return ChatRun(id=run_id, conversation_id="", status=ChatRunStatus.RUNNING)
+
+    def complete(self, run_id, assistant_msg, artifacts):
+        # Assign a seq from the in-memory transcript (the DB path assigns it
+        # inside the atomic write) and append so the next turn sees this reply.
+        assistant_msg.seq = (self.messages[-1].seq + 1) if self.messages else 1
+        self.messages.append(assistant_msg)
+        return assistant_msg
+
+    def fail(self, run_id, error):
+        pass
+
+    def cancel(self, run_id):
+        pass

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -157,6 +157,18 @@ class ChatRunner:
             status = started.status if started else "cancelled"
             self._emit(run_id, f"run_{status}", {"run_id": run_id})
             return None
+        # Pre-start cancellation: honor a cancel that arrived while the run was
+        # still queued BEFORE opening the (costly) model/tool stream. The DB
+        # path usually catches this via the terminal-guarded claim above (a
+        # cancelled queued row fails the RUNNING transition), but a policy with
+        # no terminal row — NullPersistencePolicy — would otherwise build the
+        # stream and only notice the cancel after the first chunk. Checking here
+        # keeps both policies on the same branch and stops Ghost Chat's Stop
+        # from kicking off an LLM request it immediately abandons.
+        if cancel_check is not None and cancel_check():
+            persistence.cancel(run_id)
+            self._emit(run_id, "run_cancelled", {"run_id": run_id})
+            return None
         self._emit(run_id, "run_started", {"run_id": run_id, "conversation_id": conv.id})
 
         assistant_msg_id = str(uuid.uuid4())

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -33,6 +33,7 @@ from .runs import ChatRunStatus
 from .llm_proxy import stream_chat_completion
 from .tool_loop import stream_with_tools
 from .prompt_builder import build_chat_messages
+from .persistence import DbPersistencePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -107,16 +108,21 @@ class ChatTurnRequest:
 
 
 class ChatRunner:
-    def __init__(self, db, event_bus=None):
+    def __init__(self, db=None, event_bus=None, persistence=None):
+        # Persistence is delegated to a policy so the same stream can run
+        # DB-backed or ephemeral (Ghost Chat, #57). Default to the durable
+        # policy built from `db` so existing callers are unchanged; pass an
+        # explicit `persistence` to override (e.g. NullPersistencePolicy).
         self.db = db
         self.event_bus = event_bus
+        self.persistence = persistence or DbPersistencePolicy(db)
 
     def _emit(self, run_id: str, type: str, data: dict = None):
         if self.event_bus is not None:
             self.event_bus.publish(run_id, ChatRuntimeEvent(type, data or {}))
 
     def _build_stream(self, conv: Conversation, mcp_manager):
-        messages = self.db.get_messages(conv.id)
+        messages = self.persistence.load_messages(conv)
         enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
         messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
         tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None
@@ -138,15 +144,15 @@ class ChatRunner:
         a fully-silent generation is only interrupted once the next event or
         chunk arrives.
         """
-        db = self.db
+        persistence = self.persistence
         conv = request.conversation
         mcp_manager = request.mcp_manager
         run_id = run.id
 
-        # Claim the run. update_chat_run_status no-ops on a terminal row, so if
-        # the run was cancelled before the worker picked it up, the transition
+        # Claim the run. The durable policy no-ops on a terminal row, so if the
+        # run was cancelled before the worker picked it up, the transition
         # doesn't win — do no work and surface the terminal state.
-        started = db.update_chat_run_status(run_id, ChatRunStatus.RUNNING, active_step="generating")
+        started = persistence.claim_running(run_id)
         if started is None or started.status != ChatRunStatus.RUNNING:
             status = started.status if started else "cancelled"
             self._emit(run_id, f"run_{status}", {"run_id": run_id})
@@ -171,7 +177,7 @@ class ChatRunner:
                         stream.close()
                     except Exception:
                         logger.exception("error closing stream on cancel for run %s", run_id)
-                    db.cancel_chat_run(run_id)  # idempotent if already cancelled
+                    persistence.cancel(run_id)  # idempotent if already cancelled
                     self._emit(run_id, "run_cancelled", {"run_id": run_id})
                     return None
                 if event_type == "delta":
@@ -225,10 +231,10 @@ class ChatRunner:
                         )
                         for art in collected_artifacts
                     ]
-                    # Atomic + terminal-guarded: writes the message, artifacts,
-                    # and the completed status together, or nothing if the run
-                    # was cancelled mid-stream.
-                    saved = db.complete_run_with_message(run_id, assistant_msg, artifacts)
+                    # Atomic + terminal-guarded (durable policy): writes the
+                    # message, artifacts, and the completed status together, or
+                    # nothing if the run was cancelled mid-stream.
+                    saved = persistence.complete(run_id, assistant_msg, artifacts)
                     if saved is None:
                         self._emit(run_id, "run_cancelled", {"run_id": run_id})
                         return None
@@ -244,6 +250,6 @@ class ChatRunner:
             return self._fail(run_id, str(exc) or "internal error")
 
     def _fail(self, run_id: str, error: str) -> None:
-        self.db.fail_chat_run(run_id, error)
+        self.persistence.fail(run_id, error)
         self._emit(run_id, "run_failed", {"error": error})
         return None

--- a/dashboard/tests/test_chat_persistence.py
+++ b/dashboard/tests/test_chat_persistence.py
@@ -165,6 +165,32 @@ def test_null_policy_failure_does_not_persist(tmp_path, monkeypatch):
     assert [m.role for m in policy.messages] == ["user"]
 
 
+def test_null_policy_pre_start_cancel_does_not_open_stream(monkeypatch):
+    # A run cancelled while still queued (cancel_check already true) must NOT
+    # open the model stream. The DB path gets this from its terminal-guarded
+    # claim; the null policy needs the explicit pre-start check.
+    opened = {"iterated": False}
+
+    def _factory():
+        opened["iterated"] = True  # runs only if the stream is iterated
+        yield _delta("should not happen")
+        yield ("done", {"content": "nope", "reasoning_content": None})
+
+    _patch_stream(monkeypatch, _factory)
+    conv = _conv()
+    policy = NullPersistencePolicy(messages=[_user_msg(conv)])
+    bus = _RecordingBus()
+    run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+
+    saved = ChatRunner(persistence=policy, event_bus=bus).run(
+        run, ChatTurnRequest(conversation=conv), cancel_check=lambda: True)
+
+    assert saved is None
+    assert opened["iterated"] is False        # the costly stream never opened
+    assert bus.types() == ["run_cancelled"]   # no run_started for a pre-start cancel
+    assert [m.role for m in policy.messages] == ["user"]  # no assistant appended
+
+
 # -- seam shape ----------------------------------------------------------
 
 

--- a/dashboard/tests/test_chat_persistence.py
+++ b/dashboard/tests/test_chat_persistence.py
@@ -1,0 +1,180 @@
+"""Persistence-policy seam for the chat runtime (Phase 8 of #58).
+
+Runs the SAME monkeypatched model stream through ChatRunner under two
+policies — DbPersistencePolicy (durable) and NullPersistencePolicy (ephemeral)
+— and asserts the runtime drives an identical event stream either way, while
+only the durable policy writes to SQLite. This is the architectural hook Ghost
+Chat (#57) needs.
+"""
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import runtime
+from chat.db import ChatDB
+from chat.models import Conversation, Message, ChatRun
+from chat.runs import ChatRunStatus
+from chat.runtime import ChatRunner, ChatTurnRequest
+from chat.persistence import (
+    DbPersistencePolicy,
+    NullPersistencePolicy,
+    PersistencePolicy,
+)
+
+
+class _RecordingBus:
+    """Captures the (type, data) of every runtime event the runner publishes."""
+
+    def __init__(self):
+        self.events = []
+
+    def publish(self, run_id, event):
+        self.events.append(event)
+
+    def types(self):
+        return [e.type for e in self.events]
+
+
+def _delta(content, reasoning=""):
+    return ("delta", {"content": content, "reasoning_content": reasoning,
+                      "raw": json.dumps({"choices": [{"delta": {"content": content}}]})})
+
+
+def _patch_stream(monkeypatch, factory):
+    def _wrap(*a, **k):
+        return factory()
+    monkeypatch.setattr(runtime, "stream_chat_completion", _wrap)
+    monkeypatch.setattr(runtime, "stream_with_tools", _wrap)
+
+
+def _stub():
+    yield _delta("Hello ")
+    yield _delta("world")
+    yield ("done", {"content": "Hello world", "reasoning_content": None})
+
+
+def _conv():
+    return Conversation(id=str(uuid.uuid4()), title="t", main_service="svc")
+
+
+def _user_msg(conv):
+    return Message(id=str(uuid.uuid4()), conversation_id=conv.id, role="user",
+                   content="hi", seq=1)
+
+
+# -- durable policy ------------------------------------------------------
+
+
+def test_db_policy_persists_and_completes(tmp_path, monkeypatch):
+    _patch_stream(monkeypatch, _stub)
+    db = ChatDB(str(tmp_path / "chat.db"))
+    conv = _conv()
+    db.create_conversation(conv)
+    user = _user_msg(conv)
+    db.add_message(user)
+    run = db.create_chat_run(ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                                     status=ChatRunStatus.QUEUED, user_message_id=user.id))
+    bus = _RecordingBus()
+
+    runner = ChatRunner(db, event_bus=bus)
+    saved = runner.run(run, ChatTurnRequest(conversation=conv))
+
+    assert saved is not None
+    assert saved.content == "Hello world"
+    # Durable: the assistant message and completed status are in SQLite.
+    roles = [m.role for m in db.get_messages(conv.id)]
+    assert roles == ["user", "assistant"]
+    assert db.get_chat_run(run.id).status == "completed"
+    assert bus.types() == ["run_started", "delta", "delta", "run_completed"]
+
+
+# -- ephemeral policy ----------------------------------------------------
+
+
+def test_null_policy_runs_without_persisting(tmp_path, monkeypatch):
+    _patch_stream(monkeypatch, _stub)
+    # A real DB exists but the null policy must never touch it.
+    db = ChatDB(str(tmp_path / "chat.db"))
+    conv = _conv()
+    db.create_conversation(conv)
+
+    user = _user_msg(conv)
+    policy = NullPersistencePolicy(messages=[user])
+    bus = _RecordingBus()
+    run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+
+    runner = ChatRunner(persistence=policy, event_bus=bus)
+    saved = runner.run(run, ChatTurnRequest(conversation=conv))
+
+    assert saved is not None
+    assert saved.content == "Hello world"
+    # Ephemeral: nothing written to SQLite, but the transcript is kept in memory.
+    assert db.get_messages(conv.id) == []
+    assert db.get_chat_run(run.id) is None
+    assert [m.role for m in policy.messages] == ["user", "assistant"]
+    assert policy.messages[-1].seq == 2
+    assert bus.types() == ["run_started", "delta", "delta", "run_completed"]
+
+
+def test_same_stream_identical_events_across_policies(tmp_path, monkeypatch):
+    """Acceptance: the same model stream produces the same runtime event
+    sequence regardless of persistence policy."""
+    _patch_stream(monkeypatch, _stub)
+
+    db = ChatDB(str(tmp_path / "chat.db"))
+    conv = _conv()
+    db.create_conversation(conv)
+    user = _user_msg(conv)
+    db.add_message(user)
+    run = db.create_chat_run(ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id,
+                                     status=ChatRunStatus.QUEUED, user_message_id=user.id))
+    db_bus = _RecordingBus()
+    ChatRunner(db, event_bus=db_bus).run(run, ChatTurnRequest(conversation=conv))
+
+    null_bus = _RecordingBus()
+    null_run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+    ChatRunner(persistence=NullPersistencePolicy(messages=[_user_msg(conv)]),
+               event_bus=null_bus).run(null_run, ChatTurnRequest(conversation=conv))
+
+    assert db_bus.types() == null_bus.types()
+
+
+def test_null_policy_failure_does_not_persist(tmp_path, monkeypatch):
+    def _boom():
+        yield ("error", {"message": "model exploded"})
+
+    _patch_stream(monkeypatch, _boom)
+    db = ChatDB(str(tmp_path / "chat.db"))
+    conv = _conv()
+    db.create_conversation(conv)
+    policy = NullPersistencePolicy(messages=[_user_msg(conv)])
+    bus = _RecordingBus()
+    run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+
+    saved = ChatRunner(persistence=policy, event_bus=bus).run(
+        run, ChatTurnRequest(conversation=conv))
+
+    assert saved is None
+    assert bus.types() == ["run_started", "run_failed"]
+    # No assistant turn was appended on failure.
+    assert [m.role for m in policy.messages] == ["user"]
+
+
+# -- seam shape ----------------------------------------------------------
+
+
+def test_default_runner_uses_db_policy(tmp_path):
+    db = ChatDB(str(tmp_path / "chat.db"))
+    runner = ChatRunner(db)
+    assert isinstance(runner.persistence, DbPersistencePolicy)
+    assert runner.persistence.db is db
+
+
+def test_policies_implement_the_interface():
+    assert issubclass(DbPersistencePolicy, PersistencePolicy)
+    assert issubclass(NullPersistencePolicy, PersistencePolicy)


### PR DESCRIPTION
Final phase of #58. Introduces the persistence-policy seam Ghost Chat (#57) needs, **without** implementing Ghost Chat (explicit non-goal of this issue).

## Changes
- **`chat/persistence.py`** — `PersistencePolicy` interface + two implementations:
  - `DbPersistencePolicy` reproduces the runtime's previous inline behavior exactly (claim → complete/fail/cancel on `chat_runs`; message + artifacts written atomically).
  - `NullPersistencePolicy` performs **no** durable writes — keeps the transcript in memory and returns synthetic run/message objects shaped like the DB path's, so the runtime takes identical branches. This is the ephemeral mode Ghost Chat plugs into.
- **`chat/runtime.py`** — `ChatRunner` now delegates every per-turn read/write to a persistence policy, defaulting to `DbPersistencePolicy(db)` so existing callers are unchanged. Pass `persistence=NullPersistencePolicy(...)` to run the same stream ephemerally.

Run-manager orchestration (recovery, the cancel registry, active/list lookups) intentionally stays on the DB — those are durable-coordination concerns, not part of running a single stream; an ephemeral mode wires up its own (or no) manager.

## Acceptance criteria (issue #58)
- ✅ **Clear place for non-persisted chat modes** — `NullPersistencePolicy`.
- ✅ **SSE-encoding code does no DB writes** — already true after Phases 3–5 (`event_codec` / `_sse_frames_for` / `observe` only encode/read); runtime writes now route through the policy rather than calling `db` inline.
- ✅ **Same model/tool stream runs through different persistence policies** — `test_chat_persistence.py` asserts the Db and Null policies produce **identical** runtime event sequences while only the durable one writes to SQLite.

## Tests
`test_chat_persistence.py`: durable policy persists + completes; null policy runs without persisting (nothing in SQLite, transcript kept in memory); identical event stream across policies; null-policy failure persists nothing; default runner uses the DB policy.

Backend-only. **310 backend tests pass**; frontend unchanged (113 pass, build clean, lint unchanged).