### PR TITLE
feat(chat): support chatting with OpenRouter models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,30 @@ accuracy / tool-posture guidance. See
 `dashboard/mcp_servers.example.json` for the `websearch` `tool_hint`
 carrying the web-research guidance.
 
+## Chatting with OpenRouter models
+
+Chat can target OpenRouter-hosted models alongside local Docker services.
+Enable by setting `OPENROUTER_API_KEY` in `dashboard/.env` (restart the
+dashboard to pick it up); without it, OpenRouter models simply don't
+appear in the chat pickers.
+
+- An OpenRouter model is addressed by the service string
+  `openrouter:<model-id>` (e.g. `openrouter:anthropic/claude-sonnet-5`) in
+  the same `main_service` / `sidekick_service` / `model_service` columns as
+  local service names. `chat/llm_proxy.resolve_service()` branches on the
+  prefix via `chat/openrouter.py`.
+- The curated picker list (built-in defaults in
+  `chat/openrouter.py:DEFAULT_MODELS`) is editable at runtime: Tools page →
+  "OpenRouter models" card, or `GET/PUT/DELETE
+  /api/chat/settings/openrouter-models` (stored under `openrouter_models`
+  in `chat_settings.json`). The list is a picker convenience, **not an
+  allowlist** — any `openrouter:` string resolves as long as the key is
+  set, so removing a model doesn't break conversations already using it.
+- MCP tool calling, streaming, images, and critique all go through the
+  same code paths as local models. OpenRouter requires an explicit
+  `model` field in the payload; local single-model servers must NOT get
+  one (regression-tested in `tests/test_openrouter_routes.py`).
+
 ## Reference: working embedding service
 
 `vllm-nomic-embed-text-v1.5` (port 3320) — see `services.json`. Smoke

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -5,3 +5,5 @@ COMPOSE_PROJECT_NAME=llm-dock
 COMPOSE_FILE=../docker-compose.yml
 LOG_LEVEL=INFO
 LLM_DOCK_API_KEY=your-global-api-key-here
+# Optional: enables OpenRouter-hosted models in the chat model pickers.
+# OPENROUTER_API_KEY=sk-or-v1-...

