### PR TITLE
feat(chat): projects — group conversations into projects (phase 1)

### DIFF
--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -323,13 +323,25 @@ class ChatDB:
             self._close_conn(conn)
 
     def list_conversations(self, limit: int = 50, offset: int = 0) -> Tuple[List[Conversation], int]:
+        """List conversations, newest-updated first.
+
+        A negative limit returns the ENTIRE list in one statement — a
+        consistent snapshot (offset pagination over the mutable
+        updated_at ordering can skip or duplicate rows when conversations
+        are touched between page fetches).
+        """
         conn = self._get_conn()
         try:
             total = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
-            rows = conn.execute(
-                "SELECT * FROM conversations ORDER BY updated_at DESC LIMIT ? OFFSET ?",
-                (limit, offset),
-            ).fetchall()
+            if limit is None or limit < 0:
+                rows = conn.execute(
+                    "SELECT * FROM conversations ORDER BY updated_at DESC"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM conversations ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+                    (limit, offset),
+                ).fetchall()
             convs = [self._row_to_conversation(row) for row in rows]
             self._attach_active_runs(conn, convs)
             return convs, total

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -86,6 +86,31 @@ CREATE INDEX IF NOT EXISTS idx_chat_runs_conversation ON chat_runs(conversation_
 CREATE INDEX IF NOT EXISTS idx_chat_runs_status ON chat_runs(status);
 """
 
+# conversations.project_id was added via ALTER TABLE, which in sqlite cannot
+# carry a foreign key — these triggers provide the referential half. They
+# close the validate-then-write race (a project deleted between a route's
+# existence check and the conversation write): the write itself fails with
+# IntegrityError('project not found') instead of persisting an orphan id.
+# delete_project detaches conversations in the same transaction as the
+# project row's deletion, so the triggers never fire on that path.
+TRIGGERS_SQL = """
+CREATE TRIGGER IF NOT EXISTS trg_conversations_project_fk_insert
+BEFORE INSERT ON conversations
+WHEN NEW.project_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'project not found');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_conversations_project_fk_update
+BEFORE UPDATE OF project_id ON conversations
+WHEN NEW.project_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM projects WHERE id = NEW.project_id)
+BEGIN
+    SELECT RAISE(ABORT, 'project not found');
+END;
+"""
+
 
 class ChatDB:
     def __init__(self, db_path: str = "chat.db"):
@@ -119,6 +144,11 @@ class ChatDB:
             conn.executescript(SCHEMA_SQL)
             conn.commit()
             self._migrate(conn)
+            # Created AFTER migrations: the triggers reference
+            # conversations.project_id, which on a pre-existing DB only
+            # exists once _migrate has added it.
+            conn.executescript(TRIGGERS_SQL)
+            conn.commit()
         finally:
             self._close_conn(conn)
 

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -2,12 +2,22 @@ import sqlite3
 import logging
 from typing import Optional, List, Tuple
 
-from .models import Conversation, Message, Critique, Artifact, ChatRun
+from .models import Conversation, Message, Critique, Artifact, ChatRun, Project
 from .runs import ChatRunStatus, ACTIVE_STATUSES, TERMINAL_STATUSES, ALL_STATUSES
 
 logger = logging.getLogger(__name__)
 
 SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS projects (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_updated ON projects(updated_at DESC);
+
 CREATE TABLE IF NOT EXISTS conversations (
     id                     TEXT PRIMARY KEY,
     title                  TEXT NOT NULL DEFAULT 'New Conversation',
@@ -120,6 +130,9 @@ class ChatDB:
             ("conversations", "mcp_servers_json", "ALTER TABLE conversations ADD COLUMN mcp_servers_json TEXT"),
             ("messages", "tool_calls_json", "ALTER TABLE messages ADD COLUMN tool_calls_json TEXT"),
             ("messages", "parse_warning_json", "ALTER TABLE messages ADD COLUMN parse_warning_json TEXT"),
+            # No FK here: sqlite's ALTER TABLE can't add one, so project
+            # detachment on delete is handled explicitly in delete_project.
+            ("conversations", "project_id", "ALTER TABLE conversations ADD COLUMN project_id TEXT"),
         ]
         for table, column, sql in migrations:
             try:
@@ -128,6 +141,101 @@ class ChatDB:
                 logger.info(f"Migration: added {column} column to {table}")
             except sqlite3.OperationalError:
                 pass  # column already exists
+
+    # -- Projects --
+
+    def _row_to_project(self, row: sqlite3.Row) -> Project:
+        return Project(
+            id=row["id"],
+            name=row["name"],
+            description=row["description"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def create_project(self, project: Project) -> Project:
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                "INSERT INTO projects (id, name, description) VALUES (?, ?, ?)",
+                (project.id, project.name, project.description),
+            )
+            conn.commit()
+            return self.get_project(project.id)
+        finally:
+            self._close_conn(conn)
+
+    def get_project(self, project_id: str) -> Optional[Project]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM projects WHERE id = ?", (project_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            project = self._row_to_project(row)
+            project.conversation_count = conn.execute(
+                "SELECT COUNT(*) FROM conversations WHERE project_id = ?",
+                (project_id,),
+            ).fetchone()[0]
+            return project
+        finally:
+            self._close_conn(conn)
+
+    def list_projects(self) -> List[Project]:
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM projects ORDER BY name COLLATE NOCASE"
+            ).fetchall()
+            projects = [self._row_to_project(row) for row in rows]
+            counts = dict(conn.execute(
+                "SELECT project_id, COUNT(*) FROM conversations "
+                "WHERE project_id IS NOT NULL GROUP BY project_id"
+            ).fetchall())
+            for p in projects:
+                p.conversation_count = counts.get(p.id, 0)
+            return projects
+        finally:
+            self._close_conn(conn)
+
+    def update_project(self, project_id: str, **kwargs) -> Optional[Project]:
+        allowed = {"name", "description"}
+        fields = []
+        params = []
+        for key, val in kwargs.items():
+            if key in allowed:
+                fields.append(f"{key} = ?")
+                params.append(val)
+        if not fields:
+            return self.get_project(project_id)
+        fields.append("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')")
+        params.append(project_id)
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                f"UPDATE projects SET {', '.join(fields)} WHERE id = ?",
+                params,
+            )
+            conn.commit()
+            return self.get_project(project_id)
+        finally:
+            self._close_conn(conn)
+
+    def delete_project(self, project_id: str) -> bool:
+        """Delete a project, detaching its conversations (they become
+        unfiled rather than being destroyed)."""
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                "UPDATE conversations SET project_id = NULL WHERE project_id = ?",
+                (project_id,),
+            )
+            cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            self._close_conn(conn)
 
     # -- Conversations --
 
@@ -142,6 +250,7 @@ class ChatDB:
             parent_conversation_id=row["parent_conversation_id"],
             selected_text=row["selected_text"],
             mcp_servers_json=row["mcp_servers_json"],
+            project_id=row["project_id"],
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )
@@ -153,11 +262,12 @@ class ChatDB:
                 """INSERT INTO conversations
                    (id, title, main_service, sidekick_service,
                     main_system_prompt, sidekick_system_prompt,
-                    parent_conversation_id, selected_text, mcp_servers_json)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    parent_conversation_id, selected_text, mcp_servers_json, project_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (conv.id, conv.title, conv.main_service, conv.sidekick_service,
                  conv.main_system_prompt, conv.sidekick_system_prompt,
-                 conv.parent_conversation_id, conv.selected_text, conv.mcp_servers_json),
+                 conv.parent_conversation_id, conv.selected_text, conv.mcp_servers_json,
+                 conv.project_id),
             )
             conn.commit()
             return self.get_conversation(conv.id)
@@ -198,7 +308,8 @@ class ChatDB:
 
     def update_conversation(self, conv_id: str, **kwargs) -> Optional[Conversation]:
         allowed = {"title", "main_service", "sidekick_service",
-                    "main_system_prompt", "sidekick_system_prompt", "mcp_servers_json"}
+                    "main_system_prompt", "sidekick_system_prompt", "mcp_servers_json",
+                    "project_id"}
         fields = []
         params = []
         for key, val in kwargs.items():

--- a/dashboard/chat/models.py
+++ b/dashboard/chat/models.py
@@ -137,6 +137,27 @@ class ChatRun:
 
 
 @dataclass
+class Project:
+    id: str
+    name: str
+    description: str = ""
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    # Populated by the DB layer (not a stored column).
+    conversation_count: int = 0
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "conversation_count": self.conversation_count,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
 class Conversation:
     id: str
     title: str
