### PR TITLE
Reattach to live run progress on return to an in-progress conversation

### DIFF
--- a/dashboard/chat/event_bus.py
+++ b/dashboard/chat/event_bus.py
@@ -21,10 +21,24 @@ import threading
 # terminates. Dropped middle deltas don't lose data: the DB has the full reply.
 SUBSCRIBER_QUEUE_MAX = 2048
 
+# Event type that marks a run fully finished. Matches run_manager.STREAM_END;
+# kept as a literal so the bus stays free of a run_manager import. On this event
+# the run's replay history is dropped (the run is over — reattachers fall back
+# to the DB).
+_STREAM_END_TYPE = "stream_end"
+
 
 class EventBus:
     def __init__(self):
         self._subscribers = {}  # run_id -> list[queue.Queue]
+        # run_id -> list[event]: the in-flight history of an active run, kept so
+        # a client that reattaches mid-run (navigated away and back) can replay
+        # everything generated before it subscribed. Appended in publish, dropped
+        # when the run ends (STREAM_END). Unlike the per-observer queues this is
+        # NOT bounded/evicted — losing the oldest deltas would blank the start of
+        # the reply on reattach — so it lives only for one active run at a time
+        # and is freed as soon as that run finishes.
+        self._replay = {}
         self._lock = threading.Lock()
 
     def subscribe(self, run_id: str) -> "queue.Queue":
@@ -33,6 +47,21 @@ class EventBus:
         with self._lock:
             self._subscribers.setdefault(run_id, []).append(q)
         return q
+
+    def subscribe_with_replay(self, run_id: str):
+        """Register an observer AND atomically capture the run's history so far.
+
+        Returns (queue, history). The snapshot and the queue registration happen
+        under one lock, so every in-flight event is delivered to the new observer
+        exactly once: events already published are in `history`; events published
+        after this call arrive on the queue. Used by the reattach endpoint so a
+        returning client replays the full in-progress turn before going live.
+        """
+        q = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAX)
+        with self._lock:
+            self._subscribers.setdefault(run_id, []).append(q)
+            history = list(self._replay.get(run_id, ()))
+        return q, history
 
     def unsubscribe(self, run_id: str, q: "queue.Queue") -> None:
         with self._lock:
@@ -54,11 +83,23 @@ class EventBus:
         evicted to make room, so a slow observer's memory stays bounded and the
         newest events (incl. the terminal stream_end) are preserved.
 
-        No-op when nobody is listening — the run keeps going regardless; the
-        event is simply not replayed (the DB holds the durable result).
+        Records the event in the run's replay history (so a later reattach can
+        replay it) and, on the terminal stream_end, drops that history. Both the
+        history append and the subscriber snapshot happen under the lock so a
+        concurrent subscribe_with_replay sees a consistent cut.
+
+        No-op for delivery when nobody is listening — the run keeps going
+        regardless; the event is simply not replayed live (the DB holds the
+        durable result), though it is still recorded for an in-flight reattach.
         """
+        is_end = getattr(event, "type", None) == _STREAM_END_TYPE
         with self._lock:
             subs = list(self._subscribers.get(run_id, ()))
+            if is_end:
+                # Run finished: future reattachers fall back to the DB.
+                self._replay.pop(run_id, None)
+            else:
+                self._replay.setdefault(run_id, []).append(event)
         for q in subs:
             while True:
                 try:

--- a/dashboard/chat/event_bus.py
+++ b/dashboard/chat/event_bus.py
@@ -10,8 +10,10 @@ run_id and get a Queue they drain; publishers push events to every current
 subscriber of that run. Thread-safe: the background runner publishes from a
 worker thread while SSE generators drain from request threads.
 """
+import json
 import queue
 import threading
+from collections import namedtuple
 
 # Per-observer queue cap. Generous enough to absorb a normal burst of token
 # deltas, but bounded so a live-but-non-draining client (TCP backpressure, a
@@ -21,23 +23,76 @@ import threading
 # terminates. Dropped middle deltas don't lose data: the DB has the full reply.
 SUBSCRIBER_QUEUE_MAX = 2048
 
-# Event type that marks a run fully finished. Matches run_manager.STREAM_END;
-# kept as a literal so the bus stays free of a run_manager import. On this event
-# the run's replay history is dropped (the run is over — reattachers fall back
-# to the DB).
-_STREAM_END_TYPE = "stream_end"
+# Event types after which a run is finished and its replay history is dropped
+# (future reattachers fall back to the DB). Includes the per-turn terminal
+# runtime events — so a ChatRunner used directly with a bus, which ends on
+# run_completed/run_failed/run_cancelled and never emits the manager-only
+# stream_end, still frees its history — as well as stream_end itself.
+_TERMINAL_TYPES = frozenset({"run_completed", "run_failed", "run_cancelled", "stream_end"})
+
+# A duck-typed stand-in for runtime.ChatRuntimeEvent, used only for the
+# coalesced delta a reattach replay emits. Has .type / .data like the real
+# event, so _sse_frames_for consumes it identically — and the bus stays free of
+# a runtime import.
+_ReplayEvent = namedtuple("_ReplayEvent", ["type", "data"])
+
+
+class _ReplayBuffer:
+    """A run's in-flight history, kept so a reattaching client can replay it.
+
+    Consecutive deltas are folded into a single accumulated segment, so memory
+    scales with the length of the generated text rather than the number of
+    token events (a long reply would otherwise retain one dict + raw-JSON string
+    per token until the run ends). Non-delta events (tool calls/results,
+    artifacts, parse warnings) are kept discrete and in order; a delta segment
+    that follows them starts fresh, preserving the per-round boundaries the
+    frontend relies on (it resets visible content after each tool result).
+    """
+    __slots__ = ("_segments",)
+
+    def __init__(self):
+        # Each segment is either a [content_parts, reasoning_parts] list (a run
+        # of coalesced deltas) or a non-delta event kept as-is.
+        self._segments = []
+
+    def add(self, event):
+        if getattr(event, "type", None) == "delta":
+            data = event.data or {}
+            tail = self._segments[-1] if self._segments else None
+            if isinstance(tail, list):
+                tail[0].append(data.get("content") or "")
+                tail[1].append(data.get("reasoning_content") or "")
+            else:
+                self._segments.append([[data.get("content") or ""],
+                                       [data.get("reasoning_content") or ""]])
+        else:
+            self._segments.append(event)
+
+    def snapshot(self):
+        """Materialize the history into replayable events (deltas coalesced)."""
+        out = []
+        for seg in self._segments:
+            if isinstance(seg, list):
+                content = "".join(seg[0])
+                reasoning = "".join(seg[1])
+                raw = json.dumps({"choices": [{"delta": {
+                    "content": content, "reasoning_content": reasoning}}]})
+                out.append(_ReplayEvent("delta", {
+                    "content": content, "reasoning_content": reasoning, "raw": raw}))
+            else:
+                out.append(seg)
+        return out
 
 
 class EventBus:
     def __init__(self):
         self._subscribers = {}  # run_id -> list[queue.Queue]