--- a/dashboard/chat/critique.py
+++ b/dashboard/chat/critique.py
@@ -53,8 +53,10 @@ def request_critique(sidekick_service: str, context: str, extra_instructions: st
             return {"error": f"Sidekick returned HTTP {resp.status_code}: {resp.text}"}
 
         data = resp.json()
-        raw_content = data["choices"][0]["message"].get("content", "")
         message = data["choices"][0]["message"]
+        # OpenAI-compatible providers define content as string|null — an
+        # explicit null bypasses .get()'s default, so normalize with `or`.
+        raw_content = message.get("content") or ""
         raw_reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
 
         # The actual critique may be in content or reasoning_content depending on model

--- a/dashboard/chat/critique.py
+++ b/dashboard/chat/critique.py
@@ -6,7 +6,7 @@ import re
 import requests
 
 from .constants import CRITIQUE_SYSTEM_PROMPT, DEFAULT_CONTEXT_WINDOW
-from .llm_proxy import resolve_service
+from .llm_proxy import build_endpoint, resolve_service, unreachable_message
 from .models import Message
 
 logger = logging.getLogger(__name__)
@@ -33,13 +33,9 @@ def request_critique(sidekick_service: str, context: str, extra_instructions: st
     """Send a critique request to the sidekick model and parse the response."""
     svc = resolve_service(sidekick_service)
     if svc is None:
-        return {"error": f"Service '{sidekick_service}' is not reachable. Is it running?"}
+        return {"error": unreachable_message(sidekick_service)}
 
-    url = f"http://localhost:{svc['host_port']}/v1/chat/completions"
-    headers = {
-        "Authorization": f"Bearer {svc['api_key']}",
-        "Content-Type": "application/json",
-    }
+    url, headers = build_endpoint(svc)
     payload = {
         "messages": [
             {"role": "system", "content": CRITIQUE_SYSTEM_PROMPT},
@@ -47,6 +43,9 @@ def request_critique(sidekick_service: str, context: str, extra_instructions: st
         ],
         "temperature": 0.3,
     }
+    if svc.get("model"):
+        # Remote multi-model providers (OpenRouter) require an explicit model.
+        payload["model"] = svc["model"]
 
     try:
         resp = requests.post(url, json=payload, headers=headers, timeout=120)
@@ -55,7 +54,8 @@ def request_critique(sidekick_service: str, context: str, extra_instructions: st
 
         data = resp.json()
         raw_content = data["choices"][0]["message"].get("content", "")
-        raw_reasoning = data["choices"][0]["message"].get("reasoning_content", "")
+        message = data["choices"][0]["message"]
+        raw_reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
 
         # The actual critique may be in content or reasoning_content depending on model
         critique_text = raw_content if raw_content.strip() else raw_reasoning

--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -59,7 +59,16 @@ def detect_format_drift(content: str, reasoning: str = "", had_tool_calls: bool 
 
 
 def resolve_service(service_name: str) -> dict:
-    """Resolve a service name to host_port and api_key using docker_utils."""
+    """Resolve a service name to connection details.
+
+    Local Docker services resolve to ``{host_port, api_key}`` via
+    docker_utils; ``openrouter:<model-id>`` strings resolve to
+    ``{base_url, api_key, model, extra_headers}`` (or None when no
+    OPENROUTER_API_KEY is configured).
+    """
+    from . import openrouter
+    if openrouter.is_openrouter_service(service_name):
+        return openrouter.resolve(service_name)
     from docker_utils import get_docker_services
     services = get_docker_services()
     for svc in services:
@@ -69,6 +78,45 @@ def resolve_service(service_name: str) -> dict:
                 "api_key": svc["api_key"],
             }
     return None
+
+
+def unreachable_message(service_name: str) -> str:
+    """Error text for a service that failed to resolve."""
+    from . import openrouter
+    if openrouter.is_openrouter_service(service_name):
+        return ("OpenRouter is not configured "
+                "(OPENROUTER_API_KEY missing in dashboard/.env).")
+    return f"Service '{service_name}' is not reachable. Is it running?"
+
+
+def build_endpoint(svc: dict) -> tuple:
+    """Return (url, headers) for a resolved service — local docker or remote.
+
+    ``base_url`` (when present) is an OpenAI-style base already ending in
+    ``/v1``, e.g. ``https://openrouter.ai/api/v1``.
+    """
+    base = svc.get("base_url") or f"http://localhost:{svc['host_port']}/v1"
+    headers = {
+        "Authorization": f"Bearer {svc['api_key']}",
+        "Content-Type": "application/json",
+    }
+    headers.update(svc.get("extra_headers") or {})
+    return f"{base}/chat/completions", headers
+
+
+def _extract_error_message(resp) -> str:
+    """Pull the provider's error message out of a non-200 response body.
+
+    OpenAI-compatible providers return ``{"error": {"message": ...}}``;
+    fall back to the raw body when that shape isn't there.
+    """
+    try:
+        err = resp.json().get("error")
+        if isinstance(err, dict) and err.get("message"):
+            return err["message"]
+    except (ValueError, AttributeError):
+        pass
+    return resp.text
 
 
 def build_messages_array(system_prompt: str, messages: list) -> list:
@@ -111,18 +159,18 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
     """
     svc = resolve_service(service_name)
     if svc is None:
-        yield ("error", {"message": f"Service '{service_name}' is not reachable. Is it running?"})
+        yield ("error", {"message": unreachable_message(service_name)})
         return
 
-    url = f"http://localhost:{svc['host_port']}/v1/chat/completions"
-    headers = {
-        "Authorization": f"Bearer {svc['api_key']}",
-        "Content-Type": "application/json",
-    }
+    url, headers = build_endpoint(svc)
     payload = {
         "messages": messages_array,
         "stream": True,
     }
+    if svc.get("model"):
+        # Remote multi-model providers (OpenRouter) require an explicit model;
+        # local single-model servers don't get one and ignore its absence.
+        payload["model"] = svc["model"]
     if tools:
         payload["tools"] = tools
         payload["tool_choice"] = tool_choice or "auto"
@@ -148,7 +196,7 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
         resp = requests.post(url, json=payload, headers=headers, stream=True, timeout=300)
         resp.encoding = "utf-8"
         if resp.status_code != 200:
-            error_body = resp.text
+            error_body = _extract_error_message(resp)
             yield ("error", {"message": f"Model returned HTTP {resp.status_code}: {error_body}"})
             return
 
@@ -165,6 +213,14 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
                 chunk = json.loads(data)
             except json.JSONDecodeError:
                 continue
+
+            # OpenRouter can deliver an error object mid-stream (e.g. a rate
+            # limit hit after streaming started) instead of a choices chunk.
+            if isinstance(chunk, dict) and "error" in chunk:
+                err = chunk["error"] or {}
+                message = err.get("message") if isinstance(err, dict) else None
+                yield ("error", {"message": f"Provider error: {message or json.dumps(err)}"})
+                return
 
             choice = chunk.get("choices", [{}])[0]
             delta = choice.get("delta", {})

--- a/dashboard/chat/llm_proxy.py
+++ b/dashboard/chat/llm_proxy.py
@@ -222,7 +222,10 @@ def stream_chat_completion(service_name: str, messages_array: list, tools: list 
                 yield ("error", {"message": f"Provider error: {message or json.dumps(err)}"})
                 return
 
-            choice = chunk.get("choices", [{}])[0]
+            # `choices` can be legitimately empty — OpenRouter emits a final
+            # usage chunk with `choices: []` before [DONE]. Treat it (and any
+            # other choice-less chunk) as a no-op instead of IndexError-ing.
+            choice = (chunk.get("choices") or [{}])[0]
             delta = choice.get("delta", {})
             chunk_finish = choice.get("finish_reason")
             if chunk_finish:

--- a/dashboard/chat/openrouter.py
+++ b/dashboard/chat/openrouter.py
@@ -1,0 +1,76 @@
+"""OpenRouter provider support for chat.
+
+An OpenRouter model is addressed with a ``openrouter:<model-id>`` service
+string (e.g. ``openrouter:anthropic/claude-sonnet-5``) stored in the same
+``main_service`` / ``sidekick_service`` / ``model_service`` columns as local
+Docker service names — no schema changes. ``llm_proxy.resolve_service``
+branches on the prefix and calls :func:`resolve` here instead of the Docker
+lookup.
+
+The curated model list shown in the picker is a convenience, not an
+allowlist: any ``openrouter:`` service string resolves as long as
+``OPENROUTER_API_KEY`` is configured, so conversations keep working when
+their model is later removed from the list. The list itself is editable at
+runtime via ``settings_store`` (Tools page), with :data:`DEFAULT_MODELS` as
+the built-in baseline.
+"""
+
+import config
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+SERVICE_PREFIX = "openrouter:"
+
+# Optional attribution headers OpenRouter recommends; they identify the app
+# in OpenRouter's logs and rankings.
+OPENROUTER_EXTRA_HEADERS = {
+    "HTTP-Referer": "https://github.com/teo-mateo/llm-dock",
+    "X-Title": "llm-dock",
+}
+
+# Built-in curated selection of popular models (all tool-capable, verified
+# against openrouter.ai/api/v1/models). Overridable at runtime via
+# settings_store.set_openrouter_models().
+DEFAULT_MODELS = [
+    {"id": "anthropic/claude-sonnet-5", "label": "Claude Sonnet 5"},
+    {"id": "anthropic/claude-opus-4.8", "label": "Claude Opus 4.8"},
+    {"id": "anthropic/claude-haiku-4.5", "label": "Claude Haiku 4.5"},
+    {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
+    {"id": "openai/gpt-5.4-mini", "label": "GPT-5.4 Mini"},
+    {"id": "google/gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro (Preview)"},
+    {"id": "google/gemini-3.5-flash", "label": "Gemini 3.5 Flash"},
+    {"id": "x-ai/grok-4.5", "label": "Grok 4.5"},
+    {"id": "deepseek/deepseek-v3.2", "label": "DeepSeek V3.2"},
+    {"id": "qwen/qwen3.7-max", "label": "Qwen3.7 Max"},
+    {"id": "moonshotai/kimi-k2.6", "label": "Kimi K2.6"},
+    {"id": "z-ai/glm-5", "label": "GLM 5"},
+]
+
+
+def is_configured() -> bool:
+    """True when an OpenRouter API key is present in the environment."""
+    return bool(config.OPENROUTER_API_KEY)
+
+
+def is_openrouter_service(service_name) -> bool:
+    return isinstance(service_name, str) and service_name.startswith(SERVICE_PREFIX)
+
+
+def model_id(service_name: str) -> str:
+    return service_name[len(SERVICE_PREFIX):]
+
+
+def resolve(service_name: str):
+    """Provider-branch counterpart of ``llm_proxy.resolve_service``.
+
+    Returns the connection dict for an ``openrouter:`` service string, or
+    ``None`` when no API key is configured (same shape as a stopped local
+    service, so callers hit their existing unreachable path).
+    """
+    if not is_configured():
+        return None
+    return {
+        "base_url": OPENROUTER_BASE_URL,
+        "api_key": config.OPENROUTER_API_KEY,
+        "model": model_id(service_name),
+        "extra_headers": dict(OPENROUTER_EXTRA_HEADERS),
+    }

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -16,7 +16,7 @@ from .event_codec import DONE, encode_sse, encode_sse_event, encode_sse_delta
 from .event_bus import EventBus
 from .run_manager import ChatRunManager
 from .runs import ChatRunStatus, TERMINAL_STATUSES
-from . import settings_store
+from . import openrouter, settings_store
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +116,53 @@ def delete_main_system_prompt_setting():
     settings_store.reset_main_system_prompt()
     logger.info("default main_system_prompt reset to built-in")
     return jsonify(_settings_payload())
+
+
+# -- Settings: curated OpenRouter model list --
+
+def _openrouter_settings_payload() -> dict:
+    """Shape returned by every openrouter-models settings endpoint.
+
+    ``configured`` tells the frontend whether OPENROUTER_API_KEY is set —
+    the chat picker hides the OpenRouter group when it isn't, while the
+    Tools-page editor stays usable and just shows a banner.
+    """
+    return {
+        "configured": openrouter.is_configured(),
+        "current": settings_store.get_openrouter_models(),
+        "builtin": openrouter.DEFAULT_MODELS,
+        "customized": settings_store.is_openrouter_models_customized(),
+    }
+
+
+@chat_bp.route("/api/chat/settings/openrouter-models", methods=["GET"])
+@require_auth
+def get_openrouter_models_setting():
+    return jsonify(_openrouter_settings_payload())
+
+
+@chat_bp.route("/api/chat/settings/openrouter-models", methods=["PUT"])
+@require_auth
+def put_openrouter_models_setting():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be {models: [{id, label?}]}"}), 400
+    models = data.get("models")
+    try:
+        settings_store.set_openrouter_models(models)
+    except (TypeError, ValueError) as e:
+        return jsonify({"error": str(e)}), 400
+    logger.info("openrouter model list updated (%d models)", len(models))
+    return jsonify(_openrouter_settings_payload())
+
+
+@chat_bp.route("/api/chat/settings/openrouter-models", methods=["DELETE"])
+@require_auth
+def delete_openrouter_models_setting():
+    """Drop any customization, reverting the picker to the built-in list."""
+    settings_store.reset_openrouter_models()
+    logger.info("openrouter model list reset to built-in")
+    return jsonify(_openrouter_settings_payload())
 
 
 # -- Conversations CRUD --

--- a/dashboard/chat/settings_store.py
+++ b/dashboard/chat/settings_store.py
@@ -1,11 +1,16 @@
 """Persistent chat settings (singleton).
 
-Currently holds one value: the user-customized default
-``main_system_prompt`` used for new conversations. If the setting is
-absent (or the settings file does not exist or fails to parse), the
-built-in ``DEFAULT_MAIN_SYSTEM_PROMPT`` from ``constants.py`` is used.
-This lets the dashboard surface the default prompt as something the user
-can edit without a code change + service restart.
+Holds user-customized settings that fall back to built-in defaults when
+absent (or when the settings file does not exist or fails to parse):
+
+- ``main_system_prompt`` — the default system prompt for new
+  conversations (built-in: ``DEFAULT_MAIN_SYSTEM_PROMPT`` in
+  ``constants.py``).
+- ``openrouter_models`` — the curated OpenRouter model list shown in the
+  chat model pickers (built-in: ``DEFAULT_MODELS`` in ``openrouter.py``).
+
+This lets the dashboard surface these as editable without a code change +
+service restart.
 
 Storage: a single JSON file (``dashboard/chat_settings.json`` by
 default), one top-level object. Written atomically via tempfile + fsync +
@@ -25,6 +30,7 @@ import tempfile
 import threading
 
 from .constants import DEFAULT_MAIN_SYSTEM_PROMPT
+from .openrouter import DEFAULT_MODELS as DEFAULT_OPENROUTER_MODELS
 
 logger = logging.getLogger(__name__)
 
@@ -124,11 +130,16 @@ def set_main_system_prompt(content: str) -> None:
 
 def reset_main_system_prompt() -> None:
     """Remove any stored override so new conversations get the built-in."""
+    _reset_key("main_system_prompt")
+
+
+def _reset_key(key: str) -> None:
+    """Remove ``key`` from the store, unlinking the file if it ends up empty."""
     with _lock:
         data = _load_unlocked()
-        if "main_system_prompt" not in data:
+        if key not in data:
             return
-        del data["main_system_prompt"]
+        del data[key]
         if data:
             _save_unlocked(data)
             return
@@ -140,3 +151,87 @@ def reset_main_system_prompt() -> None:
                 os.unlink(path)
             except OSError as e:
                 logger.warning("chat_settings: cannot unlink %s: %s", path, e)
+
+
+# -- Curated OpenRouter model list --
+
+def _valid_openrouter_models(value) -> bool:
+    """True if ``value`` is a well-formed stored model list (may be empty)."""
+    if not isinstance(value, list):
+        return False
+    seen = set()
+    for entry in value:
+        if not isinstance(entry, dict):
+            return False
+        model = entry.get("id")
+        if not isinstance(model, str) or not model.strip():
+            return False
+        label = entry.get("label")
+        if label is not None and not isinstance(label, str):
+            return False
+        if model in seen:
+            return False
+        seen.add(model)
+    return True
+
+
+def _normalize_openrouter_models(models: list) -> list:
+    return [
+        {"id": m["id"].strip(), "label": (m.get("label") or m["id"]).strip() or m["id"].strip()}
+        for m in models
+    ]
+
+
+def get_openrouter_models() -> list:
+    """Return the customized model list, or the built-in if not set/invalid.
+
+    An empty stored list is honored — it means the user hid every
+    OpenRouter model from the picker without unsetting the API key.
+    """
+    with _lock:
+        data = _load_unlocked()
+    value = data.get("openrouter_models")
+    if _valid_openrouter_models(value):
+        return value
+    return [dict(m) for m in DEFAULT_OPENROUTER_MODELS]
+
+
+def is_openrouter_models_customized() -> bool:
+    """True if a valid override is stored AND differs from the built-in."""
+    with _lock:
+        data = _load_unlocked()
+    value = data.get("openrouter_models")
+    return _valid_openrouter_models(value) and value != DEFAULT_OPENROUTER_MODELS
+
+
+def set_openrouter_models(models: list) -> None:
+    """Persist ``models`` as the curated OpenRouter model list.
+
+    Each entry must be a dict with a non-empty string ``id``; ``label`` is
+    optional and defaults to the id. An empty list is allowed. Raises
+    ``TypeError`` / ``ValueError`` on malformed input.
+    """
+    if not isinstance(models, list):
+        raise TypeError("openrouter_models must be a list")
+    seen = set()
+    for entry in models:
+        if not isinstance(entry, dict):
+            raise ValueError("each model must be an object with an 'id'")
+        model = entry.get("id")
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError("each model must have a non-empty string 'id'")
+        label = entry.get("label")
+        if label is not None and not isinstance(label, str):
+            raise ValueError("model 'label' must be a string when present")
+        if model.strip() in seen:
+            raise ValueError(f"duplicate model id: {model.strip()}")
+        seen.add(model.strip())
+    with _lock:
+        data = _load_unlocked()
+        data["openrouter_models"] = _normalize_openrouter_models(models)
+        _save_unlocked(data)
+
+
+def reset_openrouter_models() -> None:
+    """Remove any stored override, reverting the picker to the built-in list."""
+    _reset_key("openrouter_models")

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -13,6 +13,9 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 COMPOSE_FILE = os.getenv("COMPOSE_FILE", "../docker-compose.yml")
 COMPOSE_PROJECT = os.getenv("COMPOSE_PROJECT_NAME", "dockerized-models")
 GLOBAL_API_KEY = os.getenv("LLM_DOCK_API_KEY")
+# Optional. When set, OpenRouter-hosted models become selectable in the chat
+# model pickers. Read via ``config.OPENROUTER_API_KEY`` (attribute access).
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
 
 def set_global_api_key(new_key: str, dotenv_path: str = DOTENV_PATH):

--- a/dashboard/frontend/src/components/chat/ChatArea.jsx
+++ b/dashboard/frontend/src/components/chat/ChatArea.jsx
@@ -128,7 +128,7 @@ export default function ChatArea({
           <p className="text-sm text-fg-subtle mb-6 text-center">
             {defaultModelName
               ? <>Type a message below — a chat will be created with <span className="text-fg-muted">{defaultModelName}</span>.</>
-              : 'No running model services available. Start a model first.'}
+              : 'No model available. Start a local model or configure OpenRouter.'}
           </p>
           <div className="w-full">
             <ChatInput

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -5,6 +5,8 @@ import ChatArea from './ChatArea'
 import useConversations from '../../hooks/useConversations'
 import useChat from '../../hooks/useChat'
 import useRunningServices from '../../hooks/useRunningServices'
+import useOpenRouterModels from '../../hooks/useOpenRouterModels'
+import { serviceNameForModel, formatModelLabel } from '../../utils/openrouter'
 import { pendingFlushDecision } from './pendingFlush'
 
 export default function ChatPage() {
@@ -14,6 +16,7 @@ export default function ChatPage() {
 
   const { conversations, refresh, create, remove, removeMany, patchConversation } = useConversations()
   const { services: runningServices } = useRunningServices()
+  const { data: openRouterData } = useOpenRouterModels()
   const {
     conversation,
     messages,
@@ -86,31 +89,38 @@ export default function ChatPage() {
     }
   }, [runReady]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Default main model for new conversations: the first running local
+  // service wins; with none running, fall back to the first curated
+  // OpenRouter model (only offered when OPENROUTER_API_KEY is configured).
+  // The backend requires a non-empty main_service so we can't create
+  // without one.
+  const openRouterModels = openRouterData?.configured ? openRouterData.current : []
+  const defaultModelName =
+    runningServices[0]?.name ||
+    (openRouterModels[0] ? serviceNameForModel(openRouterModels[0].id) : null)
+
   const handleCreate = useCallback(async () => {
-    // Default the main model to the first running service. When exactly
-    // one model is up this preselects it; the backend requires a non-empty
-    // main_service so we can't create without one.
-    if (runningServices.length === 0) {
-      window.alert('No running model services available. Start a model first.')
+    if (!defaultModelName) {
+      window.alert('No model available. Start a local model or configure OpenRouter.')
       return
     }
     const conv = await create({
-      main_service: runningServices[0].name,
+      main_service: defaultModelName,
     })
     navigate(`/chat/${conv.id}`)
-  }, [create, navigate, runningServices])
+  }, [create, navigate, defaultModelName])
 
   // Empty-state composer: create a conversation, then queue the typed
   // message so it sends as soon as the new conversation loads.
   const handleCreateAndSend = useCallback(async (content, images) => {
-    if (runningServices.length === 0) {
-      window.alert('No running model services available. Start a model first.')
+    if (!defaultModelName) {
+      window.alert('No model available. Start a local model or configure OpenRouter.')
       return
     }
-    const conv = await create({ main_service: runningServices[0].name })
+    const conv = await create({ main_service: defaultModelName })
     pendingMsgRef.current = { convId: conv.id, content, images }
     navigate(`/chat/${conv.id}`)
-  }, [create, navigate, runningServices])
+  }, [create, navigate, defaultModelName])
 
   const handleSelect = useCallback((id) => {
     navigate(`/chat/${id}`)
@@ -159,7 +169,7 @@ export default function ChatPage() {
       <ChatArea
         conversation={conversation}
         awaitingConversation={!!convId && (!conversation || conversation.id !== convId)}
-        defaultModelName={runningServices[0]?.name || null}
+        defaultModelName={formatModelLabel(defaultModelName, openRouterModels)}
         onCreateAndSend={handleCreateAndSend}
         messages={messages}
         critiques={critiques}

--- a/dashboard/frontend/src/components/chat/ChatPageDefaultModel.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPageDefaultModel.test.jsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ChatPage from './ChatPage'
+
+// This file covers the default-model fallback: with zero local services
+// running, a configured OpenRouter model must make chat creation possible
+// (ChatArea gets a non-null defaultModelName), and with neither source the
+// composer stays disabled (null).
+
+vi.mock('./ChatSidebar', () => ({ default: () => null }))
+
+const { capturedAreaProps } = vi.hoisted(() => ({ capturedAreaProps: { current: null } }))
+vi.mock('./ChatArea', () => ({
+  default: (props) => { capturedAreaProps.current = props; return null },
+}))
+
+const { mockServicesSSE, mockOpenRouterModels } = vi.hoisted(() => ({
+  mockServicesSSE: vi.fn(),
+  mockOpenRouterModels: vi.fn(),
+}))
+vi.mock('../../hooks/useServicesSSE', () => ({ default: (...a) => mockServicesSSE(...a) }))
+vi.mock('../../hooks/useOpenRouterModels', () => ({ default: (...a) => mockOpenRouterModels(...a) }))
+
+const { mockListConversations } = vi.hoisted(() => ({ mockListConversations: vi.fn() }))
+vi.mock('../../services/chat', async (importActual) => ({
+  ...(await importActual()),
+  listConversations: (...a) => mockListConversations(...a),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <Routes>
+        <Route path="/chat/:conversationId?" element={<ChatPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  capturedAreaProps.current = null
+  mockListConversations.mockReset()
+  mockListConversations.mockResolvedValue({ conversations: [] })
+})
+
+afterEach(() => cleanup())
+
+describe('ChatPage default model fallback', () => {
+  it('prefers the first running local service', async () => {
+    mockServicesSSE.mockReturnValue({ services: [{ name: 'vllm-test', status: 'running', kind: 'chat' }], loading: false })
+    mockOpenRouterModels.mockReturnValue({
+      data: { configured: true, current: [{ id: 'vendor/model-a', label: 'Model A' }], builtin: [], customized: false },
+      loading: false,
+    })
+    renderPage()
+    await waitFor(() => expect(capturedAreaProps.current).not.toBeNull())
+    expect(capturedAreaProps.current.defaultModelName).toBe('vllm-test')
+  })
+
+  it('falls back to the first OpenRouter model when no local service runs', async () => {
+    mockServicesSSE.mockReturnValue({ services: [], loading: false })
+    mockOpenRouterModels.mockReturnValue({
+      data: { configured: true, current: [{ id: 'vendor/model-a', label: 'Model A' }], builtin: [], customized: false },
+      loading: false,
+    })
+    renderPage()
+    await waitFor(() => expect(capturedAreaProps.current).not.toBeNull())
+    // Displayed via formatModelLabel — the friendly curated label.
+    expect(capturedAreaProps.current.defaultModelName).toBe('Model A · OpenRouter')
+  })
+
+  it('passes null when neither local services nor OpenRouter are available', async () => {
+    mockServicesSSE.mockReturnValue({ services: [], loading: false })
+    mockOpenRouterModels.mockReturnValue({
+      data: { configured: false, current: [{ id: 'vendor/model-a', label: 'Model A' }], builtin: [], customized: false },
+      loading: false,
+    })
+    renderPage()
+    await waitFor(() => expect(capturedAreaProps.current).not.toBeNull())
+    expect(capturedAreaProps.current.defaultModelName).toBe(null)
+  })
+})

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -14,6 +14,7 @@ import ToolResultBlock from './ToolResultBlock'
 import FormatDriftChip from './FormatDriftChip'
 import { detectFormatDrift } from './formatDrift'
 import useProseClass from '../../hooks/useProseClass'
+import { formatModelLabel } from '../../utils/openrouter'
 
 const MD_COMPONENTS = {
   pre: CopyablePre,
@@ -70,7 +71,7 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
         <div className={`max-w-[90%] ${isUser ? 'order-1' : ''}`}>
           {/* Role label — light/minimal, no mono meta line */}
           <div className={`text-[10px] text-fg-subtle mb-1 ${isUser ? 'text-right' : ''}`}>
-            {isUser ? 'You' : message.model_service || 'Assistant'}
+            {isUser ? 'You' : formatModelLabel(message.model_service) || 'Assistant'}
           </div>
 
         {/* Thinking block for assistant */}

--- a/dashboard/frontend/src/components/chat/ModelSelector.jsx
+++ b/dashboard/frontend/src/components/chat/ModelSelector.jsx
@@ -1,11 +1,48 @@
 import useRunningServices from '../../hooks/useRunningServices'
+import useOpenRouterModels from '../../hooks/useOpenRouterModels'
+import { isOpenRouterService, openRouterModelId, serviceNameForModel } from '../../utils/openrouter'
+
+// One dropdown's options: local running services + curated OpenRouter models.
+// `selected` may reference an OpenRouter model that was since removed from
+// the curated list (or a key that got unset) — keep it visible as a fallback
+// option so the native select doesn't render blank and the persisted value
+// survives an unrelated save.
+function ModelOptions({ services, openRouterModels, selected }) {
+  const openRouterValues = openRouterModels.map(m => serviceNameForModel(m.id))
+  const stale =
+    isOpenRouterService(selected) && !openRouterValues.includes(selected)
+  return (
+    <>
+      {services.length > 0 && (
+        <optgroup label="Local">
+          {services.map(s => (
+            <option key={s.name} value={s.name}>{s.name}</option>
+          ))}
+        </optgroup>
+      )}
+      {openRouterModels.length > 0 && (
+        <optgroup label="OpenRouter">
+          {openRouterModels.map(m => (
+            <option key={m.id} value={serviceNameForModel(m.id)}>{m.label}</option>
+          ))}
+        </optgroup>
+      )}
+      {stale && (
+        <option value={selected}>{openRouterModelId(selected)} (not in list)</option>
+      )}
+    </>
+  )
+}
 
 export default function ModelSelector({ mainService, sidekickService, onChangeMain, onChangeSidekick, disabled }) {
   const { services, loading } = useRunningServices()
+  const { data: openRouterData, loading: openRouterLoading } = useOpenRouterModels()
 
-  if (loading) {
+  if (loading || openRouterLoading) {
     return <div className="text-xs text-fg-subtle">Loading services...</div>
   }
+
+  const openRouterModels = openRouterData?.configured ? openRouterData.current : []
 
   return (
     <div className="flex gap-4 items-center flex-wrap">
@@ -18,9 +55,7 @@ export default function ModelSelector({ mainService, sidekickService, onChangeMa
           className="bg-surface border border-border rounded px-2 py-1 text-xs text-fg disabled:opacity-50"
         >
           <option value="">Select model...</option>
-          {services.map(s => (
-            <option key={s.name} value={s.name}>{s.name}</option>
-          ))}
+          <ModelOptions services={services} openRouterModels={openRouterModels} selected={mainService} />
         </select>
       </div>
       <div className="flex items-center gap-2">
@@ -32,9 +67,7 @@ export default function ModelSelector({ mainService, sidekickService, onChangeMa
           className="bg-surface border border-border rounded px-2 py-1 text-xs text-fg disabled:opacity-50"
         >
           <option value="">None</option>
-          {services.map(s => (
-            <option key={s.name} value={s.name}>{s.name}</option>
-          ))}
+          <ModelOptions services={services} openRouterModels={openRouterModels} selected={sidekickService} />
         </select>
       </div>
     </div>

--- a/dashboard/frontend/src/components/chat/ModelSelector.test.jsx
+++ b/dashboard/frontend/src/components/chat/ModelSelector.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import ModelSelector from './ModelSelector'
+
+const { mockRunningServices, mockOpenRouterModels } = vi.hoisted(() => ({
+  mockRunningServices: vi.fn(),
+  mockOpenRouterModels: vi.fn(),
+}))
+vi.mock('../../hooks/useRunningServices', () => ({ default: (...a) => mockRunningServices(...a) }))
+vi.mock('../../hooks/useOpenRouterModels', () => ({ default: (...a) => mockOpenRouterModels(...a) }))
+
+const LOCAL = [{ name: 'vllm-test' }]
+const CURATED = [{ id: 'vendor/model-a', label: 'Model A' }]
+
+function setup({ services = LOCAL, configured = true, current = CURATED, mainService = '' } = {}) {
+  mockRunningServices.mockReturnValue({ services, loading: false })
+  mockOpenRouterModels.mockReturnValue({
+    data: { configured, current, builtin: CURATED, customized: false },
+    loading: false,
+  })
+  return render(
+    <ModelSelector
+      mainService={mainService}
+      sidekickService={null}
+      onChangeMain={() => {}}
+      onChangeSidekick={() => {}}
+      disabled={false}
+    />
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('ModelSelector OpenRouter integration', () => {
+  it('shows Local and OpenRouter optgroups when configured', () => {
+    const { container } = setup()
+    const groups = [...container.querySelectorAll('optgroup')].map(g => g.label)
+    // Both selects (Main + Critic) get both groups.
+    expect(groups).toEqual(['Local', 'OpenRouter', 'Local', 'OpenRouter'])
+    const openRouterOption = container.querySelector('option[value="openrouter:vendor/model-a"]')
+    expect(openRouterOption).not.toBeNull()
+    expect(openRouterOption.textContent).toBe('Model A')
+  })
+
+  it('hides the OpenRouter group when the key is not configured', () => {
+    const { container } = setup({ configured: false })
+    const groups = [...container.querySelectorAll('optgroup')].map(g => g.label)
+    expect(groups).toEqual(['Local', 'Local'])
+    expect(container.querySelector('option[value="openrouter:vendor/model-a"]')).toBeNull()
+  })
+
+  it('renders with no local services running (OpenRouter only)', () => {
+    const { container } = setup({ services: [] })
+    const groups = [...container.querySelectorAll('optgroup')].map(g => g.label)
+    expect(groups).toEqual(['OpenRouter', 'OpenRouter'])
+  })
+
+  it('keeps a stale OpenRouter selection visible as a fallback option', () => {
+    const { container } = setup({ mainService: 'openrouter:vendor/removed' })
+    const fallback = container.querySelector('option[value="openrouter:vendor/removed"]')
+    expect(fallback).not.toBeNull()
+    expect(fallback.textContent).toContain('vendor/removed')
+    expect(fallback.textContent).toContain('not in list')
+    // The select still reflects the persisted value.
+    const mainSelect = container.querySelectorAll('select')[0]
+    expect(mainSelect.value).toBe('openrouter:vendor/removed')
+  })
+
+  it('does not add a fallback when the selection is in the curated list', () => {
+    const { container } = setup({ mainService: 'openrouter:vendor/model-a' })
+    const options = container.querySelectorAll('option[value="openrouter:vendor/model-a"]')
+    // One per select (Main + Critic), no extra fallback entries.
+    expect(options.length).toBe(2)
+  })
+})

--- a/dashboard/frontend/src/components/tools/OpenRouterModelsEditor.jsx
+++ b/dashboard/frontend/src/components/tools/OpenRouterModelsEditor.jsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from 'react'
+import useOpenRouterModels from '../../hooks/useOpenRouterModels'
+
+const toJson = (models) => JSON.stringify(models ?? [], null, 2)
+
+// Client-side mirror of the server validation, so Save can be gated and the
+// error shown before a round-trip. Returns an error string or null.
+function validateModelsJson(text) {
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    return `Invalid JSON: ${e.message}`
+  }
+  if (!Array.isArray(parsed)) return 'Top level must be an array of {id, label?} objects.'
+  const seen = new Set()
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return 'Each model must be an object with an "id".'
+    }
+    if (typeof entry.id !== 'string' || !entry.id.trim()) {
+      return 'Each model must have a non-empty string "id".'
+    }
+    if (entry.label !== undefined && typeof entry.label !== 'string') {
+      return '"label" must be a string when present.'
+    }
+    if (seen.has(entry.id.trim())) return `Duplicate model id: ${entry.id.trim()}`
+    seen.add(entry.id.trim())
+  }
+  return null
+}
+
+// Editor for the curated OpenRouter model list shown in the chat model
+// pickers. The list is a picker convenience, not an allowlist — existing
+// conversations keep working if their model is removed here.
+export default function OpenRouterModelsEditor() {
+  const { data, loading, error, save, reset } = useOpenRouterModels()
+
+  const [content, setContent] = useState('[]')
+  const [dirty, setDirty] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState(null)
+  const [savedNote, setSavedNote] = useState(null)
+  const [confirmingReset, setConfirmingReset] = useState(false)
+
+  // Sync the textarea from the server value whenever it changes — but not
+  // while the user has unsaved edits, so a background refresh can't stomp
+  // their work.
+  useEffect(() => {
+    if (data && !dirty) setContent(toJson(data.current))
+  }, [data, dirty])
+
+  function onChange(v) {
+    setContent(v)
+    setDirty(true)
+    setActionError(null)
+    setSavedNote(null)
+    setConfirmingReset(false)
+  }
+
+  const validationError = dirty ? validateModelsJson(content) : null
+
+  async function handleSave() {
+    setBusy(true)
+    setActionError(null)
+    setSavedNote(null)
+    try {
+      const d = await save(JSON.parse(content))
+      setContent(toJson(d.current))
+      setDirty(false)
+      setSavedNote('Saved')
+    } catch (e) {
+      setActionError(e.message || 'Save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleReset() {
+    setBusy(true)
+    setActionError(null)
+    setSavedNote(null)
+    try {
+      const d = await reset()
+      setContent(toJson(d.current))
+      setDirty(false)
+      setSavedNote('Reset to built-in')
+    } catch (e) {
+      setActionError(e.message || 'Reset failed')
+    } finally {
+      setBusy(false)
+      setConfirmingReset(false)
+    }
+  }
+
+  function handleDiscard() {
+    setContent(toJson(data?.current))
+    setDirty(false)
+    setActionError(null)
+    setSavedNote(null)
+    setConfirmingReset(false)
+  }
+
+  const customized = !!data?.customized
+  const configured = !!data?.configured
+
+  return (
+    <div className="border border-border rounded bg-app">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border">
+        <div className="text-sm text-fg-muted">
+          <i className="fa-solid fa-cloud mr-2 text-fg-subtle"></i>
+          OpenRouter models
+          {customized && (
+            <span className="ml-2 text-xs text-warning-fg border border-warning rounded px-1.5 py-0.5">
+              Modified from built-in
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {savedNote && <span className="text-xs text-success-fg">{savedNote}</span>}
+          {dirty && <span className="text-xs text-warning-fg">Unsaved</span>}
+
+          {confirmingReset ? (
+            <>
+              <span className="text-xs text-fg-muted">Reset to built-in?</span>
+              <button
+                onClick={handleReset}
+                disabled={busy}
+                className="text-xs px-2 py-1 rounded bg-danger hover:bg-danger text-white disabled:opacity-50"
+              >
+                Confirm reset
+              </button>
+              <button
+                onClick={() => setConfirmingReset(false)}
+                disabled={busy}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={handleDiscard}
+                disabled={busy || !dirty}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Discard
+              </button>
+              <button
+                onClick={() => { setConfirmingReset(true); setActionError(null); setSavedNote(null) }}
+                disabled={busy || !customized}
+                title={customized ? 'Discard the customization and revert to the built-in list' : 'Already using the built-in list'}
+                className="text-xs px-2 py-1 rounded bg-surface hover:bg-surface-strong disabled:opacity-50"
+              >
+                Reset to built-in
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={busy || !dirty || !!validationError}
+                className="text-xs px-2 py-1 rounded bg-accent-strong hover:bg-accent-hover disabled:opacity-50 text-white"
+              >
+                Save
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <p className="px-3 pt-2 text-xs text-fg-subtle">
+        Curated models offered in the chat model pickers, as{' '}
+        <span className="font-mono">{'[{"id": "vendor/model", "label": "…"}]'}</span>.
+        Removing a model here does not break conversations already using it.
+      </p>
+
+      {!configured && !loading && (
+        <div className="mx-3 mt-2 text-xs text-warning-fg bg-app border border-warning rounded px-3 py-2">
+          <i className="fa-solid fa-triangle-exclamation mr-1"></i>
+          <span className="font-mono">OPENROUTER_API_KEY</span> is not set in{' '}
+          <span className="font-mono">dashboard/.env</span> — these models won't appear in the chat picker until it is.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="px-3 py-6 text-sm text-fg-subtle">
+          <i className="fa-solid fa-spinner fa-spin mr-2"></i>Loading…
+        </div>
+      ) : (
+        <textarea
+          value={content}
+          onChange={(e) => onChange(e.target.value)}
+          spellCheck={false}
+          disabled={busy}
+          className="w-full h-64 bg-surface-muted text-fg font-mono text-xs p-3 mt-2 focus:outline-none resize-y disabled:opacity-60"
+          placeholder='[{"id": "anthropic/claude-sonnet-5", "label": "Claude Sonnet 5"}]'
+        />
+      )}
+
+      {(error || actionError || validationError) && !loading && (
+        <div className="px-3 py-2 border-t border-border text-xs space-y-1">
+          {error && (
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{error}</div>
+          )}
+          {actionError && (
+            <div className="text-danger-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{actionError}</div>
+          )}
+          {validationError && (
+            <div className="text-warning-fg"><i className="fa-solid fa-triangle-exclamation mr-1"></i>{validationError}</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/tools/ToolsPage.jsx
+++ b/dashboard/frontend/src/components/tools/ToolsPage.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import useRegistry from '../../hooks/useRegistry'
 import RegistryEditor from './RegistryEditor'
 import DefaultPromptEditor from './DefaultPromptEditor'
+import OpenRouterModelsEditor from './OpenRouterModelsEditor'
 import ServerTestPanel from './ServerTestPanel'
 
 function ServerRow({ server, selected, onSelect }) {
@@ -158,6 +159,8 @@ export default function ToolsPage() {
       </div>
 
       <DefaultPromptEditor />
+
+      <OpenRouterModelsEditor />
 
       <RegistryEditor
         initialContent={json?.content}

--- a/dashboard/frontend/src/hooks/useOpenRouterModels.js
+++ b/dashboard/frontend/src/hooks/useOpenRouterModels.js
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  getOpenRouterModels,
+  putOpenRouterModels,
+  resetOpenRouterModels,
+} from '../services/openrouterModels'
+
+// Loads and mutates the curated OpenRouter model list. `data` is the
+// { configured, current, builtin, customized } payload, or null until the
+// first load resolves. `save` / `reset` throw on failure so the editor can
+// surface the message; on success they refresh `data` from the response.
+export default function useOpenRouterModels() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const mountedRef = useRef(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const d = await getOpenRouterModels()
+      if (!mountedRef.current) return
+      setData(d)
+      setError(null)
+    } catch (e) {
+      if (mountedRef.current) setError(e.message || 'Failed to load OpenRouter models')
+    } finally {
+      if (mountedRef.current) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    refresh()
+    return () => { mountedRef.current = false }
+  }, [refresh])
+
+  const save = useCallback(async (models) => {
+    const d = await putOpenRouterModels(models)
+    if (mountedRef.current) setData(d)
+    return d
+  }, [])
+
+  const reset = useCallback(async () => {
+    const d = await resetOpenRouterModels()
+    if (mountedRef.current) setData(d)
+    return d
+  }, [])
+
+  return { data, loading, error, refresh, save, reset }
+}

--- a/dashboard/frontend/src/services/openrouterModels.js
+++ b/dashboard/frontend/src/services/openrouterModels.js
@@ -1,0 +1,14 @@
+import { fetchAPI } from '../api'
+
+// Curated OpenRouter model list. The backend returns
+// { configured, current, builtin, customized } from every verb —
+// `configured` is whether OPENROUTER_API_KEY is set (the chat picker hides
+// the OpenRouter group when it isn't; the Tools editor stays usable).
+const PATH = '/chat/settings/openrouter-models'
+
+export const getOpenRouterModels = () => fetchAPI(PATH)
+
+export const putOpenRouterModels = (models) =>
+  fetchAPI(PATH, { method: 'PUT', body: JSON.stringify({ models }) })
+
+export const resetOpenRouterModels = () => fetchAPI(PATH, { method: 'DELETE' })

--- a/dashboard/frontend/src/utils/openrouter.js
+++ b/dashboard/frontend/src/utils/openrouter.js
@@ -1,0 +1,23 @@
+// Pure helpers for the `openrouter:<model-id>` service-string convention.
+// An OpenRouter model rides through the same main_service / sidekick_service /
+// model_service strings as local Docker service names — these helpers are the
+// single place the prefix is encoded/decoded on the frontend.
+
+export const OPENROUTER_PREFIX = 'openrouter:'
+
+export const isOpenRouterService = (name) =>
+  typeof name === 'string' && name.startsWith(OPENROUTER_PREFIX)
+
+export const openRouterModelId = (name) => name.slice(OPENROUTER_PREFIX.length)
+
+export const serviceNameForModel = (id) => OPENROUTER_PREFIX + id
+
+// Display label for a service string. OpenRouter values get their curated
+// label when `models` is supplied (array of {id, label}), otherwise the bare
+// model id, suffixed with the provider. Local names pass through unchanged.
+export function formatModelLabel(name, models = []) {
+  if (!isOpenRouterService(name)) return name
+  const id = openRouterModelId(name)
+  const curated = models.find(m => m.id === id)
+  return `${curated?.label || id} · OpenRouter`
+}

--- a/dashboard/frontend/src/utils/openrouter.test.js
+++ b/dashboard/frontend/src/utils/openrouter.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OPENROUTER_PREFIX,
+  isOpenRouterService,
+  openRouterModelId,
+  serviceNameForModel,
+  formatModelLabel,
+} from './openrouter'
+
+describe('openrouter service-string helpers', () => {
+  it('detects the prefix', () => {
+    expect(isOpenRouterService('openrouter:anthropic/claude-sonnet-5')).toBe(true)
+    expect(isOpenRouterService('vllm-qwen')).toBe(false)
+    expect(isOpenRouterService(null)).toBe(false)
+    expect(isOpenRouterService(undefined)).toBe(false)
+    expect(isOpenRouterService('')).toBe(false)
+  })
+
+  it('round-trips model id <-> service name', () => {
+    const name = serviceNameForModel('vendor/model-a')
+    expect(name).toBe(OPENROUTER_PREFIX + 'vendor/model-a')
+    expect(openRouterModelId(name)).toBe('vendor/model-a')
+  })
+
+  it('formatModelLabel passes local names through unchanged', () => {
+    expect(formatModelLabel('vllm-qwen')).toBe('vllm-qwen')
+    expect(formatModelLabel(null)).toBe(null)
+    expect(formatModelLabel(undefined)).toBe(undefined)
+  })
+
+  it('formatModelLabel uses the curated label when known', () => {
+    const models = [{ id: 'vendor/model-a', label: 'Model A' }]
+    expect(formatModelLabel('openrouter:vendor/model-a', models)).toBe('Model A · OpenRouter')
+  })
+
+  it('formatModelLabel falls back to the bare model id', () => {
+    expect(formatModelLabel('openrouter:vendor/model-x')).toBe('vendor/model-x · OpenRouter')
+    expect(formatModelLabel('openrouter:vendor/model-x', [{ id: 'other', label: 'O' }]))
+      .toBe('vendor/model-x · OpenRouter')
+  })
+})

--- a/dashboard/tests/test_openrouter_routes.py
+++ b/dashboard/tests/test_openrouter_routes.py
@@ -1,0 +1,297 @@
+"""Tests for the OpenRouter settings HTTP API and the resolver branch.
+
+Mirrors test_chat_settings_routes.py for the endpoint trio, plus resolver /
+request-building coverage for the ``openrouter:`` provider branch in
+chat.llm_proxy and chat.critique.
+"""
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-openrouter")
+
+import config
+from chat import critique, llm_proxy, openrouter
+from chat.db import ChatDB
+from chat.openrouter import DEFAULT_MODELS
+from chat.routes import chat_bp
+
+TOKEN = "test-token-openrouter"
+SETTINGS_PATH = "/api/chat/settings/openrouter-models"
+
+MODELS_A = [{"id": "vendor/model-a", "label": "Model A"}]
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    settings_file = tmp_path / "chat_settings.json"
+    monkeypatch.setenv("LLM_DOCK_CHAT_SETTINGS_FILE", str(settings_file))
+
+    app = Flask(__name__)
+    app.config["DASHBOARD_TOKEN"] = TOKEN
+    app.config["CHAT_DB"] = ChatDB(":memory:")
+    app.register_blueprint(chat_bp)
+    app.testing = True
+    return app.test_client()
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+# -- Auth ---------------------------------------------------------------
+
+
+def test_get_requires_auth(client):
+    assert client.get(SETTINGS_PATH).status_code == 401
+
+
+def test_put_requires_auth(client):
+    assert client.put(SETTINGS_PATH, json={"models": []}).status_code == 401
+
+
+def test_delete_requires_auth(client):
+    assert client.delete(SETTINGS_PATH).status_code == 401
+
+
+# -- GET ----------------------------------------------------------------
+
+
+def test_get_fresh_returns_builtin(client, monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    r = client.get(SETTINGS_PATH, headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["current"] == DEFAULT_MODELS
+    assert body["builtin"] == DEFAULT_MODELS
+    assert body["customized"] is False
+    assert body["configured"] is False
+
+
+def test_configured_flips_with_api_key(client, monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", "sk-or-test")
+    assert client.get(SETTINGS_PATH, headers=_auth()).get_json()["configured"] is True
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    assert client.get(SETTINGS_PATH, headers=_auth()).get_json()["configured"] is False
+
+
+# -- PUT ----------------------------------------------------------------
+
+
+def test_put_persists_and_marks_customized(client):
+    r = client.put(SETTINGS_PATH, json={"models": MODELS_A}, headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["current"] == MODELS_A
+    assert body["customized"] is True
+    # Survives a fresh GET.
+    assert client.get(SETTINGS_PATH, headers=_auth()).get_json()["current"] == MODELS_A
+
+
+def test_put_works_without_api_key(client, monkeypatch):
+    """Editing the curated list is independent of key presence."""
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    r = client.put(SETTINGS_PATH, json={"models": MODELS_A}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["configured"] is False
+
+
+def test_put_empty_list_is_valid(client):
+    r = client.put(SETTINGS_PATH, json={"models": []}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["current"] == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"models": "not a list"},
+        {"models": None},
+        {"models": [{"label": "no id"}]},
+        {"models": [{"id": ""}]},
+        {"models": [{"id": "a/b"}, {"id": "a/b"}]},
+    ],
+)
+def test_put_rejects_invalid_payload(client, body):
+    r = client.put(SETTINGS_PATH, json=body, headers=_auth())
+    assert r.status_code == 400
+    assert "error" in r.get_json()
+    assert client.get(SETTINGS_PATH, headers=_auth()).get_json()["customized"] is False
+
+
+@pytest.mark.parametrize("raw_body", ["[1]", '"x"', "123", "true", "null"])
+def test_put_rejects_non_object_json_body(client, raw_body):
+    r = client.put(
+        SETTINGS_PATH, data=raw_body, content_type="application/json", headers=_auth()
+    )
+    assert r.status_code == 400, f"body {raw_body!r} should 400, got {r.status_code}"
+
+
+# -- DELETE -------------------------------------------------------------
+
+
+def test_delete_reverts_to_builtin(client):
+    client.put(SETTINGS_PATH, json={"models": MODELS_A}, headers=_auth())
+    r = client.delete(SETTINGS_PATH, headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["current"] == DEFAULT_MODELS
+    assert body["customized"] is False
+
+
+def test_delete_when_no_customization_is_noop(client):
+    r = client.delete(SETTINGS_PATH, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["customized"] is False
+
+
+# -- Resolver branch ------------------------------------------------------
+
+
+def test_resolve_openrouter_service_with_key(monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", "sk-or-test")
+    svc = llm_proxy.resolve_service("openrouter:vendor/model-a")
+    assert svc == {
+        "base_url": openrouter.OPENROUTER_BASE_URL,
+        "api_key": "sk-or-test",
+        "model": "vendor/model-a",
+        "extra_headers": openrouter.OPENROUTER_EXTRA_HEADERS,
+    }
+
+
+def test_resolve_openrouter_service_without_key(monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    assert llm_proxy.resolve_service("openrouter:vendor/model-a") is None
+
+
+def test_resolution_ignores_curated_list(monkeypatch, tmp_path):
+    """The curated list is a picker convenience, not an allowlist."""
+    monkeypatch.setenv("LLM_DOCK_CHAT_SETTINGS_FILE", str(tmp_path / "s.json"))
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", "sk-or-test")
+    svc = llm_proxy.resolve_service("openrouter:vendor/not-in-any-list")
+    assert svc is not None
+    assert svc["model"] == "vendor/not-in-any-list"
+
+
+def test_unreachable_message_mentions_key_for_openrouter():
+    msg = llm_proxy.unreachable_message("openrouter:vendor/model-a")
+    assert "OPENROUTER_API_KEY" in msg
+    msg = llm_proxy.unreachable_message("vllm-local")
+    assert "OPENROUTER_API_KEY" not in msg
+
+
+def test_stream_unconfigured_yields_specific_error(monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    events = list(llm_proxy.stream_chat_completion("openrouter:vendor/model-a", []))
+    assert events[0][0] == "error"
+    assert "OPENROUTER_API_KEY" in events[0][1]["message"]
+
+
+# -- Request building ------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, lines):
+        self.status_code = 200
+        self.encoding = None
+        self._lines = lines
+        self.closed = False
+
+    def iter_lines(self, decode_unicode=True):
+        yield from self._lines
+
+    def close(self):
+        self.closed = True
+
+
+def test_stream_openrouter_request_shape(monkeypatch):
+    """OpenRouter requests hit the remote URL with model + extra headers."""
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", "sk-or-test")
+    captured = {}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        captured["headers"] = kwargs["headers"]
+        return _FakeResp(['data: {"choices":[{"delta":{"content":"hi"}}]}',
+                          'data: [DONE]'])
+
+    monkeypatch.setattr(llm_proxy.requests, "post", _post)
+    events = list(llm_proxy.stream_chat_completion("openrouter:vendor/model-a", []))
+    assert any(e[0] == "done" for e in events)
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["json"]["model"] == "vendor/model-a"
+    assert captured["headers"]["Authorization"] == "Bearer sk-or-test"
+    assert captured["headers"]["X-Title"] == "llm-dock"
+
+
+def test_stream_local_request_has_no_model_field(monkeypatch):
+    """Regression: local single-model services must NOT get a model field."""
+    monkeypatch.setattr(llm_proxy, "resolve_service",
+                        lambda name: {"host_port": 1234, "api_key": "k"})
+    captured = {}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        return _FakeResp(['data: [DONE]'])
+
+    monkeypatch.setattr(llm_proxy.requests, "post", _post)
+    list(llm_proxy.stream_chat_completion("svc", []))
+    assert captured["url"] == "http://localhost:1234/v1/chat/completions"
+    assert "model" not in captured["json"]
+
+
+def test_stream_midstream_error_chunk(monkeypatch):
+    """An {\"error\": ...} SSE chunk (e.g. mid-stream rate limit) surfaces
+    as an error event instead of being silently swallowed."""
+    resp = _FakeResp([
+        'data: {"choices":[{"delta":{"content":"partial"}}]}',
+        'data: {"error":{"message":"Rate limit exceeded","code":429}}',
+        'data: {"choices":[{"delta":{"content":"never seen"}}]}',
+    ])
+    monkeypatch.setattr(llm_proxy, "resolve_service",
+                        lambda name: {"host_port": 1234, "api_key": "k"})
+    monkeypatch.setattr(llm_proxy.requests, "post", lambda *a, **k: resp)
+
+    events = list(llm_proxy.stream_chat_completion("svc", []))
+    kinds = [e[0] for e in events]
+    assert kinds == ["delta", "error"]
+    assert "Rate limit exceeded" in events[-1][1]["message"]
+    assert resp.closed
+
+
+def test_critique_openrouter_request_shape(monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", "sk-or-test")
+    captured = {}
+
+    class _JsonResp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"choices": [{"message": {
+                "content": '{"verdict": "ok", "summary": "s", "annotations": []}'
+            }}]}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        return _JsonResp()
+
+    monkeypatch.setattr(critique.requests, "post", _post)
+    result = critique.request_critique("openrouter:vendor/model-a", "ctx")
+    assert "error" not in result
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["json"]["model"] == "vendor/model-a"
+
+
+def test_critique_unconfigured_returns_specific_error(monkeypatch):
+    monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
+    result = critique.request_critique("openrouter:vendor/model-a", "ctx")
+    assert "OPENROUTER_API_KEY" in result["error"]

--- a/dashboard/tests/test_openrouter_routes.py
+++ b/dashboard/tests/test_openrouter_routes.py
@@ -311,6 +311,28 @@ def test_critique_openrouter_request_shape(monkeypatch):
     assert captured["json"]["model"] == "vendor/model-a"
 
 
+def test_critique_null_content_falls_back_to_reasoning(monkeypatch):
+    """Non-streaming message.content is string|null; an explicit null must
+    not crash .strip() — the critique should be parsed from `reasoning`."""
+    monkeypatch.setattr(critique, "resolve_service",
+                        lambda name: {"host_port": 1234, "api_key": "k"})
+
+    class _JsonResp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"choices": [{"message": {
+                "content": None,
+                "reasoning": '{"verdict": "ok", "summary": "s", "annotations": []}',
+            }}]}
+
+    monkeypatch.setattr(critique.requests, "post", lambda *a, **k: _JsonResp())
+    result = critique.request_critique("svc", "ctx")
+    assert result.get("verdict") == "ok"
+    assert "error" not in result
+
+
 def test_critique_unconfigured_returns_specific_error(monkeypatch):
     monkeypatch.setattr(config, "OPENROUTER_API_KEY", None)
     result = critique.request_critique("openrouter:vendor/model-a", "ctx")

--- a/dashboard/tests/test_openrouter_routes.py
+++ b/dashboard/tests/test_openrouter_routes.py
@@ -247,6 +247,26 @@ def test_stream_local_request_has_no_model_field(monkeypatch):
     assert "model" not in captured["json"]
 
 
+def test_stream_final_usage_chunk_with_empty_choices(monkeypatch):
+    """OpenRouter emits a final usage chunk with `choices: []` before [DONE]
+    (https://openrouter.ai/docs/api/reference/overview#responses). It must be
+    a no-op, not an IndexError that fails the run after a complete answer."""
+    resp = _FakeResp([
+        ': OPENROUTER PROCESSING',
+        'data: {"choices":[{"delta":{"content":"hello"}}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":1}}',
+        'data: [DONE]',
+    ])
+    monkeypatch.setattr(llm_proxy, "resolve_service",
+                        lambda name: {"host_port": 1234, "api_key": "k"})
+    monkeypatch.setattr(llm_proxy.requests, "post", lambda *a, **k: resp)
+
+    events = list(llm_proxy.stream_chat_completion("svc", []))
+    kinds = [e[0] for e in events]
+    assert kinds == ["delta", "done"]
+    assert events[-1][1]["content"] == "hello"
+
+
 def test_stream_midstream_error_chunk(monkeypatch):
     """An {\"error\": ...} SSE chunk (e.g. mid-stream rate limit) surfaces
     as an error event instead of being silently swallowed."""

--- a/dashboard/tests/test_openrouter_settings.py
+++ b/dashboard/tests/test_openrouter_settings.py
@@ -1,0 +1,135 @@
+"""Tests for the curated OpenRouter model list in chat.settings_store.
+
+Mirrors test_settings_store.py: the store falls back to the built-in
+``DEFAULT_MODELS`` from ``chat.openrouter`` whenever the file is missing,
+unreadable, malformed, or holds an invalid value for the key. Unlike the
+system prompt, an *empty list* is a valid stored value — it hides every
+OpenRouter model from the picker without unsetting the API key.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chat import settings_store
+from chat.openrouter import DEFAULT_MODELS
+
+MODELS_A = [{"id": "vendor/model-a", "label": "Model A"}]
+
+
+@pytest.fixture
+def settings_file(tmp_path, monkeypatch):
+    """Point the store at a tmp file via the env override."""
+    path = tmp_path / "chat_settings.json"
+    monkeypatch.setenv("LLM_DOCK_CHAT_SETTINGS_FILE", str(path))
+    return path
+
+
+def test_missing_file_returns_builtin(settings_file):
+    assert not settings_file.exists()
+    assert settings_store.get_openrouter_models() == DEFAULT_MODELS
+    assert settings_store.is_openrouter_models_customized() is False
+
+
+def test_builtin_result_is_a_copy(settings_file):
+    """Mutating the returned default list must not corrupt DEFAULT_MODELS."""
+    models = settings_store.get_openrouter_models()
+    models[0]["id"] = "mutated/mutated"
+    assert settings_store.get_openrouter_models() == DEFAULT_MODELS
+
+
+def test_set_and_get_roundtrip(settings_file):
+    settings_store.set_openrouter_models(MODELS_A)
+    assert settings_store.get_openrouter_models() == MODELS_A
+    assert settings_store.is_openrouter_models_customized() is True
+    with open(settings_file) as f:
+        data = json.load(f)
+    assert data == {"openrouter_models": MODELS_A}
+
+
+def test_label_defaults_to_id(settings_file):
+    settings_store.set_openrouter_models([{"id": "vendor/no-label"}])
+    assert settings_store.get_openrouter_models() == [
+        {"id": "vendor/no-label", "label": "vendor/no-label"}
+    ]
+
+
+def test_empty_list_is_honored(settings_file):
+    """An empty list is a deliberate 'hide all', not 'unset'."""
+    settings_store.set_openrouter_models([])
+    assert settings_store.get_openrouter_models() == []
+    assert settings_store.is_openrouter_models_customized() is True
+
+
+def test_set_rejects_non_list(settings_file):
+    with pytest.raises(TypeError):
+        settings_store.set_openrouter_models("not a list")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        settings_store.set_openrouter_models(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "models",
+    [
+        ["bare string"],
+        [{"label": "no id"}],
+        [{"id": ""}],
+        [{"id": "   "}],
+        [{"id": 42}],
+        [{"id": "a/b", "label": 42}],
+        [{"id": "a/b"}, {"id": "a/b"}],  # duplicate ids
+    ],
+)
+def test_set_rejects_malformed_entries(settings_file, models):
+    with pytest.raises(ValueError):
+        settings_store.set_openrouter_models(models)
+    # Nothing was persisted.
+    assert settings_store.is_openrouter_models_customized() is False
+
+
+def test_reset_removes_file_when_only_field(settings_file):
+    settings_store.set_openrouter_models(MODELS_A)
+    assert settings_file.exists()
+    settings_store.reset_openrouter_models()
+    assert not settings_file.exists()
+    assert settings_store.get_openrouter_models() == DEFAULT_MODELS
+    assert settings_store.is_openrouter_models_customized() is False
+
+
+def test_reset_keeps_other_keys(settings_file):
+    settings_file.write_text(
+        json.dumps({"openrouter_models": MODELS_A, "main_system_prompt": "custom"})
+    )
+    settings_store.reset_openrouter_models()
+    with open(settings_file) as f:
+        data = json.load(f)
+    assert data == {"main_system_prompt": "custom"}
+
+
+def test_reset_when_nothing_stored_is_noop(settings_file):
+    settings_store.reset_openrouter_models()
+    settings_store.reset_openrouter_models()  # idempotent
+    assert not settings_file.exists()
+
+
+def test_invalid_stored_value_falls_back_to_builtin(settings_file):
+    """A hand-edited file with a malformed list must not break reads."""
+    settings_file.write_text(json.dumps({"openrouter_models": [{"label": "no id"}]}))
+    assert settings_store.get_openrouter_models() == DEFAULT_MODELS
+    assert settings_store.is_openrouter_models_customized() is False
+
+
+def test_value_matching_builtin_is_not_customized(settings_file):
+    settings_store.set_openrouter_models(DEFAULT_MODELS)
+    assert settings_store.is_openrouter_models_customized() is False
+
+
+def test_coexists_with_main_system_prompt(settings_file):
+    """Both settings share one file without clobbering each other."""
+    settings_store.set_main_system_prompt("custom prompt")
+    settings_store.set_openrouter_models(MODELS_A)
+    assert settings_store.get_main_system_prompt() == "custom prompt"
+    assert settings_store.get_openrouter_models() == MODELS_A


### PR DESCRIPTION
## Summary

Chat (main + critic) can now target OpenRouter-hosted models from a curated, editable selection of popular models, alongside the local Docker vLLM/llama.cpp services.

- **Convention**: an OpenRouter model rides through the existing `main_service` / `sidekick_service` / `model_service` strings as `openrouter:<model-id>` — no DB migration.
- **Backend**: `chat/openrouter.py` (prefix helpers, built-in `DEFAULT_MODELS`, resolver); `llm_proxy.resolve_service()` branches on the prefix; a shared `build_endpoint()` generalizes URL/header building for `stream_chat_completion` and `critique.py`. OpenRouter payloads get the required `model` field; local single-model servers keep model-less payloads (regression-tested).
- **Curated list**: editable at runtime via `GET/PUT/DELETE /api/chat/settings/openrouter-models` (settings_store pattern, stored in `chat_settings.json`) and a new Tools-page card. The list is a picker convenience, not an allowlist — removing a model doesn't break conversations already using it.
- **Gating**: everything keys off `OPENROUTER_API_KEY` in `dashboard/.env`. Unset → no OpenRouter group in the pickers, and `openrouter:` conversations fail fast with a specific error.
- **Streaming hardening**: mid-stream `{"error": ...}` chunks (e.g. rate limits) now surface as error events instead of being silently swallowed; non-200 bodies get their provider `error.message` extracted.
- **Frontend**: Local/OpenRouter optgroups in both dropdowns with a stale-selection fallback option; new-conversation default falls back to the first curated model when no local service runs; message bubbles show `model-id · OpenRouter`.

MCP tool calling, images, auto-titling, and spinoffs work unchanged through the same code paths.

## Testing

- Backend: 377 passed (`pytest dashboard/tests`), including new `test_openrouter_settings.py` / `test_openrouter_routes.py` and provider-branch coverage.
- Frontend: 140 passed (vitest), including new ModelSelector / ChatPage-default-model / helper tests; `npm run build` clean.
- Live end-to-end (real key, streamed reply, tools, critic) pending a dashboard restart — a model is currently running, so the service was deliberately not restarted.