### PR TITLE
feat(chat): add GLM 5.2, DeepSeek V4 Pro/Flash, Hunyuan 3 to default OpenRouter models

### DIFF
--- a/dashboard/chat/openrouter.py
+++ b/dashboard/chat/openrouter.py
@@ -40,9 +40,13 @@ DEFAULT_MODELS = [
     {"id": "google/gemini-3.5-flash", "label": "Gemini 3.5 Flash"},
     {"id": "x-ai/grok-4.5", "label": "Grok 4.5"},
     {"id": "deepseek/deepseek-v3.2", "label": "DeepSeek V3.2"},
+    {"id": "deepseek/deepseek-v4-pro", "label": "DeepSeek V4 Pro"},
+    {"id": "deepseek/deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
     {"id": "qwen/qwen3.7-max", "label": "Qwen3.7 Max"},
     {"id": "moonshotai/kimi-k2.6", "label": "Kimi K2.6"},
     {"id": "z-ai/glm-5", "label": "GLM 5"},
+    {"id": "z-ai/glm-5.2", "label": "GLM 5.2"},
+    {"id": "tencent/hy3", "label": "Hunyuan 3"},
 ]
 
 


### PR DESCRIPTION
Adds four entries to the built-in curated OpenRouter model list (`chat/openrouter.py:DEFAULT_MODELS`): GLM 5.2, DeepSeek V4 Pro, DeepSeek V4 Flash, and Hunyuan 3 (`tencent/hy3`). All four verified present and tool-capable in the live OpenRouter catalog. No logic changes; the 52 OpenRouter tests pass (they compare against `DEFAULT_MODELS`, not hardcoded contents).