-        # run_id -> list[event]: the in-flight history of an active run, kept so
-        # a client that reattaches mid-run (navigated away and back) can replay
-        # everything generated before it subscribed. Appended in publish, dropped
-        # when the run ends (STREAM_END). Unlike the per-observer queues this is
-        # NOT bounded/evicted — losing the oldest deltas would blank the start of
-        # the reply on reattach — so it lives only for one active run at a time
-        # and is freed as soon as that run finishes.
+        # run_id -> _ReplayBuffer: the in-flight history of an active run, kept
+        # so a client that reattaches mid-run (navigated away and back) can
+        # replay everything generated before it subscribed. Folded in publish,
+        # dropped when the run ends (any terminal event). Deltas are coalesced so
+        # memory scales with text length, not token count; the buffer lives only
+        # while its run is in flight and is freed as soon as the run finishes.
         self._replay = {}
         self._lock = threading.Lock()
 
@@ -60,7 +115,8 @@ class EventBus:
         q = queue.Queue(maxsize=SUBSCRIBER_QUEUE_MAX)
         with self._lock:
             self._subscribers.setdefault(run_id, []).append(q)
-            history = list(self._replay.get(run_id, ()))
+            buf = self._replay.get(run_id)
+            history = buf.snapshot() if buf is not None else []
         return q, history
 
     def unsubscribe(self, run_id: str, q: "queue.Queue") -> None:
@@ -84,22 +140,27 @@ class EventBus:
         newest events (incl. the terminal stream_end) are preserved.
 
         Records the event in the run's replay history (so a later reattach can