@@ -147,6 +168,7 @@ class Conversation:
     parent_conversation_id: Optional[str] = None
     selected_text: Optional[str] = None
     mcp_servers_json: Optional[str] = None
+    project_id: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
     messages: List[Message] = field(default_factory=list)
@@ -169,6 +191,7 @@ class Conversation:
             "sidekick_system_prompt": self.sidekick_system_prompt,
             "parent_conversation_id": self.parent_conversation_id,
             "selected_text": self.selected_text,
+            "project_id": self.project_id,
             "mcp_servers": json.loads(self.mcp_servers_json) if self.mcp_servers_json else [],
             "active_run": self.active_run,
             "last_run": self.last_run,

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -7,7 +7,7 @@ from flask import Blueprint, jsonify, request, current_app, Response, stream_wit
 
 from auth import require_auth
 from .db import ChatDB
-from .models import Conversation, Message, Critique, ChatRun
+from .models import Conversation, Message, Critique, ChatRun, Project
 from .constants import DEFAULT_MAIN_SYSTEM_PROMPT, DEFAULT_SIDEKICK_SYSTEM_PROMPT, DEFAULT_CONTEXT_WINDOW
 from .llm_proxy import stream_chat_completion
 from .critique import build_critique_context, request_critique, validate_annotations
@@ -165,6 +165,81 @@ def delete_openrouter_models_setting():
     return jsonify(_openrouter_settings_payload())
 
 
+# -- Projects CRUD --
+
+def _validate_project_name(name):
+    """Returns (cleaned_name, error). A name is required and non-blank."""
+    if not isinstance(name, str) or not name.strip():
+        return None, "name is required"
+    return name.strip(), None
+
+
+@chat_bp.route("/api/chat/projects", methods=["POST"])
+@require_auth
+def create_project():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be a JSON object"}), 400
+    name, err = _validate_project_name(data.get("name"))
+    if err:
+        return jsonify({"error": err}), 400
+    description = data.get("description", "")
+    if not isinstance(description, str):
+        return jsonify({"error": "description must be a string"}), 400
+    project = Project(id=str(uuid.uuid4()), name=name, description=description)
+    project = _get_db().create_project(project)
+    return jsonify(project.to_dict()), 201
+
+
+@chat_bp.route("/api/chat/projects", methods=["GET"])
+@require_auth
+def list_projects():
+    projects = _get_db().list_projects()
+    return jsonify({"projects": [p.to_dict() for p in projects]})
+
+
+@chat_bp.route("/api/chat/projects/<project_id>", methods=["GET"])
+@require_auth
+def get_project(project_id):
+    project = _get_db().get_project(project_id)
+    if project is None:
+        return jsonify({"error": "Project not found"}), 404
+    return jsonify(project.to_dict())
+
+
+@chat_bp.route("/api/chat/projects/<project_id>", methods=["PUT"])
+@require_auth
+def update_project(project_id):
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be a JSON object"}), 400
+    updates = {}
+    if "name" in data:
+        name, err = _validate_project_name(data.get("name"))
+        if err:
+            return jsonify({"error": err}), 400
+        updates["name"] = name
+    if "description" in data:
+        if not isinstance(data["description"], str):
+            return jsonify({"error": "description must be a string"}), 400
+        updates["description"] = data["description"]
+    db = _get_db()
+    if db.get_project(project_id) is None:
+        return jsonify({"error": "Project not found"}), 404
+    project = db.update_project(project_id, **updates)
+    return jsonify(project.to_dict())
+
+
+@chat_bp.route("/api/chat/projects/<project_id>", methods=["DELETE"])
+@require_auth
+def delete_project(project_id):
+    """Delete a project. Its conversations are detached (become unfiled),
+    not deleted."""
+    if _get_db().delete_project(project_id):
+        return jsonify({"ok": True})
+    return jsonify({"error": "Project not found"}), 404
+
+
 # -- Conversations CRUD --
 
 @chat_bp.route("/api/chat/conversations", methods=["POST"])
@@ -174,6 +249,10 @@ def create_conversation():
     main_service = data.get("main_service")
     if not main_service:
         return jsonify({"error": "main_service is required"}), 400
+
+    project_id = data.get("project_id")
+    if project_id is not None and _get_db().get_project(project_id) is None:
+        return jsonify({"error": "Project not found"}), 400
 
     # Honor an explicit prompt from the client (a fork or programmatic
     # caller may want one), otherwise fall back to whatever the user has
@@ -193,6 +272,7 @@ def create_conversation():
         sidekick_system_prompt=data.get("sidekick_system_prompt", DEFAULT_SIDEKICK_SYSTEM_PROMPT),
         parent_conversation_id=data.get("parent_conversation_id"),
         selected_text=data.get("selected_text"),
+        project_id=project_id,
     )
     conv = _get_db().create_conversation(conv)
     return jsonify(conv.to_dict(include_messages=True)), 201
@@ -231,6 +311,11 @@ def get_conversation(conv_id):
 def update_conversation(conv_id):
     data = request.get_json() or {}
     db = _get_db()
+    # project_id: null detaches (back to unfiled); a non-null value must
+    # name an existing project.
+    if "project_id" in data and data["project_id"] is not None:
+        if db.get_project(data["project_id"]) is None:
+            return jsonify({"error": "Project not found"}), 400
     conv = db.update_conversation(conv_id, **data)
     if conv is None:
         return jsonify({"error": "Conversation not found"}), 404

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -228,6 +228,10 @@ def update_project(project_id):
     if db.get_project(project_id) is None:
         return jsonify({"error": "Project not found"}), 404
     project = db.update_project(project_id, **updates)
+    if project is None:
+        # The project was deleted between the existence check and the
+        # update (two-tab rename/delete race) — a 404, not a 500.
+        return jsonify({"error": "Project not found"}), 404
     return jsonify(project.to_dict())
 
 

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sqlite3
 import uuid
 
 from flask import Blueprint, jsonify, request, current_app, Response, stream_with_context
@@ -251,8 +252,14 @@ def create_conversation():
         return jsonify({"error": "main_service is required"}), 400
 
     project_id = data.get("project_id")
-    if project_id is not None and _get_db().get_project(project_id) is None:
-        return jsonify({"error": "Project not found"}), 400
+    if project_id is not None:
+        if not isinstance(project_id, str):
+            return jsonify({"error": "project_id must be a string or null"}), 400
+        # Membership is root-only: spin-offs follow their parent's project.
+        if data.get("parent_conversation_id"):
+            return jsonify({"error": "Spin-off conversations inherit their parent's project"}), 400
+        if _get_db().get_project(project_id) is None:
+            return jsonify({"error": "Project not found"}), 400
 
     # Honor an explicit prompt from the client (a fork or programmatic
     # caller may want one), otherwise fall back to whatever the user has
@@ -274,7 +281,12 @@ def create_conversation():
         selected_text=data.get("selected_text"),
         project_id=project_id,
     )
-    conv = _get_db().create_conversation(conv)
+    try:
+        conv = _get_db().create_conversation(conv)
+    except sqlite3.IntegrityError:
+        # The project was deleted between the existence check above and the
+        # insert — the DB trigger rejected the orphan reference.
+        return jsonify({"error": "Project not found"}), 400
     return jsonify(conv.to_dict(include_messages=True)), 201
 
 
@@ -311,12 +323,25 @@ def get_conversation(conv_id):
 def update_conversation(conv_id):
     data = request.get_json() or {}
     db = _get_db()
-    # project_id: null detaches (back to unfiled); a non-null value must
-    # name an existing project.
+    # project_id: null detaches (back to unfiled); a non-null value must be
+    # a string naming an existing project, and only root conversations can
+    # be assigned — spin-offs follow their parent's project.
     if "project_id" in data and data["project_id"] is not None:
+        if not isinstance(data["project_id"], str):
+            return jsonify({"error": "project_id must be a string or null"}), 400
+        existing = db.get_conversation(conv_id)
+        if existing is None:
+            return jsonify({"error": "Conversation not found"}), 404
+        if existing.parent_conversation_id:
+            return jsonify({"error": "Spin-off conversations inherit their parent's project"}), 400
         if db.get_project(data["project_id"]) is None:
             return jsonify({"error": "Project not found"}), 400
