### PR TITLE
fix(chat): make direct clicks on sidebar checkboxes toggle selection

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -30,7 +30,12 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
           mouse event. Reading shiftKey from the label click — and
           preventDefault-ing so the synthetic input toggle never fires —
           keeps the full hit target consistent with the visible checkbox
-          (PR #48 codex iter 2). */}
+          (PR #48 codex iter 2). Direct clicks on the input must NOT be
+          canceled — a canceled click makes the browser revert the native
+          checked toggle after React has already committed checked=true,
+          desyncing the visible box from selection state — so the input
+          handles its own click (stopPropagation keeps the label handler
+          out of it). */}
       {isSpinoff ? (
         <label
           className="group/iconslot relative w-8 h-8 -m-2 flex items-center justify-center flex-shrink-0 cursor-pointer"
@@ -43,6 +48,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => {}}
+            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${spinoffCheckboxVisibilityClass}`}
             title="Select"
           />
@@ -56,6 +62,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
             type="checkbox"
             checked={selected}
             onChange={() => {}}
+            onClick={e => { e.stopPropagation(); onToggleSelect(conv.id, e.shiftKey) }}
             className={`w-3.5 h-3.5 accent-accent cursor-pointer transition-opacity ${
               checkboxShown ? 'opacity-100' : 'opacity-0 group-hover/iconslot:opacity-100'
             }`}

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -94,15 +94,47 @@ describe('ChatSidebar shift-click range selection', () => {
     expect(selectedTitles()).toEqual(['A', 'A1', 'B', 'C', 'C1', 'D'])
   })
 
-  // Note: the in-real-browsers scenario where the user clicks directly
-  // on the visible 14px <input> (whose click bubbles up to the label's
-  // onClick) cannot be reproduced under jsdom — its label activation
-  // model doesn't propagate input clicks to a wrapping label's onClick
-  // the way real browsers do. The label-padding tests above (which click
-  // the label element directly) cover the case codex iter 2 actually
-  // flagged: the synthetic activation when the user clicks the larger
-  // hit target. Direct-input clicks are exercised manually in the
-  // browser as part of the PR's test plan.
+  // Direct clicks on the 14px <input> itself take a different code path
+  // from label-padding clicks: the input's own onClick stops propagation
+  // (so the label's preventDefault never cancels the native toggle) and
+  // toggles selection itself. These tests click the input element
+  // directly so a regression in either duplicated input handler — or a
+  // reintroduced preventDefault that desyncs the visible checkbox from
+  // selection state — fails here even while the label-padding tests stay
+  // green.
+  function inputFor(title) {
+    const row = screen.getByText(title).closest('.group')
+    return within(row).getByRole('checkbox')
+  }
+
+  it('clicking directly on a root checkbox input selects it and checks the box', () => {
+    renderSidebar()
+    fireEvent.click(inputFor('B'))
+    expect(inputFor('B').checked).toBe(true)
+    expect(selectedTitles()).toEqual(['B'])
+  })
+
+  it('clicking directly on a spinoff checkbox input selects it and checks the box', () => {
+    renderSidebar()
+    fireEvent.click(inputFor('A1'))
+    expect(inputFor('A1').checked).toBe(true)
+    expect(selectedTitles()).toEqual(['A1'])
+  })
+
+  it('shift-clicking directly on an input extends the range from the anchor', () => {
+    renderSidebar()
+    fireEvent.click(inputFor('A'))                      // anchor = A
+    fireEvent.click(inputFor('C'), { shiftKey: true })  // range A..C
+    expect(selectedTitles()).toEqual(['A', 'A1', 'B', 'C'])
+  })
+
+  it('clicking a selected input directly deselects it', () => {
+    renderSidebar()
+    fireEvent.click(inputFor('B'))
+    fireEvent.click(inputFor('B'))
+    expect(inputFor('B').checked).toBe(false)
+    expect(selectedTitles()).toEqual([])
+  })
 
   it('Clear resets the anchor so the next shift-click no longer extends the old range', () => {
     renderSidebar()


### PR DESCRIPTION
## Problem

Selecting a conversation via its checkbox showed **"1 selected"** in the toolbar, but the checkbox itself stayed visually unchecked.

## Root cause

The `<label>` wrapping each checkbox calls `e.preventDefault()` on click (needed since PR #48 to suppress the label's synthetic forwarded click for padding clicks). But when the click lands **directly on the input**, canceling the event makes the browser revert the native `checked` toggle *after* React has already committed `checked={true}` — and since React only rewrites the DOM property when the prop changes, the box stays permanently desynced from selection state.

## Fix

Direct input clicks are now handled on the input itself: `stopPropagation()` keeps the label's `preventDefault` out of the path (so nothing reverts the native toggle), and the handler calls `onToggleSelect(conv.id, e.shiftKey)` — shift-click range selection keeps working since the modifier is read from the real mouse event. Padding clicks go through the unchanged label path.

## Testing

- `vitest run src/components/chat/ChatSidebar.test.jsx` — 9/9 pass