-        replay it) and, on the terminal stream_end, drops that history. Both the
-        history append and the subscriber snapshot happen under the lock so a
-        concurrent subscribe_with_replay sees a consistent cut.
+        replay it) and, on any terminal event (run_completed / run_failed /
+        run_cancelled / stream_end), drops that history. Both the history fold
+        and the subscriber snapshot happen under the lock so a concurrent
+        subscribe_with_replay sees a consistent cut.
 
         No-op for delivery when nobody is listening — the run keeps going
         regardless; the event is simply not replayed live (the DB holds the
         durable result), though it is still recorded for an in-flight reattach.
         """
-        is_end = getattr(event, "type", None) == _STREAM_END_TYPE
+        is_terminal = getattr(event, "type", None) in _TERMINAL_TYPES
         with self._lock:
             subs = list(self._subscribers.get(run_id, ()))
-            if is_end:
+            if is_terminal:
                 # Run finished: future reattachers fall back to the DB.
                 self._replay.pop(run_id, None)
             else:
-                self._replay.setdefault(run_id, []).append(event)
+                buf = self._replay.get(run_id)
+                if buf is None:
+                    buf = _ReplayBuffer()
+                    self._replay[run_id] = buf
+                buf.add(event)
         for q in subs:
             while True:
                 try:

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -362,8 +362,8 @@ def stream_run(run_id):
             yield encode_sse_event("run_status", {"status": run.status, "error": run.error})
         return Response(terminal(), mimetype="text/event-stream", headers=headers)
 
-    q = manager.subscribe(run_id)
-    return Response(stream_with_context(manager.observe(run_id, q)),
+    q, replay = manager.subscribe_with_replay(run_id)
+    return Response(stream_with_context(manager.observe(run_id, q, replay)),
                     mimetype="text/event-stream", headers=headers)
 
 

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -177,10 +177,19 @@ class ChatRunManager:
     def subscribe(self, run_id: str):
         return self.event_bus.subscribe(run_id)
 
-    def observe(self, run_id: str, q):
+    def subscribe_with_replay(self, run_id: str):
+        """Subscribe and capture the run's in-flight history (for reattach)."""
+        return self.event_bus.subscribe_with_replay(run_id)
+
+    def observe(self, run_id: str, q, replay=()):
         """SSE generator: drain the bus queue for a run, emitting legacy SSE
         frames, until the STREAM_END sentinel. Injects heartbeats on idle so
         the connection stays alive during slow model output.
+
+        `replay` is the history captured atomically with the subscription (see
+        subscribe_with_replay): for a client reattaching mid-run it replays
+        everything generated before it subscribed, so the in-progress turn
+        renders in full before the live tail. Empty for the fresh-send path.
 
         Closing this generator (client disconnect) only unsubscribes — the
         background run keeps going.
@@ -193,6 +202,15 @@ class ChatRunManager:
             # _sse_frames_for to avoid a duplicate). Lets the client POST
             # /runs/<id>/cancel even for a still-queued run.
             yield encode_sse_event("run_started", {"run_id": run_id})
+            # Replay the in-flight history first so a reattaching client sees the
+            # content generated before it returned. These events are NOT on the
+            # live queue (the snapshot was taken atomically with the subscribe),
+            # so there is no duplication with the loop below.
+            for event in replay:
+                for frame in _sse_frames_for(event):
+                    yield frame
+                if event.type == STREAM_END:
+                    return
             while True:
                 try:
                     event = q.get(timeout=HEARTBEAT_INTERVAL_S)

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor, cleanup, act } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ChatPage from './ChatPage'
+
+// Stub the heavy presentational children — this test is about the
+// data/effect wiring in ChatPage, not what the sidebar/area render.
+vi.mock('./ChatSidebar', () => ({ default: () => null }))
+vi.mock('./ChatArea', () => ({ default: () => null }))
+
+// Running services come from an SSE hook; give it one model so the page
+// behaves as a normal authenticated session.
+vi.mock('../../hooks/useServicesSSE', () => ({
+  default: () => ({ services: [{ name: 'vllm-test', kind: 'chat' }], loading: false }),
+}))
+
+const { mockGetConversation, mockListConversations, mockCancelActiveRun } = vi.hoisted(() => ({
+  mockGetConversation: vi.fn(),
+  mockListConversations: vi.fn(),
+  mockCancelActiveRun: vi.fn(),
+}))
+vi.mock('../../services/chat', async (importActual) => ({
+  ...(await importActual()),
+  getConversation: (...a) => mockGetConversation(...a),
+  listConversations: (...a) => mockListConversations(...a),
+  cancelActiveRun: (...a) => mockCancelActiveRun(...a),
+}))
+
+// streamChat is never expected to fire here (no active run), but stub it to a
+// pending promise so an accidental call can't crash the test.
+const { mockStreamChat } = vi.hoisted(() => ({ mockStreamChat: vi.fn() }))
+vi.mock('../../services/sse', () => ({ streamChat: (...a) => mockStreamChat(...a) }))
+
+beforeEach(() => {
+  mockGetConversation.mockReset()
+  mockListConversations.mockReset()
+  mockStreamChat.mockReset()
+  mockGetConversation.mockResolvedValue({
+    id: 'abc', title: 'T', main_service: 'vllm-test',
+    messages: [], active_run: null, last_run: null,
+  })
+  mockListConversations.mockResolvedValue({ conversations: [] })
+  mockStreamChat.mockImplementation(() => new Promise(() => {}))
+})
+
+afterEach(() => cleanup())
+
+describe('ChatPage URL-load effect', () => {
+  it('loads the route conversation exactly once across parent rerenders', async () => {
+    // Regression for codex iteration 3 P1 on PR #69: ChatPage builds a fresh
+    // onConversationUpdated callback every render. The reattach work made
+    // loadConversation depend (transitively) on that callback; if it changed
+    // identity each render, the URL-load effect ([convId, loadConversation])
+    // would re-fire on every rerender and reload in a loop. useChat now holds
+    // the callback behind a ref so loadConversation stays stable.
+    // `tick` is ignored by the component; bumping it just forces the parent
+    // (and thus ChatPage) to re-render, re-running ChatPage's body and
+    // rebuilding the inline onConversationUpdated each time.
+    function Harness({ tick }) { // eslint-disable-line no-unused-vars
+      return (
+        <MemoryRouter initialEntries={['/chat/abc']}>
+          <Routes>
+            <Route path="/chat/:conversationId" element={<ChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      )
+    }
+
+    const { rerender } = render(<Harness tick={0} />)
+    await waitFor(() => expect(mockGetConversation).toHaveBeenCalledTimes(1))
+
+    // Force several parent rerenders. A stable loadConversation means the
+    // URL-load effect does not re-fire.
+    for (let i = 1; i <= 3; i++) {
+      await act(async () => { rerender(<Harness tick={i} />) })
+    }
+
+    // Give any spurious effect re-runs a chance to land before asserting.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mockGetConversation).toHaveBeenCalledTimes(1)
+    expect(mockGetConversation).toHaveBeenCalledWith('abc')
+  })
+})

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -89,13 +89,25 @@ export default function useChat({ onConversationUpdated } = {}) {
   // SSE stream. Used by the message_saved handler so we don't cancel our
   // own pipe before the trailing conversation_updated event (auto-title)
   // arrives.
-  const refetchMessages = useCallback(async (convId) => {
+  //
+  // `isFresh` is an optional predicate, re-checked AFTER the fetch resolves,
+  // that must still hold for the result to be committed. The id guard alone
+  // can't order two same-id fetches: with concurrent same-id loads the
+  // responses can arrive oldest-last, so an older snapshot ({active_run:
+  // running}) would otherwise overwrite a newer one ({active_run: null}) and
+  // leave stale state. loadConversation passes its generation here so only the
+  // latest load commits. Other callers (post-save drain, reconcile) pass none
+  // and keep the plain id-only behavior.
+  const refetchMessages = useCallback(async (convId, isFresh) => {
+    const stillCurrent = () => observedConvIdRef.current === convId
+                               && (isFresh ? isFresh() : true)
     try {
       const data = await getConversation(convId)
-      // Drop the result if the user navigated to a different conversation while
-      // this fetch was in flight — otherwise a late resolve writes stale
-      // conversation/messages over the one now intended (request-sequencing).
-      if (observedConvIdRef.current !== convId) return null
+      // Drop the result if the user navigated to a different conversation, or a
+      // newer same-id load superseded this one, while the fetch was in flight —
+      // otherwise a late resolve writes stale conversation/messages over the one
+      // now intended (request-sequencing).
+      if (!stillCurrent()) return null
       setConversation(data)
       setMessages(data.messages || [])
       setCritiques(data.critiques || {})
@@ -108,7 +120,7 @@ export default function useChat({ onConversationUpdated } = {}) {
       }
       return data
     } catch (err) {
-      if (observedConvIdRef.current !== convId) return null
+      if (!stillCurrent()) return null
       setError(err.message)
       return null
     }
@@ -315,7 +327,10 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreamingArtifacts([])
     setStreamingParseWarning(null)
     setError(null)
-    const data = await refetchMessages(convId)
+    // Pass the generation as the freshness predicate so a superseded same-id
+    // load neither commits its (stale) snapshot nor reattaches — refetchMessages
+    // returns null for it, short-circuiting the reattach below.
+    const data = await refetchMessages(convId, () => loadGenRef.current === gen)
     // If the conversation's run is still going, reattach to its live stream so
     // the in-progress turn streams in as if we never left. Gate on BOTH the
     // intended conversation and this load's generation so a slow load that lost

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -156,6 +156,24 @@ export default function useChat({ onConversationUpdated } = {}) {
     setRunReady(true)
     liveControllersRef.current.add(controller)
 
+    // Did a terminal signal (saved / run_status / error) already reconcile this
+    // reattach? If the stream instead closes silently — the run was cancelled
+    // elsewhere, which the bus emits no frame for — or a setup/transport error
+    // rejects the promise, we still must drop `streaming` and refetch so the
+    // (now terminal) active_run can't leave the composer stuck disabled.
+    let terminalSeen = false
+    const reconcile = () => {
+      // Gate entirely on still observing this conversation: if the user
+      // navigated away (which aborted this stream), do nothing — clearing
+      // `streaming` here would stomp the conversation they moved to (which may
+      // itself be reattaching).
+      if (observedConvIdRef.current !== conv.id) return
+      setStreaming(false)
+      setHeartbeat(null)
+      setPendingToolCalls([])
+      refetchMessages(conv.id)
+    }
+
     streamChat(`/chat/runs/${run.id}/stream`, null, {
       method: 'GET',
       signal: controller.signal,
@@ -199,6 +217,7 @@ export default function useChat({ onConversationUpdated } = {}) {
       onArtifact: (evt) => setStreamingArtifacts(prev => [...prev, evt]),
       onConversationUpdated,
       onMessageSaved: () => {
+        terminalSeen = true
         setStreamingContent('')
         setStreamingReasoning('')
         setStreaming(false)
@@ -211,23 +230,36 @@ export default function useChat({ onConversationUpdated } = {}) {
         // The run was already terminal when we reattached (it finished just
         // before/as we returned) — no live frames coming. Refetch shows the
         // persisted reply, or a failed-run error via last_run.
-        setStreaming(false)
-        setHeartbeat(null)
-        setPendingToolCalls([])
-        refetchMessages(conv.id)
+        terminalSeen = true
+        reconcile()
       },
       onError: (msg) => {
+        // A live failure delivered after attach. Surface it AND refetch so the
+        // now-failed active_run stops blocking the next send/edit.
+        terminalSeen = true
         setError(msg)
-        setStreaming(false)
         setStreamingContent('')
         setStreamingReasoning('')
-        setPendingToolCalls([])
-        setHeartbeat(null)
         drainingRef.current = false
+        reconcile()
       },
-    }).finally(() => {
-      liveControllersRef.current.delete(controller)
     })
+      .catch((err) => {
+        // Setup/transport failure (token/fetch/response body) before streamChat's
+        // own reader loop — it rejects here rather than calling onError.
+        if (err?.name !== 'AbortError') {
+          terminalSeen = true
+          if (observedConvIdRef.current === conv.id) setError(err?.message || 'Reattach failed')
+          reconcile()
+        }
+      })
+      .finally(() => {
+        liveControllersRef.current.delete(controller)
+        // Closed with no terminal signal — the run was cancelled elsewhere (the
+        // bus emits no frame for run_cancelled / stream_end). Reconcile so the
+        // UI doesn't stay stuck on `streaming`.
+        if (!terminalSeen) reconcile()
+      })
   }, [refetchMessages, onConversationUpdated])
 
   const loadConversation = useCallback(async (convId) => {

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -64,6 +64,14 @@ export default function useChat({ onConversationUpdated } = {}) {
   // kill a newer run that started after the one the user stopped. Reset at the
   // start of each send/edit/load so it never carries a stale run's id.
   const runIdRef = useRef(null)
+  // Monotonic load generation. Incremented synchronously at the start of every
+  // loadConversation; the post-fetch reattach only fires if it is still the
+  // latest. The id guard (observedConvIdRef) alone is insufficient when two
+  // loads share a conversation id — React StrictMode runs the URL-load effect
+  // twice on mount, and an A→B→A navigation re-loads A while A's first fetch is
+  // pending. Without the generation, both same-id loads pass the id guard, each
+  // opens its own run stream, and the replay + live deltas render twice.
+  const loadGenRef = useRef(0)
   // Hold the caller's onConversationUpdated behind a ref and expose a STABLE
   // wrapper. Callers (ChatPage) pass a fresh inline function each render; if the
   // stream callbacks depended on it directly, sendMessage/editMessage/reattachRun
@@ -275,6 +283,10 @@ export default function useChat({ onConversationUpdated } = {}) {
   }, [refetchMessages, handleConversationUpdated])
 
   const loadConversation = useCallback(async (convId) => {
+    // Claim this load's generation synchronously, before awaiting the fetch.
+    // Only the latest load may reattach; a superseded same-id load (StrictMode
+    // double-mount, or A→B→A re-entry) must not open a second run stream.
+    const gen = ++loadGenRef.current
     // Claim the intended conversation synchronously, before awaiting the fetch.
     // This is what makes a concurrent post-cancel reconcile for the PREVIOUS
     // conversation skip: it gates on observedConvIdRef, which now already names
@@ -305,9 +317,11 @@ export default function useChat({ onConversationUpdated } = {}) {
     setError(null)
     const data = await refetchMessages(convId)
     // If the conversation's run is still going, reattach to its live stream so
-    // the in-progress turn streams in as if we never left. Gate on the intended
-    // conversation so a slow load that lost the navigation race doesn't attach.
-    if (data && observedConvIdRef.current === convId && isRunActive(data.active_run)) {
+    // the in-progress turn streams in as if we never left. Gate on BOTH the
+    // intended conversation and this load's generation so a slow load that lost
+    // the navigation race — or a superseded same-id load — doesn't attach.
+    if (data && loadGenRef.current === gen && observedConvIdRef.current === convId
+        && isRunActive(data.active_run)) {
       reattachRun(data)
     }
   }, [refetchMessages, reattachRun])

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -75,7 +75,7 @@ export default function useChat({ onConversationUpdated } = {}) {
       // Drop the result if the user navigated to a different conversation while
       // this fetch was in flight — otherwise a late resolve writes stale
       // conversation/messages over the one now intended (request-sequencing).
-      if (observedConvIdRef.current !== convId) return
+      if (observedConvIdRef.current !== convId) return null
       setConversation(data)
       setMessages(data.messages || [])
       setCritiques(data.critiques || {})
@@ -86,9 +86,11 @@ export default function useChat({ onConversationUpdated } = {}) {
       if (data.last_run?.status === 'failed' && data.last_run.error) {
         setError(data.last_run.error)
       }
+      return data
     } catch (err) {
-      if (observedConvIdRef.current !== convId) return
+      if (observedConvIdRef.current !== convId) return null
       setError(err.message)
+      return null
     }
   }, [])
 
@@ -127,6 +129,107 @@ export default function useChat({ onConversationUpdated } = {}) {
       })
   }, [refetchMessages])
 
+  // Reattach to a still-running background run's live stream (the user
+  // navigated away and came back). Feeds the run-stream SSE frames through the
+  // same handlers as a live send so the in-progress turn renders in full — the
+  // backend replays the buffered history first, then the live tail. No
+  // optimistic user row here: the transcript was just refetched, so the user
+  // message is already persisted.
+  const reattachRun = useCallback((conv) => {
+    const run = conv.active_run
+    if (!isRunActive(run)) return
+
+    setError(null)
+    setStreaming(true)
+    setStreamingContent('')
+    setStreamingReasoning('')
+    setToolEvents([])
+    setPendingToolCalls([])
+    setHeartbeat(null)
+    setStreamingArtifacts([])
+    setStreamingParseWarning(null)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+    drainingRef.current = false
+    runIdRef.current = run.id        // id known → Stop stays guarded
+    setRunReady(true)
+    liveControllersRef.current.add(controller)
+
+    streamChat(`/chat/runs/${run.id}/stream`, null, {
+      method: 'GET',
+      signal: controller.signal,
+      onDelta: ({ content: c, reasoning_content: r }) => {
+        setHeartbeat(null)
+        if (c) setStreamingContent(prev => prev + c)
+        if (r) setStreamingReasoning(prev => prev + r)
+      },
+      onHeartbeat: (evt) => setHeartbeat({ elapsed_s: evt.elapsed_s }),
+      onParseWarning: (evt) => setStreamingParseWarning({
+        kind: evt.kind, snippet: evt.snippet, description: evt.description,
+      }),
+      onToolCallPending: (evt) => {
+        setHeartbeat(null)
+        setPendingToolCalls(prev => {
+          const others = prev.filter(p => p.index !== evt.index)
+          return [...others, { index: evt.index, name: evt.name }]
+        })
+      },
+      onToolCall: (evt) => {
+        setHeartbeat(null)
+        setPendingToolCalls([])
+        setToolEvents(prev => [...prev, { type: 'call', ...evt }])
+      },
+      onToolResult: (evt) => {
+        setHeartbeat(null)
+        setToolEvents(prev => {
+          for (let i = prev.length - 1; i >= 0; i--) {
+            const e = prev[i]
+            if (e.type === 'call' && e.name === evt.name && !('result' in e)) {
+              const next = [...prev]
+              next[i] = { ...e, result: evt.result, server_id: evt.server_id }
+              return next
+            }
+          }
+          return [...prev, { type: 'call', name: evt.name, server_id: evt.server_id, result: evt.result }]
+        })
+        // New round begins after a tool result — reset the visible content.
+        setStreamingContent('')
+      },
+      onArtifact: (evt) => setStreamingArtifacts(prev => [...prev, evt]),
+      onConversationUpdated,
+      onMessageSaved: () => {
+        setStreamingContent('')
+        setStreamingReasoning('')
+        setStreaming(false)
+        setPendingToolCalls([])
+        setHeartbeat(null)
+        drainingRef.current = true
+        refetchMessages(conv.id)
+      },
+      onRunStatus: () => {
+        // The run was already terminal when we reattached (it finished just
+        // before/as we returned) — no live frames coming. Refetch shows the
+        // persisted reply, or a failed-run error via last_run.
+        setStreaming(false)
+        setHeartbeat(null)
+        setPendingToolCalls([])
+        refetchMessages(conv.id)
+      },
+      onError: (msg) => {
+        setError(msg)
+        setStreaming(false)
+        setStreamingContent('')
+        setStreamingReasoning('')
+        setPendingToolCalls([])
+        setHeartbeat(null)
+        drainingRef.current = false
+      },
+    }).finally(() => {
+      liveControllersRef.current.delete(controller)
+    })
+  }, [refetchMessages, onConversationUpdated])
+
   const loadConversation = useCallback(async (convId) => {
     // Claim the intended conversation synchronously, before awaiting the fetch.
     // This is what makes a concurrent post-cancel reconcile for the PREVIOUS
@@ -156,8 +259,14 @@ export default function useChat({ onConversationUpdated } = {}) {
     setStreamingArtifacts([])
     setStreamingParseWarning(null)
     setError(null)
-    await refetchMessages(convId)
-  }, [refetchMessages])
+    const data = await refetchMessages(convId)
+    // If the conversation's run is still going, reattach to its live stream so
+    // the in-progress turn streams in as if we never left. Gate on the intended
+    // conversation so a slow load that lost the navigation race doesn't attach.
+    if (data && observedConvIdRef.current === convId && isRunActive(data.active_run)) {
+      reattachRun(data)
+    }
+  }, [refetchMessages, reattachRun])
 
   const sendMessage = useCallback(async (content, images) => {
     // Block a send while a run is active for this conversation (including a

--- a/dashboard/frontend/src/hooks/useChat.js
+++ b/dashboard/frontend/src/hooks/useChat.js
@@ -64,6 +64,18 @@ export default function useChat({ onConversationUpdated } = {}) {
   // kill a newer run that started after the one the user stopped. Reset at the
   // start of each send/edit/load so it never carries a stale run's id.
   const runIdRef = useRef(null)
+  // Hold the caller's onConversationUpdated behind a ref and expose a STABLE
+  // wrapper. Callers (ChatPage) pass a fresh inline function each render; if the
+  // stream callbacks depended on it directly, sendMessage/editMessage/reattachRun
+  // — and therefore loadConversation — would change identity every render, and
+  // ChatPage's URL-load effect (deps on loadConversation) would re-run and
+  // reload in a loop. The wrapper's identity never changes, so those callbacks
+  // stay stable.
+  const onConversationUpdatedRef = useRef(onConversationUpdated)
+  useEffect(() => { onConversationUpdatedRef.current = onConversationUpdated }, [onConversationUpdated])
+  const handleConversationUpdated = useCallback((evt) => {
+    onConversationUpdatedRef.current?.(evt)
+  }, [])
 
   // Refetch the conversation from the server WITHOUT touching the active
   // SSE stream. Used by the message_saved handler so we don't cancel our
@@ -215,7 +227,7 @@ export default function useChat({ onConversationUpdated } = {}) {
         setStreamingContent('')
       },
       onArtifact: (evt) => setStreamingArtifacts(prev => [...prev, evt]),
-      onConversationUpdated,
+      onConversationUpdated: handleConversationUpdated,
       onMessageSaved: () => {
         terminalSeen = true
         setStreamingContent('')
@@ -260,7 +272,7 @@ export default function useChat({ onConversationUpdated } = {}) {
         // UI doesn't stay stuck on `streaming`.
         if (!terminalSeen) reconcile()
       })
-  }, [refetchMessages, onConversationUpdated])
+  }, [refetchMessages, handleConversationUpdated])
 
   const loadConversation = useCallback(async (convId) => {
     // Claim the intended conversation synchronously, before awaiting the fetch.
@@ -407,7 +419,7 @@ export default function useChat({ onConversationUpdated } = {}) {
         onDone: () => {
           // Will be followed by message_saved
         },
-        onConversationUpdated,
+        onConversationUpdated: handleConversationUpdated,
         onRunStarted: (evt) => { runIdRef.current = evt.run_id; setRunReady(true) },
         onMessageSaved: (data) => {
           const assistantMsg = {
@@ -455,7 +467,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, refetchMessages, onConversationUpdated])
+  }, [conversation, messages, streaming, refetchMessages, handleConversationUpdated])
 
   const editMessage = useCallback(async (msgId, content) => {
     // Block edits while a run is active for this conversation — including a
@@ -489,9 +501,6 @@ export default function useChat({ onConversationUpdated } = {}) {
     setRunReady(false)
     liveControllersRef.current.add(controller)
 
-    let fullContent = ''
-    let fullReasoning = ''
-
     try {
       await streamChat(
         `/chat/conversations/${conversation.id}/messages/${msgId}`,
@@ -502,11 +511,9 @@ export default function useChat({ onConversationUpdated } = {}) {
           onDelta: ({ content: c, reasoning_content: r }) => {
             setHeartbeat(null)
             if (c) {
-              fullContent += c
               setStreamingContent(prev => prev + c)
             }
             if (r) {
-              fullReasoning += r
               setStreamingReasoning(prev => prev + r)
             }
           },
@@ -546,13 +553,12 @@ export default function useChat({ onConversationUpdated } = {}) {
               return [...prev, { type: 'call', name: evt.name, server_id: evt.server_id, result: evt.result }]
             })
             setStreamingContent('')
-            fullContent = ''
           },
           onArtifact: (evt) => {
             setStreamingArtifacts(prev => [...prev, evt])
           },
           onDone: () => {},
-          onConversationUpdated,
+          onConversationUpdated: handleConversationUpdated,
           onRunStarted: (evt) => { runIdRef.current = evt.run_id; setRunReady(true) },
           onMessageSaved: () => {
             setStreamingContent('')
@@ -580,7 +586,7 @@ export default function useChat({ onConversationUpdated } = {}) {
     } finally {
       liveControllersRef.current.delete(controller)
     }
-  }, [conversation, messages, streaming, loadConversation, refetchMessages, onConversationUpdated])
+  }, [conversation, messages, streaming, loadConversation, refetchMessages, handleConversationUpdated])
 
   const stopStreaming = useCallback(() => {
     // Explicit Stop must cancel the SERVER run, not just abort the SSE fetch:

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -414,6 +414,38 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.streamingContent).toBe('Hello world')
   })
 
+  it('opens only one run stream when the same conversation is loaded twice concurrently', async () => {
+    // Regression for codex iter 4 P1: React StrictMode runs the URL-load effect
+    // twice on mount, and A→B→A navigation re-loads A while the first A fetch is
+    // pending. Both same-id loads pass the conversation-id guard; without a load
+    // generation each would open its own GET run stream and replay/live-render
+    // every delta twice. Two deferred same-id loads must open exactly one stream.
+    const resolvers = []
+    mockGetConversation.mockImplementation(() => new Promise((res) => { resolvers.push(res) }))
+    const streamUrls = []
+    mockStreamChat.mockImplementation((url) => { streamUrls.push(url); return new Promise(() => {}) })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => {
+      // Kick off both loads before either fetch resolves (StrictMode double-mount).
+      const p1 = result.current.loadConversation('conv-1')
+      const p2 = result.current.loadConversation('conv-1')
+      const data = {
+        ...CONV,
+        active_run: { id: 'run-bg', status: 'running' },
+        messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }],
+        critiques: {},
+        artifacts: {},
+      }
+      resolvers.forEach((r) => r(data))  // resolve BOTH pending fetches
+      await Promise.all([p1, p2])
+    })
+
+    // Exactly one reattach stream — the superseded load did not open a second.
+    expect(streamUrls).toEqual(['/chat/runs/run-bg/stream'])
+    expect(result.current.streaming).toBe(true)
+  })
+
   it('does not reattach when the loaded conversation has no active run', async () => {
     mockGetConversation.mockResolvedValue({
       ...CONV, active_run: null, messages: [], critiques: {}, artifacts: {},

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -446,6 +446,33 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.streaming).toBe(true)
   })
 
+  it('does not commit a superseded same-id load that resolves out of order', async () => {
+    // Regression for codex iter 5 P1: two concurrent same-id loads can return
+    // different snapshots and resolve oldest-last. The older snapshot
+    // ({active_run: running}) must NOT overwrite the newer ({active_run: null}),
+    // or `conversation.active_run` would stay stale — blocking send/edit and
+    // keeping Stop visible — even though the superseded load is correctly barred
+    // from reattaching. The generation gates the state commit, not just reattach.
+    let resolveOld, resolveNew
+    mockGetConversation
+      .mockImplementationOnce(() => new Promise((r) => { resolveOld = r }))   // gen 1
+      .mockImplementationOnce(() => new Promise((r) => { resolveNew = r }))   // gen 2 (latest)
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => {
+      const p1 = result.current.loadConversation('conv-1')  // older generation
+      const p2 = result.current.loadConversation('conv-1')  // newer generation
+      // Newest resolves FIRST, oldest LAST — the dangerous ordering.
+      resolveNew({ ...CONV, active_run: null, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+      resolveOld({ ...CONV, active_run: { id: 'run-bg', status: 'running' }, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+      await Promise.all([p1, p2])
+    })
+
+    // The latest snapshot wins: no stale active run left to block the composer.
+    expect(result.current.conversation.active_run).toBe(null)
+    expect(result.current.streaming).toBe(false)
+  })
+
   it('does not reattach when the loaded conversation has no active run', async () => {
     mockGetConversation.mockResolvedValue({
       ...CONV, active_run: null, messages: [], critiques: {}, artifacts: {},

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -504,6 +504,25 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.error).toBe('network down')
   })
 
+  it('loadConversation stays stable when onConversationUpdated identity changes', () => {
+    // Regression for codex iter 3 P1: ChatPage passes a fresh onConversationUpdated
+    // every render. If loadConversation changed identity with it, ChatPage's
+    // URL-load effect would re-run and reload in a loop. The hook holds the
+    // callback behind a ref so loadConversation (and send/edit/reattach) stay
+    // referentially stable.
+    const { result, rerender } = renderHook(
+      ({ cb }) => useChat({ onConversationUpdated: cb }),
+      { initialProps: { cb: () => {} } },
+    )
+    const firstLoad = result.current.loadConversation
+    const firstSend = result.current.sendMessage
+
+    rerender({ cb: () => {} }) // brand-new callback identity
+
+    expect(result.current.loadConversation).toBe(firstLoad)
+    expect(result.current.sendMessage).toBe(firstSend)
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -451,6 +451,59 @@ describe('useChat stop/cancel wiring', () => {
     expect(result.current.streaming).toBe(false)
   })
 
+  it('reattach reconciles when the run is cancelled elsewhere (silent stream close)', async () => {
+    // Codex iter 1 P1: a cancel from another tab emits no frame, so the reattach
+    // stream just closes. The hook must still drop streaming + refetch.
+    mockGetConversation
+      .mockResolvedValueOnce({ ...CONV, active_run: { id: 'run-bg', status: 'running' }, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+      .mockResolvedValue({ ...CONV, active_run: null, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+    let resolveStream
+    mockStreamChat.mockImplementation(() => new Promise((res) => { resolveStream = res }))
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+    expect(result.current.streaming).toBe(true)
+
+    await act(async () => { resolveStream(); await Promise.resolve(); await Promise.resolve() })
+    expect(result.current.streaming).toBe(false)
+  })
+
+  it('reattach reconciles on a live failure delivered after attach', async () => {
+    // Codex iter 1 P1: a failure encoded as an error frame must clear the stale
+    // active_run (refetch) so it stops blocking the next send.
+    mockGetConversation
+      .mockResolvedValueOnce({ ...CONV, active_run: { id: 'run-bg', status: 'running' }, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+      .mockResolvedValue({ ...CONV, active_run: null, last_run: { id: 'run-bg', status: 'failed', error: 'boom' }, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+    let handlers
+    mockStreamChat.mockImplementation((_u, _b, h) => { handlers = h; return new Promise(() => {}) })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+    await act(async () => { handlers.onError('boom'); await Promise.resolve(); await Promise.resolve() })
+
+    expect(result.current.streaming).toBe(false)
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('reattach reconciles when the run-stream request fails to open', async () => {
+    // Codex iter 1 P2: a setup/transport failure rejects the streamChat promise
+    // before its reader loop; it must not leave the UI streaming forever.
+    mockGetConversation
+      .mockResolvedValueOnce({ ...CONV, active_run: { id: 'run-bg', status: 'running' }, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+      .mockResolvedValue({ ...CONV, active_run: null, messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }], critiques: {}, artifacts: {} })
+    mockStreamChat.mockImplementation(() => Promise.reject(new Error('network down')))
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => {
+      await result.current.loadConversation('conv-1')
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.streaming).toBe(false)
+    expect(result.current.error).toBe('network down')
+  })
+
   it('stopStreaming with no active conversation is a harmless no-op', async () => {
     const { result } = renderHook(() => useChat({}))
     // No conversation loaded.

--- a/dashboard/frontend/src/hooks/useChat.test.jsx
+++ b/dashboard/frontend/src/hooks/useChat.test.jsx
@@ -40,6 +40,10 @@ beforeEach(() => {
   mockGetConversation.mockReset()
   mockCancelActiveRun.mockResolvedValue({ run: null })
   mockGetConversation.mockResolvedValue({ ...CONV, messages: [], critiques: {}, artifacts: {} })
+  // Default: a stream that stays open. Reattach (loadConversation onto an
+  // active_run) and any send that doesn't set its own impl get a valid promise
+  // to attach to instead of undefined.
+  mockStreamChat.mockImplementation(() => new Promise(() => {}))
 })
 
 afterEach(() => {
@@ -307,9 +311,12 @@ describe('useChat stop/cancel wiring', () => {
     const { result } = renderHook(() => useChat({}))
 
     await act(async () => { await result.current.loadConversation('conv-1') })
+    // Loading an active-run conversation reattaches to its stream (one call);
+    // the blocked edit must not open ANOTHER stream.
+    const callsAfterLoad = mockStreamChat.mock.calls.length
     await act(async () => { await result.current.editMessage('u1', 'edited') })
 
-    expect(mockStreamChat).not.toHaveBeenCalled()
+    expect(mockStreamChat.mock.calls.length).toBe(callsAfterLoad)
     expect(result.current.messages.some(m => m.id === 'temp-edit')).toBe(false)
   })
 
@@ -372,6 +379,76 @@ describe('useChat stop/cancel wiring', () => {
     await act(async () => { await result.current.loadConversation('conv-1') })
 
     expect(result.current.error).toBeNull()
+  })
+
+  it('reattaches to the live run stream when loading an in-progress conversation', async () => {
+    // The fix for the "no progress on return" bug: loading a conversation whose
+    // run is still active opens GET /chat/runs/<id>/stream and renders live.
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      active_run: { id: 'run-bg', status: 'running' },
+      messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }],
+      critiques: {},
+      artifacts: {},
+    })
+    let handlers
+    mockStreamChat.mockImplementation((url, _body, h) => {
+      handlers = { url, ...h }
+      return new Promise(() => {})
+    })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+
+    // Opened the run-stream endpoint (GET, no body) and entered streaming.
+    expect(handlers.url).toBe('/chat/runs/run-bg/stream')
+    expect(handlers.method).toBe('GET')
+    expect(result.current.streaming).toBe(true)
+    expect(result.current.runReady).toBe(true)
+
+    // Replayed + live deltas render into streamingContent.
+    act(() => {
+      handlers.onDelta({ content: 'Hello ', reasoning_content: '' })
+      handlers.onDelta({ content: 'world', reasoning_content: '' })
+    })
+    expect(result.current.streamingContent).toBe('Hello world')
+  })
+
+  it('does not reattach when the loaded conversation has no active run', async () => {
+    mockGetConversation.mockResolvedValue({
+      ...CONV, active_run: null, messages: [], critiques: {}, artifacts: {},
+    })
+    const calls = []
+    mockStreamChat.mockImplementation((url) => { calls.push(url); return new Promise(() => {}) })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+
+    expect(calls).toEqual([])
+    expect(result.current.streaming).toBe(false)
+  })
+
+  it('reattach to an already-finished run refetches instead of hanging', async () => {
+    mockGetConversation.mockResolvedValue({
+      ...CONV,
+      active_run: { id: 'run-bg', status: 'running' },
+      messages: [{ id: 'u1', role: 'user', content: 'hi', seq: 1 }],
+      critiques: {},
+      artifacts: {},
+    })
+    let handlers
+    mockStreamChat.mockImplementation((url, _body, h) => { handlers = h; return new Promise(() => {}) })
+    const { result } = renderHook(() => useChat({}))
+
+    await act(async () => { await result.current.loadConversation('conv-1') })
+    expect(result.current.streaming).toBe(true)
+
+    // The run finished just as we reattached: a terminal run_status arrives.
+    await act(async () => {
+      handlers.onRunStatus({ type: 'run_status', status: 'completed' })
+      await Promise.resolve()
+    })
+    expect(result.current.streaming).toBe(false)
   })
 
   it('stopStreaming with no active conversation is a harmless no-op', async () => {

--- a/dashboard/frontend/src/services/sse.js
+++ b/dashboard/frontend/src/services/sse.js
@@ -8,7 +8,7 @@ const API_BASE = window.location.hostname === 'localhost' || window.location.hos
  * Stream a chat completion via SSE.
  * Uses fetch + ReadableStream because EventSource doesn't support auth headers.
  */
-export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, onParseWarning, onRunStarted, signal, method = 'POST' }) {
+export async function streamChat(url, body, { onDelta, onDone, onError, onMessageSaved, onToolCall, onToolCallPending, onToolResult, onArtifact, onConversationUpdated, onHeartbeat, onParseWarning, onRunStarted, onRunStatus, signal, method = 'POST' }) {
   const token = getToken()
   if (!token) throw new Error('Not authenticated')
 
@@ -18,7 +18,8 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(body),
+    // GET reattach (the run-stream endpoint) carries no body.
+    body: method === 'GET' || method === 'HEAD' ? undefined : JSON.stringify(body),
     signal,
   })
 
@@ -84,6 +85,13 @@ export async function streamChat(url, body, { onDelta, onDone, onError, onMessag
           }
           if (parsed.type === 'heartbeat') {
             onHeartbeat?.(parsed)
+            continue
+          }
+          if (parsed.type === 'run_status') {
+            // Emitted by the reattach stream when the run is already terminal
+            // (finished before/just as we reconnected) — the caller refetches
+            // the persisted result rather than expecting live frames.
+            onRunStatus?.(parsed)
             continue
           }
           if (parsed.type === 'parse_warning') {

--- a/dashboard/tests/test_chat_persistence.py
+++ b/dashboard/tests/test_chat_persistence.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from chat import runtime
 from chat.db import ChatDB
+from chat.event_bus import EventBus
 from chat.models import Conversation, Message, ChatRun
 from chat.runs import ChatRunStatus
 from chat.runtime import ChatRunner, ChatTurnRequest
@@ -189,6 +190,37 @@ def test_null_policy_pre_start_cancel_does_not_open_stream(monkeypatch):
     assert opened["iterated"] is False        # the costly stream never opened
     assert bus.types() == ["run_cancelled"]   # no run_started for a pre-start cancel
     assert [m.role for m in policy.messages] == ["user"]  # no assistant appended
+
+
+def test_direct_runner_completion_frees_replay_history(monkeypatch):
+    """A ChatRunner driven directly with a real bus (no run-manager) ends on
+    run_completed and never emits the manager-only stream_end, yet its replay
+    history is still freed — proving cleanup is on the terminal-event contract,
+    not the sentinel."""
+    _patch_stream(monkeypatch, _stub)  # two deltas + done
+    bus = EventBus()
+    conv = _conv()
+    policy = NullPersistencePolicy(messages=[_user_msg(conv)])
+    run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+
+    ChatRunner(persistence=policy, event_bus=bus).run(run, ChatTurnRequest(conversation=conv))
+
+    assert run.id not in bus._replay  # freed on run_completed, no stream_end needed
+
+
+def test_direct_runner_failure_frees_replay_history(monkeypatch):
+    def _boom():
+        yield ("error", {"message": "model exploded"})
+
+    _patch_stream(monkeypatch, _boom)
+    bus = EventBus()
+    conv = _conv()
+    policy = NullPersistencePolicy(messages=[_user_msg(conv)])
+    run = ChatRun(id=str(uuid.uuid4()), conversation_id=conv.id, status=ChatRunStatus.QUEUED)
+
+    ChatRunner(persistence=policy, event_bus=bus).run(run, ChatTurnRequest(conversation=conv))
+
+    assert run.id not in bus._replay  # freed on run_failed
 
 
 # -- seam shape ----------------------------------------------------------

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -340,6 +340,84 @@ def test_observe_backstop_closes_when_run_goes_terminal(ctx, monkeypatch):
         next(gen)
 
 
+def _delta_evt(content):
+    return runtime.ChatRuntimeEvent(
+        "delta", {"content": content, "reasoning_content": "",
+                  "raw": json.dumps({"choices": [{"delta": {"content": content}}]})})
+
+
+def test_reattach_replays_in_flight_history(ctx):
+    """A client reattaching mid-run replays everything generated before it
+    subscribed, then receives live events exactly once."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    bus = manager.event_bus
+
+    # Progress that happened before the client returned.
+    bus.publish(run.id, _delta_evt("Hello "))
+    bus.publish(run.id, _delta_evt("world"))
+
+    q, replay = manager.subscribe_with_replay(run.id)
+    gen = manager.observe(run.id, q, replay)
+
+    assert "run_started" in next(gen)
+    # Replayed history comes before any live event.
+    assert "Hello " in next(gen)
+    assert "world" in next(gen)
+
+    # A live event after reattach is delivered too, and only once.
+    bus.publish(run.id, _delta_evt("!"))
+    assert "!" in next(gen)
+
+    bus.publish(run.id, runtime.ChatRuntimeEvent(run_manager_module.STREAM_END, {}))
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_reattach_after_completion_drops_replay(ctx, monkeypatch):
+    """Once a run ends (STREAM_END) its replay history is dropped; a later
+    reattach falls back to the DB terminal backstop instead of replaying."""
+    app, db, manager = ctx
+    monkeypatch.setattr(run_manager_module, "HEARTBEAT_INTERVAL_S", 0.02)
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    bus = manager.event_bus
+
+    bus.publish(run.id, _delta_evt("partial"))
+    bus.publish(run.id, runtime.ChatRuntimeEvent(run_manager_module.STREAM_END, {}))
+    db.complete_chat_run(run.id)
+
+    q, replay = manager.subscribe_with_replay(run.id)
+    assert replay == []  # history dropped on STREAM_END
+
+    gen = manager.observe(run.id, q, replay)
+    assert "run_started" in next(gen)
+    nxt = next(gen)  # no replay, no live events -> backstop closes on terminal
+    assert "run_status" in nxt and "completed" in nxt
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_subscribe_with_replay_snapshot_excludes_later_events(ctx):
+    """The history captured by subscribe_with_replay is a cut: events published
+    AFTER it go to the queue (and are not duplicated in the snapshot)."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    bus = manager.event_bus
+
+    bus.publish(run.id, _delta_evt("before"))
+    q, replay = manager.subscribe_with_replay(run.id)
+    bus.publish(run.id, _delta_evt("after"))
+
+    replay_text = "".join(f for ev in replay for f in run_manager_module._sse_frames_for(ev))
+    assert "before" in replay_text
+    assert "after" not in replay_text  # later event is on the queue, not the snapshot
+    queued = run_manager_module._sse_frames_for(q.get_nowait())
+    assert any("after" in f for f in queued)
+
+
 def test_run_started_emitted_first_even_when_workers_saturated(tmp_path, monkeypatch):
     """run_started reaches the client immediately even if the run's worker is
     still queued behind a saturated pool (the observer synthesizes it)."""

--- a/dashboard/tests/test_chat_run_routes.py
+++ b/dashboard/tests/test_chat_run_routes.py
@@ -362,9 +362,9 @@ def test_reattach_replays_in_flight_history(ctx):
     gen = manager.observe(run.id, q, replay)
 
     assert "run_started" in next(gen)
-    # Replayed history comes before any live event.
-    assert "Hello " in next(gen)
-    assert "world" in next(gen)
+    # Replayed history comes before any live event; the two buffered deltas are
+    # coalesced into a single frame carrying the full content so far.
+    assert "Hello world" in next(gen)
 
     # A live event after reattach is delivered too, and only once.
     bus.publish(run.id, _delta_evt("!"))
@@ -373,6 +373,43 @@ def test_reattach_replays_in_flight_history(ctx):
     bus.publish(run.id, runtime.ChatRuntimeEvent(run_manager_module.STREAM_END, {}))
     with pytest.raises(StopIteration):
         next(gen)
+
+
+def test_replay_coalesces_deltas_but_keeps_tool_boundaries(ctx):
+    """Consecutive deltas fold into one frame; a tool event between two delta
+    runs keeps them as separate frames (per-round boundaries preserved)."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    bus = manager.event_bus
+
+    bus.publish(run.id, _delta_evt("round1-a "))
+    bus.publish(run.id, _delta_evt("round1-b"))
+    bus.publish(run.id, runtime.ChatRuntimeEvent(
+        "tool_call", {"name": "calc", "arguments": "{}", "server_id": "s"}))
+    bus.publish(run.id, _delta_evt("round2"))
+
+    _, replay = manager.subscribe_with_replay(run.id)
+    frames = ["".join(run_manager_module._sse_frames_for(ev)) for ev in replay]
+    # round1 deltas coalesced, then the tool_call, then round2 — 3 segments.
+    assert len(frames) == 3
+    assert "round1-a round1-b" in frames[0]
+    assert "tool_call" in frames[1] and "calc" in frames[1]
+    assert "round2" in frames[2]
+
+
+def test_terminal_runtime_event_drops_replay_without_stream_end(ctx):
+    """A run that ends on run_completed (no manager stream_end — e.g. a direct
+    ChatRunner) still frees its replay history."""
+    app, db, manager = ctx
+    conv = _conv(db)
+    run = _run_row(db, conv, ChatRunStatus.RUNNING)
+    bus = manager.event_bus
+
+    bus.publish(run.id, _delta_evt("partial"))
+    assert run.id in bus._replay
+    bus.publish(run.id, runtime.ChatRuntimeEvent("run_completed", {"message_id": "m", "seq": 2}))
+    assert run.id not in bus._replay
 
 
 def test_reattach_after_completion_drops_replay(ctx, monkeypatch):