-    conv = db.update_conversation(conv_id, **data)
+    try:
+        conv = db.update_conversation(conv_id, **data)
+    except sqlite3.IntegrityError:
+        # The project was deleted between the existence check above and the
+        # write — the DB trigger rejected the orphan reference.
+        return jsonify({"error": "Project not found"}), 400
     if conv is None:
         return jsonify({"error": "Conversation not found"}), 404
     return jsonify(conv.to_dict())

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -185,15 +185,20 @@ export default function ChatPage() {
   const handleDelete = useCallback(async (id) => {
     const shouldNavigate = activeWillBeDeleted([id])
     await remove(id)
+    // Deleted conversations may have belonged to a project — refresh the
+    // cached per-project counts so a section can't claim chats it no
+    // longer has.
+    await refreshProjects()
     if (shouldNavigate) navigate('/chat')
-  }, [remove, activeWillBeDeleted, navigate])
+  }, [remove, refreshProjects, activeWillBeDeleted, navigate])
 
   const handleDeleteMany = useCallback(async (ids) => {
     if (!ids || ids.length === 0) return
     const shouldNavigate = activeWillBeDeleted(ids)
     await removeMany(ids)
+    await refreshProjects()
     if (shouldNavigate) navigate('/chat')
-  }, [removeMany, activeWillBeDeleted, navigate])
+  }, [removeMany, refreshProjects, activeWillBeDeleted, navigate])
 
   return (
     <div className="flex-1 flex overflow-hidden">

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -3,7 +3,9 @@ import { useNavigate, useParams } from 'react-router-dom'
 import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
 import useConversations from '../../hooks/useConversations'
+import useProjects from '../../hooks/useProjects'
 import useChat from '../../hooks/useChat'
+import { updateConversation } from '../../services/chat'
 import useRunningServices from '../../hooks/useRunningServices'
 import useOpenRouterModels from '../../hooks/useOpenRouterModels'
 import { serviceNameForModel, formatModelLabel } from '../../utils/openrouter'
@@ -15,6 +17,7 @@ export default function ChatPage() {
   const navigate = useNavigate()
 
   const { conversations, refresh, create, remove, removeMany, rename, patchConversation } = useConversations()
+  const { projects, refresh: refreshProjects, create: createProject, rename: renameProject, remove: removeProject } = useProjects()
   const { services: runningServices } = useRunningServices()
   const { data: openRouterData } = useOpenRouterModels()
   const {
@@ -115,6 +118,37 @@ export default function ChatPage() {
     navigate(`/chat/${conv.id}`)
   }, [create, navigate, defaultModelName])
 
+  const handleCreateInProject = useCallback(async (projectId) => {
+    if (!defaultModelName) {
+      window.alert('No model available. Start a local model or configure OpenRouter.')
+      return
+    }
+    const conv = await create({
+      main_service: defaultModelName,
+      project_id: projectId,
+    })
+    await refreshProjects()
+    navigate(`/chat/${conv.id}`)
+  }, [create, navigate, defaultModelName, refreshProjects])
+
+  const handleCreateProject = useCallback(async () => {
+    const name = window.prompt('Project name')
+    if (!name || !name.trim()) return
+    await createProject({ name: name.trim() })
+  }, [createProject])
+
+  const handleDeleteProject = useCallback(async (id) => {
+    // Conversations are detached server-side, not deleted — refresh the
+    // list so they reappear as unfiled.
+    await removeProject(id)
+    await refresh()
+  }, [removeProject, refresh])
+
+  const handleMoveMany = useCallback(async (ids, projectId) => {
+    await Promise.all(ids.map(id => updateConversation(id, { project_id: projectId })))
+    await Promise.all([refresh(), refreshProjects()])
+  }, [refresh, refreshProjects])
+
   // Empty-state composer: create a conversation, then queue the typed
   // message so it sends as soon as the new conversation loads.
   const handleCreateAndSend = useCallback(async (content, images) => {
@@ -171,6 +205,12 @@ export default function ChatPage() {
         onDelete={handleDelete}
         onDeleteMany={handleDeleteMany}
         onRename={handleRename}
+        projects={projects}
+        onCreateProject={handleCreateProject}
+        onRenameProject={renameProject}
+        onDeleteProject={handleDeleteProject}
+        onCreateInProject={handleCreateInProject}
+        onMoveMany={handleMoveMany}
       />
       <ChatArea
         conversation={conversation}

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -5,7 +5,12 @@ import ChatPage from './ChatPage'
 
 // Stub the heavy presentational children — this test is about the
 // data/effect wiring in ChatPage, not what the sidebar/area render.
-vi.mock('./ChatSidebar', () => ({ default: () => null }))
+// The sidebar stub captures its props so tests can drive the handlers
+// ChatPage wires into it (delete → project-count refresh, etc.).
+const { sidebarProps } = vi.hoisted(() => ({ sidebarProps: { current: null } }))
+vi.mock('./ChatSidebar', () => ({
+  default: (props) => { sidebarProps.current = props; return null },
+}))
 vi.mock('./ChatArea', () => ({ default: () => null }))
 
 // Running services come from an SSE hook; give it one model so the page
@@ -14,16 +19,23 @@ vi.mock('../../hooks/useServicesSSE', () => ({
   default: () => ({ services: [{ name: 'vllm-test', kind: 'chat' }], loading: false }),
 }))
 
-const { mockGetConversation, mockListConversations, mockCancelActiveRun } = vi.hoisted(() => ({
+const { mockGetConversation, mockListConversations, mockCancelActiveRun,
+        mockListProjects, mockDeleteConversation, mockDeleteConversations } = vi.hoisted(() => ({
   mockGetConversation: vi.fn(),
   mockListConversations: vi.fn(),
   mockCancelActiveRun: vi.fn(),
+  mockListProjects: vi.fn(),
+  mockDeleteConversation: vi.fn(),
+  mockDeleteConversations: vi.fn(),
 }))
 vi.mock('../../services/chat', async (importActual) => ({
   ...(await importActual()),
   getConversation: (...a) => mockGetConversation(...a),
   listConversations: (...a) => mockListConversations(...a),
   cancelActiveRun: (...a) => mockCancelActiveRun(...a),
+  listProjects: (...a) => mockListProjects(...a),
+  deleteConversation: (...a) => mockDeleteConversation(...a),
+  deleteConversations: (...a) => mockDeleteConversations(...a),
 }))
 
 // streamChat is never expected to fire here (no active run), but stub it to a
@@ -40,7 +52,14 @@ beforeEach(() => {
     messages: [], active_run: null, last_run: null,
   })
   mockListConversations.mockResolvedValue({ conversations: [] })
+  mockListProjects.mockReset()
+  mockListProjects.mockResolvedValue({ projects: [] })
+  mockDeleteConversation.mockReset()
+  mockDeleteConversation.mockResolvedValue({ ok: true })
+  mockDeleteConversations.mockReset()
+  mockDeleteConversations.mockResolvedValue({ ok: true, deleted: 1 })
   mockStreamChat.mockImplementation(() => new Promise(() => {}))
+  sidebarProps.current = null
 })
 
 afterEach(() => cleanup())
@@ -79,5 +98,40 @@ describe('ChatPage URL-load effect', () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(mockGetConversation).toHaveBeenCalledTimes(1)
     expect(mockGetConversation).toHaveBeenCalledWith('abc')
+  })
+})
+
+describe('ChatPage delete → project count refresh', () => {
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Routes>
+          <Route path="/chat" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+  }
+
+  it('refreshes projects after a single conversation delete', async () => {
+    // Regression for codex iteration 3 on PR #77: deleting a project's
+    // conversation must refetch the cached per-project counts, or the
+    // sidebar keeps claiming chats the project no longer has.
+    renderPage()
+    await waitFor(() => expect(mockListProjects).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await sidebarProps.current.onDelete('c1') })
+
+    expect(mockDeleteConversation).toHaveBeenCalledWith('c1')
+    expect(mockListProjects).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes projects after a bulk conversation delete', async () => {
+    renderPage()
+    await waitFor(() => expect(mockListProjects).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await sidebarProps.current.onDeleteMany(['c1', 'c2']) })
+
+    expect(mockDeleteConversations).toHaveBeenCalledWith(['c1', 'c2'])
+    expect(mockListProjects).toHaveBeenCalledTimes(2)
   })
 })

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -588,11 +588,15 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
         {projects.map(project => {
           const roots = grouped.byProject.get(project.id) || []
           const collapsed = collapsedProjects.has(project.id)
+          // The server-side count is authoritative — if it disagrees with
+          // the loaded rows (e.g. a page was dropped), never claim the
+          // project is empty.
+          const count = Math.max(project.conversation_count ?? 0, roots.length)
           return (
             <div key={project.id}>
               <ProjectHeader
                 project={project}
-                count={roots.length}
+                count={count}
                 collapsed={collapsed}
                 onToggleCollapse={toggleCollapse}
                 onCreateInProject={onCreateInProject}
@@ -604,9 +608,14 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
                 onRenameProjectConfirm={handleRenameProjectConfirm}
               />
               {!collapsed && roots.map(conv => renderConv(conv, 1))}
-              {!collapsed && roots.length === 0 && (
+              {!collapsed && roots.length === 0 && count === 0 && (
                 <div className="py-2 pl-8 pr-3 text-[11px] text-fg-faint border-b border-border-subtle">
                   Empty project
+                </div>
+              )}
+              {!collapsed && roots.length === 0 && count > 0 && (
+                <div className="py-2 pl-8 pr-3 text-[11px] text-fg-faint border-b border-border-subtle">
+                  {count} conversation{count === 1 ? '' : 's'} not loaded
                 </div>
               )}
             </div>

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -187,9 +187,116 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
   )
 }
 
-export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename }) {
+function ProjectHeader({ project, collapsed, onToggleCollapse, onCreateInProject, confirmDeleteProject, setConfirmDeleteProject, onDeleteProject, renamingProject, onRenameProjectStart, onRenameProjectConfirm, count }) {
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (renamingProject === project.id) {
+      inputRef.current?.focus()
+    }
+  }, [renamingProject, project.id])
+
+  const handleRenameSubmit = (e) => {
+    e.preventDefault()
+    const val = inputRef.current?.value?.trim()
+    if (val && val !== project.name) {
+      onRenameProjectConfirm(project.id, val)
+    } else {
+      onRenameProjectConfirm(project.id, null)
+    }
+  }
+
+  const handleRenameBlur = () => {
+    requestAnimationFrame(() => {
+      if (document.activeElement === inputRef.current) return
+      const val = inputRef.current?.value?.trim()
+      if (val && val !== project.name) {
+        onRenameProjectConfirm(project.id, val)
+      } else {
+        onRenameProjectConfirm(project.id, null)
+      }
+    })
+  }
+
+  return (
+    <div
+      onClick={() => onToggleCollapse(project.id)}
+      className="group flex items-center gap-2 py-2 px-3 cursor-pointer border-b border-border-subtle bg-surface-muted/50 text-fg-muted hover:bg-surface-muted"
+      data-testid={`project-header-${project.id}`}
+    >
+      <i className={`fa-solid fa-chevron-${collapsed ? 'right' : 'down'} text-[9px] w-3 flex-shrink-0 text-fg-faint`}></i>
+      <i className="fa-solid fa-folder text-xs flex-shrink-0 text-amber-500/80"></i>
+      <div className="flex-1 min-w-0">
+        {renamingProject === project.id ? (
+          <form onSubmit={handleRenameSubmit} onClick={e => e.stopPropagation()} className="flex items-center gap-1.5">
+            <input
+              ref={inputRef}
+              type="text"
+              defaultValue={project.name}
+              onBlur={handleRenameBlur}
+              onKeyDown={e => {
+                if (e.key === 'Enter') { e.preventDefault(); handleRenameSubmit(e) }
+                if (e.key === 'Escape') onRenameProjectConfirm(project.id, null)
+              }}
+              className="flex-1 min-w-0 bg-surface-strong border border-border-strong rounded px-2 py-0.5 text-sm text-fg focus:outline-none focus:border-accent"
+            />
+          </form>
+        ) : (
+          <span className="text-sm font-medium truncate flex items-center gap-1.5">
+            <span className="truncate">{project.name}</span>
+            <span className="text-[10px] text-fg-faint flex-shrink-0">{count}</span>
+          </span>
+        )}
+      </div>
+      {confirmDeleteProject === project.id ? (
+        <div className="flex gap-1 flex-shrink-0" onClick={e => e.stopPropagation()}>
+          <button
+            onClick={() => { onDeleteProject(project.id); setConfirmDeleteProject(null) }}
+            className="text-[10px] px-1.5 py-0.5 bg-danger rounded text-white"
+          >Yes</button>
+          <button
+            onClick={() => setConfirmDeleteProject(null)}
+            className="text-[10px] px-1.5 py-0.5 bg-surface-strong rounded text-fg"
+          >No</button>
+        </div>
+      ) : renamingProject === project.id ? null : (
+        <>
+          <button
+            onClick={e => { e.stopPropagation(); onCreateInProject(project.id) }}
+            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+            title="New conversation in project"
+            aria-label="New conversation in project"
+          >
+            <i className="fa-solid fa-plus text-xs"></i>
+          </button>
+          <button
+            onClick={e => { e.stopPropagation(); onRenameProjectStart(project.id) }}
+            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+            title="Rename project"
+            aria-label="Rename project"
+          >
+            <i className="fa-solid fa-pen text-xs"></i>
+          </button>
+          <button
+            onClick={e => { e.stopPropagation(); setConfirmDeleteProject(project.id) }}
+            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-danger-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+            title="Delete project (conversations are kept)"
+            aria-label="Delete project"
+          >
+            <i className="fa-solid fa-trash text-xs"></i>
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [renaming, setRenaming] = useState(null)
+  const [confirmDeleteProject, setConfirmDeleteProject] = useState(null)
+  const [renamingProject, setRenamingProject] = useState(null)
+  const [collapsedProjects, setCollapsedProjects] = useState(() => new Set())
   const [selectedIds, setSelectedIds] = useState(() => new Set())
   const [confirmBulk, setConfirmBulk] = useState(false)
   // Anchor for shift-click range selection. Holds the id of the last
@@ -210,18 +317,42 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
     return { roots, childrenMap }
   }, [conversations])
 
-  // Flat list of conversation ids in render order (root, then its
-  // descendants depth-first, then next root, …). Used to resolve the
-  // [anchor, clicked] span for shift-click range selection.
+  // Group ROOT conversations by project. Spinoffs always render under
+  // their parent (via childrenMap) regardless of their own project_id, so
+  // only roots are bucketed. Roots pointing at an unknown project (e.g.
+  // deleted in another tab) fall back to unfiled rather than vanishing.
+  const grouped = useMemo(() => {
+    const knownIds = new Set(projects.map(p => p.id))
+    const byProject = new Map(projects.map(p => [p.id, []]))
+    const unfiled = []
+    for (const c of tree.roots) {
+      if (c.project_id && knownIds.has(c.project_id)) {
+        byProject.get(c.project_id).push(c)
+      } else {
+        unfiled.push(c)
+      }
+    }
+    return { byProject, unfiled }
+  }, [tree, projects])
+
+  // Flat list of VISIBLE conversation ids in render order (projects first,
+  // each root followed by its descendants depth-first, then unfiled roots).
+  // Collapsed projects contribute nothing — a shift-click range must never
+  // select rows the user can't see. Used to resolve the [anchor, clicked]
+  // span for shift-click range selection.
   const flatOrder = useMemo(() => {
     const out = []
     const walk = (id) => {
       out.push(id)
       for (const child of tree.childrenMap[id] || []) walk(child.id)
     }
-    for (const root of tree.roots) walk(root.id)
+    for (const p of projects) {
+      if (collapsedProjects.has(p.id)) continue
+      for (const root of grouped.byProject.get(p.id) || []) walk(root.id)
+    }
+    for (const root of grouped.unfiled) walk(root.id)
     return out
-  }, [tree])
+  }, [tree, projects, grouped, collapsedProjects])
 
   const toggleSelect = (id, shiftKey) => {
     const anchor = anchorIdRef.current
@@ -269,6 +400,26 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
   const handleRenameConfirm = async (id, newTitle) => {
     setRenaming(null)
     if (newTitle && onRename) await onRename(id, newTitle)
+  }
+
+  const handleRenameProjectConfirm = async (id, newName) => {
+    setRenamingProject(null)
+    if (newName && onRenameProject) await onRenameProject(id, newName)
+  }
+
+  const toggleCollapse = (projectId) => {
+    setCollapsedProjects(prev => {
+      const next = new Set(prev)
+      if (next.has(projectId)) next.delete(projectId)
+      else next.add(projectId)
+      return next
+    })
+  }
+
+  const handleBulkMove = async (targetProjectId) => {
+    const ids = Array.from(selectedIds)
+    clearSelection()
+    if (onMoveMany) await onMoveMany(ids, targetProjectId)
   }
 
   const selectionCount = selectedIds.size
@@ -325,6 +476,15 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
           <i className="fa-solid fa-plus"></i>
           New Conversation
         </button>
+        {onCreateProject && (
+          <button
+            onClick={onCreateProject}
+            className="w-full mt-2 px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center justify-center gap-2"
+          >
+            <i className="fa-solid fa-folder-plus"></i>
+            New Project
+          </button>
+        )}
       </div>
 
       {/* Always-visible header row: shows count + select-all in browse mode,
@@ -367,6 +527,26 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
                 </>
               ) : (
                 <>
+                  {onMoveMany && projects.length > 0 && (
+                    <select
+                      value=""
+                      onChange={e => {
+                        const v = e.target.value
+                        if (!v) return
+                        handleBulkMove(v === '__none__' ? null : v)
+                      }}
+                      onClick={e => e.stopPropagation()}
+                      className="max-w-24 bg-surface border border-border rounded px-1 py-0.5 text-[11px] text-fg-muted cursor-pointer"
+                      title="Move selected to project"
+                      aria-label="Move selected to project"
+                    >
+                      <option value="" disabled>Move to…</option>
+                      {projects.map(p => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
+                      ))}
+                      <option value="__none__">No project</option>
+                    </select>
+                  )}
                   <button
                     onClick={() => setConfirmBulk(true)}
                     className="px-2 py-1 text-danger-fg hover:text-danger-fg hover:bg-danger-subtle rounded"
@@ -386,14 +566,41 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
         )}
       </div>
 
-      {/* Conversation tree */}
+      {/* Conversation tree: project sections first, then unfiled chats */}
       <div className="flex-1 overflow-auto">
-        {conversations.length === 0 && (
+        {conversations.length === 0 && projects.length === 0 && (
           <div className="p-4 text-center text-xs text-fg-subtle">
             No conversations yet
           </div>
         )}
-        {tree.roots.map(conv => renderConv(conv, 0))}
+        {projects.map(project => {
+          const roots = grouped.byProject.get(project.id) || []
+          const collapsed = collapsedProjects.has(project.id)
+          return (
+            <div key={project.id}>
+              <ProjectHeader
+                project={project}
+                count={roots.length}
+                collapsed={collapsed}
+                onToggleCollapse={toggleCollapse}
+                onCreateInProject={onCreateInProject}
+                confirmDeleteProject={confirmDeleteProject}
+                setConfirmDeleteProject={setConfirmDeleteProject}
+                onDeleteProject={onDeleteProject}
+                renamingProject={renamingProject}
+                onRenameProjectStart={setRenamingProject}
+                onRenameProjectConfirm={handleRenameProjectConfirm}
+              />
+              {!collapsed && roots.map(conv => renderConv(conv, 1))}
+              {!collapsed && roots.length === 0 && (
+                <div className="py-2 pl-8 pr-3 text-[11px] text-fg-faint border-b border-border-subtle">
+                  Empty project
+                </div>
+              )}
+            </div>
+          )
+        })}
+        {grouped.unfiled.map(conv => renderConv(conv, 0))}
       </div>
     </div>
   )

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -417,9 +417,21 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
   }
 
   const handleBulkMove = async (targetProjectId) => {
-    const ids = Array.from(selectedIds)
+    // Membership is root-only (spin-offs always render under — and follow —
+    // their root), so resolve every selected id to its root before moving:
+    // moving a spin-off moves the tree the user actually sees. The Set also
+    // dedupes a selection that contains both a root and its descendants.
+    const byId = new Map(conversations.map(c => [c.id, c]))
+    const rootIds = new Set()
+    for (const id of selectedIds) {
+      let cursor = id
+      while (byId.get(cursor)?.parent_conversation_id) {
+        cursor = byId.get(cursor).parent_conversation_id
+      }
+      rootIds.add(cursor)
+    }
     clearSelection()
-    if (onMoveMany) await onMoveMany(ids, targetProjectId)
+    if (onMoveMany) await onMoveMany(Array.from(rootIds), targetProjectId)
   }
 
   const selectionCount = selectedIds.size

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -258,6 +258,23 @@ describe('ChatSidebar project grouping', () => {
     expect(onMoveMany).toHaveBeenCalledWith(['A'], null)
   })
 
+  it('moving a selected spinoff resolves to its root (membership is root-only)', () => {
+    const onMoveMany = vi.fn()
+    renderWithProjects({ onMoveMany })
+    fireEvent.click(checkboxFor('A1'))
+    fireEvent.change(screen.getByTitle('Move selected to project'), { target: { value: 'p2' } })
+    expect(onMoveMany).toHaveBeenCalledWith(['A'], 'p2')
+  })
+
+  it('selecting a root and its spinoff moves the root once (deduped)', () => {
+    const onMoveMany = vi.fn()
+    renderWithProjects({ onMoveMany })
+    fireEvent.click(checkboxFor('A'))
+    fireEvent.click(checkboxFor('A1'))
+    fireEvent.change(screen.getByTitle('Move selected to project'), { target: { value: 'p2' } })
+    expect(onMoveMany).toHaveBeenCalledWith(['A'], 'p2')
+  })
+
   it('project delete asks for confirmation then calls onDeleteProject', () => {
     const onDeleteProject = vi.fn()
     renderWithProjects({ onDeleteProject })

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -149,6 +149,152 @@ describe('ChatSidebar shift-click range selection', () => {
   })
 })
 
+describe('ChatSidebar project grouping', () => {
+  const projects = [
+    { id: 'p1', name: 'Alpha Project', conversation_count: 2 },
+    { id: 'p2', name: 'Beta Project', conversation_count: 0 },
+  ]
+  const convs = [
+    { id: 'A', title: 'A', parent_conversation_id: null, project_id: 'p1', updated_at: '2026-01-01' },
+    { id: 'A1', title: 'A1', parent_conversation_id: 'A', project_id: null, updated_at: '2026-01-01' },
+    { id: 'B', title: 'B', parent_conversation_id: null, project_id: 'p1', updated_at: '2026-01-01' },
+    { id: 'C', title: 'C', parent_conversation_id: null, project_id: null, updated_at: '2026-01-01' },
+    { id: 'D', title: 'D', parent_conversation_id: null, project_id: 'gone', updated_at: '2026-01-01' },
+  ]
+
+  function renderWithProjects(overrides = {}) {
+    return render(
+      <ChatSidebar
+        conversations={convs}
+        activeId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+        projects={projects}
+        onCreateProject={() => {}}
+        onRenameProject={() => {}}
+        onDeleteProject={() => {}}
+        onCreateInProject={() => {}}
+        onMoveMany={() => {}}
+        {...overrides}
+      />
+    )
+  }
+
+  it('renders project headers with their conversations grouped under them', () => {
+    renderWithProjects()
+    expect(screen.getByText('Alpha Project')).toBeTruthy()
+    expect(screen.getByText('Beta Project')).toBeTruthy()
+    // A (and its spinoff A1) and B are under Alpha; C is unfiled.
+    expect(screen.getByText('A')).toBeTruthy()
+    expect(screen.getByText('A1')).toBeTruthy()
+    expect(screen.getByText('C')).toBeTruthy()
+  })
+
+  it('a conversation pointing at an unknown project renders as unfiled', () => {
+    renderWithProjects()
+    expect(screen.getByText('D')).toBeTruthy()
+  })
+
+  it('an empty project shows an empty placeholder', () => {
+    renderWithProjects()
+    expect(screen.getByText('Empty project')).toBeTruthy()
+  })
+
+  it('collapsing a project hides its conversations', () => {
+    renderWithProjects()
+    fireEvent.click(screen.getByTestId('project-header-p1'))
+    expect(screen.queryByText('A')).toBeNull()
+    expect(screen.queryByText('A1')).toBeNull()
+    expect(screen.queryByText('B')).toBeNull()
+    // Unfiled conversations stay visible.
+    expect(screen.getByText('C')).toBeTruthy()
+    // Expanding brings them back.
+    fireEvent.click(screen.getByTestId('project-header-p1'))
+    expect(screen.getByText('A')).toBeTruthy()
+  })
+
+  it('spinoffs render under their parent inside the project regardless of own project_id', () => {
+    renderWithProjects()
+    // A1 has project_id null but its parent A is in p1 — it must render
+    // (under A), not be duplicated in the unfiled section.
+    expect(screen.getAllByText('A1')).toHaveLength(1)
+  })
+
+  it('shift-click range never crosses into a collapsed project', () => {
+    renderWithProjects()
+    // Collapse Alpha (A, A1, B hidden). Anchor on C, shift-click D:
+    // range must be just C..D — no hidden rows selected.
+    fireEvent.click(screen.getByTestId('project-header-p1'))
+    fireEvent.click(checkboxFor('C'))
+    fireEvent.click(checkboxFor('D'), { shiftKey: true })
+    // Expand and verify hidden rows were not swept into the selection.
+    fireEvent.click(screen.getByTestId('project-header-p1'))
+    expect(selectedTitles()).toEqual(['C', 'D'])
+  })
+
+  it('selection toolbar offers Move to… with each project and No project', () => {
+    renderWithProjects()
+    fireEvent.click(checkboxFor('C'))
+    const select = screen.getByTitle('Move selected to project')
+    const options = within(select).getAllByRole('option').map(o => o.textContent)
+    expect(options).toEqual(['Move to…', 'Alpha Project', 'Beta Project', 'No project'])
+  })
+
+  it('choosing a project in Move to… calls onMoveMany with ids and project id', () => {
+    const onMoveMany = vi.fn()
+    renderWithProjects({ onMoveMany })
+    fireEvent.click(checkboxFor('C'))
+    fireEvent.change(screen.getByTitle('Move selected to project'), { target: { value: 'p2' } })
+    expect(onMoveMany).toHaveBeenCalledWith(['C'], 'p2')
+  })
+
+  it('choosing No project calls onMoveMany with null', () => {
+    const onMoveMany = vi.fn()
+    renderWithProjects({ onMoveMany })
+    fireEvent.click(checkboxFor('A'))
+    fireEvent.change(screen.getByTitle('Move selected to project'), { target: { value: '__none__' } })
+    expect(onMoveMany).toHaveBeenCalledWith(['A'], null)
+  })
+
+  it('project delete asks for confirmation then calls onDeleteProject', () => {
+    const onDeleteProject = vi.fn()
+    renderWithProjects({ onDeleteProject })
+    const header = screen.getByTestId('project-header-p1')
+    fireEvent.click(within(header).getByLabelText('Delete project'))
+    fireEvent.click(within(header).getByText('Yes'))
+    expect(onDeleteProject).toHaveBeenCalledWith('p1')
+  })
+
+  it('new-conversation-in-project button calls onCreateInProject without toggling collapse', () => {
+    const onCreateInProject = vi.fn()
+    renderWithProjects({ onCreateInProject })
+    const header = screen.getByTestId('project-header-p2')
+    fireEvent.click(within(header).getByLabelText('New conversation in project'))
+    expect(onCreateInProject).toHaveBeenCalledWith('p2')
+    // Beta stayed expanded (its placeholder is still visible).
+    expect(screen.getByText('Empty project')).toBeTruthy()
+  })
+
+  it('without projects the sidebar renders the flat list as before', () => {
+    render(
+      <ChatSidebar
+        conversations={convs}
+        activeId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+      />
+    )
+    for (const t of ['A', 'A1', 'B', 'C', 'D']) {
+      expect(screen.getByText(t)).toBeTruthy()
+    }
+    expect(screen.queryByText('Alpha Project')).toBeNull()
+  })
+})
+
 describe('ChatSidebar active-run indicator', () => {
   function renderWith(convs) {
     return render(

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -202,6 +202,26 @@ describe('ChatSidebar project grouping', () => {
     expect(screen.getByText('Empty project')).toBeTruthy()
   })
 
+  it('a project whose conversations are not loaded is never claimed empty', () => {
+    // Server says 3 conversations, but none made it into the loaded list —
+    // show a "not loaded" placeholder (and the authoritative count), not
+    // "Empty project".
+    render(
+      <ChatSidebar
+        conversations={[]}
+        activeId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+        projects={[{ id: 'p9', name: 'Ghost', conversation_count: 3 }]}
+      />
+    )
+    expect(screen.queryByText('Empty project')).toBeNull()
+    expect(screen.getByText('3 conversations not loaded')).toBeTruthy()
+    expect(within(screen.getByTestId('project-header-p9')).getByText('3')).toBeTruthy()
+  })
+
   it('collapsing a project hides its conversations', () => {
     renderWithProjects()
     fireEvent.click(screen.getByTestId('project-header-p1'))

--- a/dashboard/frontend/src/hooks/useConversations.js
+++ b/dashboard/frontend/src/hooks/useConversations.js
@@ -8,22 +8,15 @@ export default function useConversations() {
 
   const refresh = useCallback(async () => {
     try {
-      // Page through the full list. The sidebar groups conversations into
-      // project sections, so a partial page would silently hide any
-      // conversation past the first page — a project's chats could become
-      // unreachable while the section claims to be empty.
-      const PAGE = 200
-      const first = await listConversations(PAGE, 0)
-      const all = first.conversations || []
-      const total = first.total ?? all.length
-      while (all.length < total) {
-        const page = await listConversations(PAGE, all.length)
-        const batch = page.conversations || []
-        if (batch.length === 0) break // total shrank mid-pagination
-        all.push(...batch)
-      }
+      // Fetch the ENTIRE list in one request (limit -1 = unlimited). The
+      // sidebar groups conversations into project sections, so a partial
+      // page would silently hide conversations; and offset pagination over
+      // the mutable updated_at ordering can skip or duplicate rows when
+      // runs/renames touch conversations between page fetches. One request
+      // is one SQL statement server-side — a consistent snapshot.
+      const data = await listConversations(-1, 0)
       if (mountedRef.current) {
-        setConversations(all)
+        setConversations(data.conversations || [])
       }
     } catch {
       // ignore

--- a/dashboard/frontend/src/hooks/useConversations.js
+++ b/dashboard/frontend/src/hooks/useConversations.js
@@ -8,9 +8,22 @@ export default function useConversations() {
 
   const refresh = useCallback(async () => {
     try {
-      const data = await listConversations()
+      // Page through the full list. The sidebar groups conversations into
+      // project sections, so a partial page would silently hide any
+      // conversation past the first page — a project's chats could become
+      // unreachable while the section claims to be empty.
+      const PAGE = 200
+      const first = await listConversations(PAGE, 0)
+      const all = first.conversations || []
+      const total = first.total ?? all.length
+      while (all.length < total) {
+        const page = await listConversations(PAGE, all.length)
+        const batch = page.conversations || []
+        if (batch.length === 0) break // total shrank mid-pagination
+        all.push(...batch)
+      }
       if (mountedRef.current) {
-        setConversations(data.conversations || [])
+        setConversations(all)
       }
     } catch {
       // ignore

--- a/dashboard/frontend/src/hooks/useConversations.test.jsx
+++ b/dashboard/frontend/src/hooks/useConversations.test.jsx
@@ -18,34 +18,23 @@ afterEach(() => {
 
 const conv = (i) => ({ id: `c${i}`, title: `C${i}`, updated_at: '2026-01-01' })
 
-describe('useConversations full-list pagination', () => {
-  it('fetches every page so project grouping never works on a partial list', async () => {
-    // 350 conversations, page size 200 → two requests.
+describe('useConversations full-list fetch', () => {
+  it('requests the entire list in ONE unlimited call — no offset pagination', async () => {
+    // Regression for codex iterations 2+4 on PR #77: project grouping must
+    // never operate on a partial list, and offset pagination over the
+    // mutable updated_at ordering can skip or duplicate rows when
+    // conversations are touched between page fetches. A single request is
+    // a consistent snapshot.
     const all = Array.from({ length: 350 }, (_, i) => conv(i))
-    chatApi.listConversations.mockImplementation(async (limit, offset) => ({
-      conversations: all.slice(offset, offset + limit),
+    chatApi.listConversations.mockResolvedValue({
+      conversations: all,
       total: all.length,
-    }))
+    })
 
     const { result } = renderHook(() => useConversations())
     await waitFor(() => expect(result.current.conversations).toHaveLength(350))
 
-    expect(chatApi.listConversations).toHaveBeenCalledWith(200, 0)
-    expect(chatApi.listConversations).toHaveBeenCalledWith(200, 200)
-  })
-
-  it('stops when a page comes back empty even if total was stale', async () => {
-    // total claims 250 but only 150 rows actually exist (rows deleted
-    // between pages) — must not loop forever.
-    const all = Array.from({ length: 150 }, (_, i) => conv(i))
-    chatApi.listConversations.mockImplementation(async (limit, offset) => ({
-      conversations: all.slice(offset, offset + limit),
-      total: 250,
-    }))
-
-    const { result } = renderHook(() => useConversations())
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    expect(result.current.conversations).toHaveLength(150)
+    expect(chatApi.listConversations).toHaveBeenCalledTimes(1)
+    expect(chatApi.listConversations).toHaveBeenCalledWith(-1, 0)
   })
 })

--- a/dashboard/frontend/src/hooks/useConversations.test.jsx
+++ b/dashboard/frontend/src/hooks/useConversations.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import useConversations from './useConversations'
+import * as chatApi from '../services/chat'
+
+vi.mock('../services/chat', () => ({
+  listConversations: vi.fn(),
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  deleteConversations: vi.fn(),
+  updateConversation: vi.fn(),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const conv = (i) => ({ id: `c${i}`, title: `C${i}`, updated_at: '2026-01-01' })
+
+describe('useConversations full-list pagination', () => {
+  it('fetches every page so project grouping never works on a partial list', async () => {
+    // 350 conversations, page size 200 → two requests.
+    const all = Array.from({ length: 350 }, (_, i) => conv(i))
+    chatApi.listConversations.mockImplementation(async (limit, offset) => ({
+      conversations: all.slice(offset, offset + limit),
+      total: all.length,
+    }))
+
+    const { result } = renderHook(() => useConversations())
+    await waitFor(() => expect(result.current.conversations).toHaveLength(350))
+
+    expect(chatApi.listConversations).toHaveBeenCalledWith(200, 0)
+    expect(chatApi.listConversations).toHaveBeenCalledWith(200, 200)
+  })
+
+  it('stops when a page comes back empty even if total was stale', async () => {
+    // total claims 250 but only 150 rows actually exist (rows deleted
+    // between pages) — must not loop forever.
+    const all = Array.from({ length: 150 }, (_, i) => conv(i))
+    chatApi.listConversations.mockImplementation(async (limit, offset) => ({
+      conversations: all.slice(offset, offset + limit),
+      total: 250,
+    }))
+
+    const { result } = renderHook(() => useConversations())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.conversations).toHaveLength(150)
+  })
+})

--- a/dashboard/frontend/src/hooks/useProjects.js
+++ b/dashboard/frontend/src/hooks/useProjects.js
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { listProjects, createProject, updateProject, deleteProject } from '../services/chat'
+
+export default function useProjects() {
+  const [projects, setProjects] = useState([])
+  const mountedRef = useRef(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await listProjects()
+      if (mountedRef.current) {
+        setProjects(data.projects || [])
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    refresh()
+    return () => { mountedRef.current = false }
+  }, [refresh])
+
+  const create = useCallback(async (data) => {
+    const project = await createProject(data)
+    await refresh()
+    return project
+  }, [refresh])
+
+  const rename = useCallback(async (id, name) => {
+    await updateProject(id, { name })
+    await refresh()
+  }, [refresh])
+
+  const remove = useCallback(async (id) => {
+    await deleteProject(id)
+    await refresh()
+  }, [refresh])
+
+  return { projects, refresh, create, rename, remove }
+}

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -35,6 +35,32 @@ export async function deleteConversations(ids) {
   })
 }
 
+// -- Projects --
+
+export async function listProjects() {
+  return fetchAPI('/chat/projects')
+}
+
+export async function createProject(data) {
+  return fetchAPI('/chat/projects', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function updateProject(id, data) {
+  return fetchAPI(`/chat/projects/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteProject(id) {
+  return fetchAPI(`/chat/projects/${id}`, {
+    method: 'DELETE',
+  })
+}
+
 export async function requestCritique(messageId, { contextWindow = 10, extraInstructions = '' } = {}) {
   return fetchAPI(`/chat/messages/${messageId}/critique`, {
     method: 'POST',

--- a/dashboard/tests/test_chat_projects.py
+++ b/dashboard/tests/test_chat_projects.py
@@ -297,6 +297,21 @@ def test_db_trigger_rejects_orphan_project_reference():
     assert db.get_conversation("c2") is None
 
 
+def test_list_conversations_negative_limit_returns_all(client):
+    """limit=-1 returns the entire list in one consistent snapshot — the
+    sidebar uses this so project grouping never sees a partial page."""
+    for i in range(60):
+        _create_conversation(client)
+    r = client.get(f"{CONVERSATIONS_PATH}?limit=-1", headers=_auth())
+    body = r.get_json()
+    assert body["total"] == 60
+    assert len(body["conversations"]) == 60
+
+    # Default paging behavior is unchanged.
+    r = client.get(CONVERSATIONS_PATH, headers=_auth())
+    assert len(r.get_json()["conversations"]) == 50
+
+
 def test_list_projects_counts(client):
     p1 = _create_project(client, name="one")
     p2 = _create_project(client, name="two")

--- a/dashboard/tests/test_chat_projects.py
+++ b/dashboard/tests/test_chat_projects.py
@@ -128,6 +128,25 @@ def test_update_missing_project_404(client):
     assert r.status_code == 404
 
 
+def test_update_project_deleted_between_check_and_write_404(client, monkeypatch):
+    """Two-tab rename/delete race: the route's existence check passes but
+    the row vanishes before the update — must be a JSON 404, not a 500."""
+    from chat.db import ChatDB
+    p = _create_project(client)
+    real_update = ChatDB.update_project
+
+    def racing_update(self, project_id, **kwargs):
+        # The concurrent delete wins just before the update runs.
+        self.delete_project(project_id)
+        return real_update(self, project_id, **kwargs)
+
+    monkeypatch.setattr(ChatDB, "update_project", racing_update)
+    r = client.put(f"{PROJECTS_PATH}/{p['id']}", json={"name": "renamed"},
+                   headers=_auth())
+    assert r.status_code == 404
+    assert r.get_json()["error"] == "Project not found"
+
+
 def test_get_missing_project_404(client):
     assert client.get(f"{PROJECTS_PATH}/nope", headers=_auth()).status_code == 404
 

--- a/dashboard/tests/test_chat_projects.py
+++ b/dashboard/tests/test_chat_projects.py
@@ -1,0 +1,223 @@
+"""Tests for chat projects: CRUD API and conversation membership.
+
+Projects are lightweight folders for conversations. Deleting a project
+detaches its conversations (they become unfiled) rather than deleting them.
+"""
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-chat-projects")
+
+from chat.db import ChatDB
+from chat.routes import chat_bp
+
+TOKEN = "test-token-chat-projects"
+PROJECTS_PATH = "/api/chat/projects"
+CONVERSATIONS_PATH = "/api/chat/conversations"
+
+
+@pytest.fixture
+def client():
+    """Minimal Flask app exposing the chat blueprint with an in-memory DB."""
+    app = Flask(__name__)
+    app.config["DASHBOARD_TOKEN"] = TOKEN
+    app.config["CHAT_DB"] = ChatDB(":memory:")
+    app.register_blueprint(chat_bp)
+    app.testing = True
+    return app.test_client()
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _create_project(client, name="My Project", **extra):
+    r = client.post(PROJECTS_PATH, json={"name": name, **extra}, headers=_auth())
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()
+
+
+def _create_conversation(client, **extra):
+    r = client.post(CONVERSATIONS_PATH, json={"main_service": "svc", **extra},
+                    headers=_auth())
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()
+
+
+# -- Auth ---------------------------------------------------------------
+
+
+def test_projects_require_auth(client):
+    assert client.get(PROJECTS_PATH).status_code == 401
+    assert client.post(PROJECTS_PATH, json={"name": "x"}).status_code == 401
+    assert client.put(f"{PROJECTS_PATH}/abc", json={"name": "x"}).status_code == 401
+    assert client.delete(f"{PROJECTS_PATH}/abc").status_code == 401
+
+
+# -- CRUD ---------------------------------------------------------------
+
+
+def test_create_and_get_project(client):
+    p = _create_project(client, name="Research", description="LLM stuff")
+    assert p["name"] == "Research"
+    assert p["description"] == "LLM stuff"
+    assert p["conversation_count"] == 0
+    assert p["created_at"] and p["updated_at"]
+
+    r = client.get(f"{PROJECTS_PATH}/{p['id']}", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Research"
+
+
+def test_create_project_trims_name(client):
+    p = _create_project(client, name="  padded  ")
+    assert p["name"] == "padded"
+
+
+def test_create_project_rejects_blank_name(client):
+    for bad in [{}, {"name": ""}, {"name": "   "}, {"name": 42}]:
+        r = client.post(PROJECTS_PATH, json=bad, headers=_auth())
+        assert r.status_code == 400
+
+
+def test_create_project_rejects_non_object_body(client):
+    r = client.post(PROJECTS_PATH, json=["not", "a", "dict"], headers=_auth())
+    assert r.status_code == 400
+
+
+def test_create_project_rejects_non_string_description(client):
+    r = client.post(PROJECTS_PATH, json={"name": "x", "description": 7},
+                    headers=_auth())
+    assert r.status_code == 400
+
+
+def test_list_projects_sorted_by_name(client):
+    _create_project(client, name="zebra")
+    _create_project(client, name="Alpha")
+    _create_project(client, name="beta")
+    r = client.get(PROJECTS_PATH, headers=_auth())
+    names = [p["name"] for p in r.get_json()["projects"]]
+    assert names == ["Alpha", "beta", "zebra"]
+
+
+def test_update_project(client):
+    p = _create_project(client)
+    r = client.put(f"{PROJECTS_PATH}/{p['id']}",
+                   json={"name": "Renamed", "description": "new desc"},
+                   headers=_auth())
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["name"] == "Renamed"
+    assert body["description"] == "new desc"
+
+
+def test_update_project_rejects_blank_name(client):
+    p = _create_project(client)
+    r = client.put(f"{PROJECTS_PATH}/{p['id']}", json={"name": "  "},
+                   headers=_auth())
+    assert r.status_code == 400
+
+
+def test_update_missing_project_404(client):
+    r = client.put(f"{PROJECTS_PATH}/nope", json={"name": "x"}, headers=_auth())
+    assert r.status_code == 404
+
+
+def test_get_missing_project_404(client):
+    assert client.get(f"{PROJECTS_PATH}/nope", headers=_auth()).status_code == 404
+
+
+def test_delete_project(client):
+    p = _create_project(client)
+    r = client.delete(f"{PROJECTS_PATH}/{p['id']}", headers=_auth())
+    assert r.status_code == 200
+    assert client.get(f"{PROJECTS_PATH}/{p['id']}", headers=_auth()).status_code == 404
+
+
+def test_delete_missing_project_404(client):
+    assert client.delete(f"{PROJECTS_PATH}/nope", headers=_auth()).status_code == 404
+
+
+# -- Conversation membership ---------------------------------------------
+
+
+def test_create_conversation_in_project(client):
+    p = _create_project(client)
+    conv = _create_conversation(client, project_id=p["id"])
+    assert conv["project_id"] == p["id"]
+
+    # Reflected in the project's conversation_count
+    r = client.get(f"{PROJECTS_PATH}/{p['id']}", headers=_auth())
+    assert r.get_json()["conversation_count"] == 1
+
+
+def test_create_conversation_unknown_project_400(client):
+    r = client.post(CONVERSATIONS_PATH,
+                    json={"main_service": "svc", "project_id": "nope"},
+                    headers=_auth())
+    assert r.status_code == 400
+
+
+def test_create_conversation_without_project(client):
+    conv = _create_conversation(client)
+    assert conv["project_id"] is None
+
+
+def test_move_conversation_into_and_out_of_project(client):
+    p = _create_project(client)
+    conv = _create_conversation(client)
+
+    r = client.put(f"{CONVERSATIONS_PATH}/{conv['id']}",
+                   json={"project_id": p["id"]}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["project_id"] == p["id"]
+
+    # Detach with explicit null
+    r = client.put(f"{CONVERSATIONS_PATH}/{conv['id']}",
+                   json={"project_id": None}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["project_id"] is None
+
+
+def test_move_conversation_to_unknown_project_400(client):
+    conv = _create_conversation(client)
+    r = client.put(f"{CONVERSATIONS_PATH}/{conv['id']}",
+                   json={"project_id": "nope"}, headers=_auth())
+    assert r.status_code == 400
+
+
+def test_delete_project_detaches_conversations(client):
+    p = _create_project(client)
+    conv = _create_conversation(client, project_id=p["id"])
+
+    r = client.delete(f"{PROJECTS_PATH}/{p['id']}", headers=_auth())
+    assert r.status_code == 200
+
+    # Conversation survives, unfiled
+    r = client.get(f"{CONVERSATIONS_PATH}/{conv['id']}", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["project_id"] is None
+
+
+def test_conversation_list_carries_project_id(client):
+    p = _create_project(client)
+    _create_conversation(client, project_id=p["id"])
+    _create_conversation(client)
+    r = client.get(CONVERSATIONS_PATH, headers=_auth())
+    convs = r.get_json()["conversations"]
+    assert {c["project_id"] for c in convs} == {p["id"], None}
+
+
+def test_list_projects_counts(client):
+    p1 = _create_project(client, name="one")
+    p2 = _create_project(client, name="two")
+    _create_conversation(client, project_id=p1["id"])
+    _create_conversation(client, project_id=p1["id"])
+    r = client.get(PROJECTS_PATH, headers=_auth())
+    counts = {p["id"]: p["conversation_count"] for p in r.get_json()["projects"]}
+    assert counts == {p1["id"]: 2, p2["id"]: 0}

--- a/dashboard/tests/test_chat_projects.py
+++ b/dashboard/tests/test_chat_projects.py
@@ -213,6 +213,71 @@ def test_conversation_list_carries_project_id(client):
     assert {c["project_id"] for c in convs} == {p["id"], None}
 
 
+def test_create_conversation_non_string_project_id_400(client):
+    for bad in [{"x": 1}, ["x"], 42, True]:
+        r = client.post(CONVERSATIONS_PATH,
+                        json={"main_service": "svc", "project_id": bad},
+                        headers=_auth())
+        assert r.status_code == 400, bad
+
+
+def test_update_conversation_non_string_project_id_400(client):
+    conv = _create_conversation(client)
+    for bad in [{"x": 1}, ["x"], 42, True]:
+        r = client.put(f"{CONVERSATIONS_PATH}/{conv['id']}",
+                       json={"project_id": bad}, headers=_auth())
+        assert r.status_code == 400, bad
+
+
+def test_spinoff_cannot_be_created_with_project(client):
+    p = _create_project(client)
+    parent = _create_conversation(client, project_id=p["id"])
+    r = client.post(CONVERSATIONS_PATH,
+                    json={"main_service": "svc",
+                          "parent_conversation_id": parent["id"],
+                          "project_id": p["id"]},
+                    headers=_auth())
+    assert r.status_code == 400
+    assert "inherit" in r.get_json()["error"]
+
+
+def test_spinoff_cannot_be_moved_into_project(client):
+    p = _create_project(client)
+    parent = _create_conversation(client)
+    spinoff = _create_conversation(client, parent_conversation_id=parent["id"])
+    r = client.put(f"{CONVERSATIONS_PATH}/{spinoff['id']}",
+                   json={"project_id": p["id"]}, headers=_auth())
+    assert r.status_code == 400
+    assert "inherit" in r.get_json()["error"]
+
+
+def test_db_trigger_rejects_orphan_project_reference():
+    """The referential triggers close the validate-then-write race: a
+    write carrying a project_id whose project no longer exists must fail
+    at the DB layer, not persist an orphan."""
+    import sqlite3
+    import pytest as _pytest
+    from chat.db import ChatDB
+    from chat.models import Conversation, Project
+
+    db = ChatDB(":memory:")
+    p = db.create_project(Project(id="p1", name="p"))
+    conv = db.create_conversation(Conversation(id="c1", title="t", main_service="svc"))
+
+    db.delete_project(p.id)
+
+    # Update path: moving into the now-deleted project must abort.
+    with _pytest.raises(sqlite3.IntegrityError):
+        db.update_conversation(conv.id, project_id="p1")
+    assert db.get_conversation(conv.id).project_id is None
+
+    # Insert path: creating directly into the deleted project must abort.
+    with _pytest.raises(sqlite3.IntegrityError):
+        db.create_conversation(
+            Conversation(id="c2", title="t", main_service="svc", project_id="p1"))
+    assert db.get_conversation("c2") is None
+
+
 def test_list_projects_counts(client):
     p1 = _create_project(client, name="one")
     p2 = _create_project(client, name="two")


### PR DESCRIPTION
Phase 1 of the projects feature: lightweight folders for chat conversations.

## What's in
- **DB**: `projects` table in `chat.db`; nullable `project_id` column on `conversations` (additive migration — existing chats stay unfiled).
- **API**: CRUD under `/api/chat/projects` (list includes per-project conversation counts). `POST/PUT /api/chat/conversations` accept `project_id` and validate it against existing projects (400 on unknown, null detaches).
- **Delete semantics**: deleting a project detaches its conversations (they become unfiled) — never destroys chats.
- **Sidebar UI**: collapsible project sections above the unfiled list; per-project actions (new chat in project, rename, delete w/ confirm); bulk-selection toolbar gains a *Move to…* project dropdown; shift-click range selection skips collapsed sections.

## Tests
- `dashboard/tests/test_chat_projects.py` — 21 backend tests (CRUD, membership, detach-on-delete, validation, auth). Full backend suite: 400 passed.
- `ChatSidebar.test.jsx` — 12 new grouping/move/collapse tests. Full frontend suite: 152 passed. Build OK.

## Not in this phase (planned next)
- Phase 2: real folder tree per project on disk + file API/UI
- Phase 3: in-browser text editor
- Phase 4: `project-files` MCP server scoped to the conversation's project