### PR DESCRIPTION
Closes #68.

Returning to a conversation whose background run is still working showed only the static sidebar spinner — no live tokens. Two causes: the frontend never connected to `GET /api/chat/runs/<id>/stream` on navigation-back, and the event bus is **live-only** (a reattaching observer missed everything generated before it subscribed).

## Backend — replay the in-flight history on reattach
- `EventBus` keeps a per-active-run **replay log** (all events since the run started), appended in `publish`, dropped on `STREAM_END`. Unlike the per-observer queues it is **not** bounded/evicted — losing the oldest deltas would blank the start of the reply — so it lives only for one active run and is freed when the run ends.
- `subscribe_with_replay(run_id) -> (queue, history)` captures the history snapshot **and** registers the live queue under one lock, so every in-flight event reaches a reattaching observer exactly once (in the snapshot xor on the queue — no gap, no duplication).
- `ChatRunManager.observe(run_id, q, replay=())` emits the replay frames (via the existing `_sse_frames_for`) before the live loop. `GET /runs/<id>/stream` uses the replay path; the fresh-send path is unchanged (empty history).

## Frontend — connect on navigation-back
- `loadConversation`, after refetch, opens the run stream when the loaded conversation has a running/queued `active_run`, feeding frames through the same handlers as a live send (delta / reasoning / tool calls / results / artifacts / parse warnings), with `streaming` + `runReady` true and the run id known so **Stop stays guarded**. A terminal `run_status` (the run finished as we reattached) refetches the persisted reply instead of hanging.
- `sse.js`: the GET run-stream carries no body; dispatch the `run_status` frame.

## Tests
- Backend (`test_chat_run_routes.py`): history is replayed before live events and only once; the subscribe snapshot excludes later events (those arrive on the queue); history is dropped on `STREAM_END` so a post-completion reattach falls back to the DB terminal backstop.
- Frontend (`useChat.test.jsx`): loading an active-run conversation opens the GET run-stream and renders deltas into `streamingContent`; no reattach when there's no active run; a terminal `run_status` ends streaming via refetch.

**116 frontend + 314 backend tests pass; build clean; lint unchanged (8 pre-existing errors, 0 new).**

## Out of scope
Cross-process / multi-dashboard coordination — the bus is per-process; a process restart still falls back to the DB, unchanged.