### PR TITLE
feat(chat): project files — real folders on disk with tree API and UI (phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ opencode.json
 
 # test harness output
 tools/traces/
+
+# Project files (machine-local user content, managed by the dashboard)
+dashboard/project_files/

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -125,7 +125,13 @@ def _validate_component(name: str):
         raise ProjectFilesError("invalid character in path component")
     # Filesystems cap components at 255 BYTES, not characters — a name of
     # 100 emoji passes a character check and still fails at the syscall.
-    if len(name.encode("utf-8")) > MAX_NAME_LENGTH:
+    # JSON happily delivers lone surrogates ("\ud800"), which are not
+    # UTF-8-encodable at all — that's bad input, not a server fault.
+    try:
+        encoded = name.encode("utf-8")
+    except UnicodeEncodeError:
+        raise ProjectFilesError("path component is not valid unicode")
+    if len(encoded) > MAX_NAME_LENGTH:
         raise ProjectFilesError("path component too long")
 
 

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -276,7 +276,10 @@ def mkdir(root: str, rel_path: str) -> dict:
     if not parts:
         raise ProjectFilesError("path is required")
     abs_path = resolve(root, rel_path)
-    if os.path.exists(abs_path):
+    # lexists: a dangling symlink is an ordinary entry in the tree (listed
+    # by build_tree) and must count as occupying its name — exists() would
+    # follow the link and report the slot free.
+    if os.path.lexists(abs_path):
         raise ProjectFilesError("path already exists", status=409)
     with _fs_errors():
         os.makedirs(abs_path)
@@ -295,9 +298,12 @@ def move(root: str, rel_src: str, rel_dst: str) -> dict:
         raise ProjectFilesError("destination is required")
     abs_src = resolve(root, rel_src)
     abs_dst = resolve(root, rel_dst)
-    if not os.path.exists(abs_src):
+    # lexists on both sides: a dangling symlink is movable (the operation
+    # applies to the link itself, as delete already does) and occupies its
+    # destination name.
+    if not os.path.lexists(abs_src):
         raise ProjectFilesError("source not found", status=404)
-    if os.path.exists(abs_dst):
+    if os.path.lexists(abs_dst):
         raise ProjectFilesError("destination already exists", status=409)
     if dst_parts[:len(src_parts)] == src_parts:
         raise ProjectFilesError("cannot move a directory into itself")

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -11,10 +11,12 @@ component validation plus a realpath containment check, so neither
 ``..`` traversal nor a symlink planted inside the tree can escape the
 project root.
 """
+import errno
 import os
 import shutil
 import logging
 import tempfile
+from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +74,46 @@ def ensure_project_root(storage_root: str, project_id: str) -> str:
     return root
 
 
-def delete_project_root(storage_root: str, project_id: str):
-    """Remove a project's entire files directory (project deletion)."""
+def delete_project_root(storage_root: str, project_id: str, strict: bool = False):
+    """Remove a project's entire files directory (project deletion).
+
+    strict=True propagates cleanup failures (used BEFORE the DB row is
+    deleted, so a permissions/IO error surfaces as a retryable 500
+    instead of silently orphaning data). The default best-effort mode is
+    for post-delete sweeps where the row is already gone — failures are
+    logged, never raised.
+    """
     root = project_root(storage_root, project_id)
-    shutil.rmtree(root, ignore_errors=True)
+    if strict:
+        try:
+            shutil.rmtree(root)
+        except FileNotFoundError:
+            pass
+        return
+    try:
+        shutil.rmtree(root)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.exception("best-effort cleanup of project files failed: %s", root)
+
+
+@contextmanager
+def _fs_errors():
+    """Translate filesystem rejections of otherwise-validated paths into
+    client errors. A component can pass the 255-CHARACTER check yet exceed
+    the filesystem's 255-BYTE limit (multibyte names → ENAMETOOLONG), the
+    total path can exceed PATH_MAX, or an intermediate component can turn
+    out to be a regular file (ENOTDIR). All are bad input, not server
+    faults."""
+    try:
+        yield
+    except OSError as e:
+        if e.errno == errno.ENAMETOOLONG:
+            raise ProjectFilesError("name or path too long for the filesystem")
+        if e.errno == errno.ENOTDIR:
+            raise ProjectFilesError("a path component is not a directory")
+        raise
 
 
 def _validate_component(name: str):
@@ -85,7 +123,9 @@ def _validate_component(name: str):
         raise ProjectFilesError("invalid path component")
     if "/" in name or "\\" in name or "\x00" in name:
         raise ProjectFilesError("invalid character in path component")
-    if len(name) > MAX_NAME_LENGTH:
+    # Filesystems cap components at 255 BYTES, not characters — a name of
+    # 100 emoji passes a character check and still fails at the syscall.
+    if len(name.encode("utf-8")) > MAX_NAME_LENGTH:
         raise ProjectFilesError("path component too long")
 
 
@@ -197,30 +237,31 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
     # "<target>.uploading" name would collide with a legitimate user file
     # of that name and with a concurrent upload of the same target.
     written = 0
-    fd, tmp_path = tempfile.mkstemp(prefix=".upload-", suffix=".tmp", dir=abs_dir)
-    try:
-        with os.fdopen(fd, "wb") as f:
-            while True:
-                chunk = stream.read(1024 * 1024)
-                if not chunk:
-                    break
-                written += len(chunk)
-                if written > MAX_UPLOAD_BYTES:
-                    raise ProjectFilesError("file too large", status=413)
-                f.write(chunk)
-        if overwrite:
-            os.replace(tmp_path, abs_target)
-        else:
-            # Atomic no-replace publication: link() fails with EEXIST if the
-            # target appeared since the pre-check, upholding the 409 contract
-            # even against a concurrent upload of the same name.
-            try:
-                os.link(tmp_path, abs_target)
-            except FileExistsError:
-                raise ProjectFilesError("file already exists", status=409)
-    finally:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
+    with _fs_errors():
+        fd, tmp_path = tempfile.mkstemp(prefix=".upload-", suffix=".tmp", dir=abs_dir)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                while True:
+                    chunk = stream.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > MAX_UPLOAD_BYTES:
+                        raise ProjectFilesError("file too large", status=413)
+                    f.write(chunk)
+            if overwrite:
+                os.replace(tmp_path, abs_target)
+            else:
+                # Atomic no-replace publication: link() fails with EEXIST if the
+                # target appeared since the pre-check, upholding the 409 contract
+                # even against a concurrent upload of the same name.
+                try:
+                    os.link(tmp_path, abs_target)
+                except FileExistsError:
+                    raise ProjectFilesError("file already exists", status=409)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
     return _node(abs_target, rel_target)
 
 
@@ -231,7 +272,8 @@ def mkdir(root: str, rel_path: str) -> dict:
     abs_path = resolve(root, rel_path)
     if os.path.exists(abs_path):
         raise ProjectFilesError("path already exists", status=409)
-    os.makedirs(abs_path)
+    with _fs_errors():
+        os.makedirs(abs_path)
     rel = "/".join(parts)
     return _node(abs_path, rel)
 
@@ -255,7 +297,8 @@ def move(root: str, rel_src: str, rel_dst: str) -> dict:
         raise ProjectFilesError("cannot move a directory into itself")
     if not os.path.isdir(os.path.dirname(abs_dst)):
         raise ProjectFilesError("destination directory not found", status=404)
-    shutil.move(abs_src, abs_dst)
+    with _fs_errors():
+        shutil.move(abs_src, abs_dst)
     return _node(abs_dst, "/".join(dst_parts))
 
 

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -1,0 +1,240 @@
+"""Filesystem-backed project files.
+
+Each project owns a real directory tree under a machine-local storage root
+(default ``<dashboard>/project_files/<project_id>/``, override with
+``LLM_DOCK_PROJECT_FILES_DIR``). The filesystem is the source of truth —
+there is no files table to keep in sync; the API walks the directory.
+
+Every public function takes the project's root and *relative* paths from
+the client. ``resolve()`` is the single choke point for path safety:
+component validation plus a realpath containment check, so neither
+``..`` traversal nor a symlink planted inside the tree can escape the
+project root.
+"""
+import os
+import shutil
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Uploads and (later) editor writes are capped; project files are meant as
+# context material for chat, not bulk storage.
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
+MAX_NAME_LENGTH = 255
+
+
+class ProjectFilesError(Exception):
+    """Client-facing error with an HTTP status."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
+def default_storage_root() -> str:
+    configured = os.environ.get("LLM_DOCK_PROJECT_FILES_DIR")
+    if configured:
+        return configured
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "project_files")
+
+
+def project_root(storage_root: str, project_id: str) -> str:
+    """Absolute directory for one project's files (not created here).
+
+    project_id is server-generated (uuid4), but validate it like a single
+    path component anyway — defense in depth against a crafted id ever
+    reaching this layer.
+    """
+    _validate_component(project_id)
+    return os.path.join(os.path.abspath(storage_root), project_id)
+
+
+def ensure_project_root(storage_root: str, project_id: str) -> str:
+    root = project_root(storage_root, project_id)
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+def delete_project_root(storage_root: str, project_id: str):
+    """Remove a project's entire files directory (project deletion)."""
+    root = project_root(storage_root, project_id)
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _validate_component(name: str):
+    if not isinstance(name, str) or not name:
+        raise ProjectFilesError("empty path component")
+    if name in (".", ".."):
+        raise ProjectFilesError("invalid path component")
+    if "/" in name or "\\" in name or "\x00" in name:
+        raise ProjectFilesError("invalid character in path component")
+    if len(name) > MAX_NAME_LENGTH:
+        raise ProjectFilesError("path component too long")
+
+
+def split_rel_path(rel_path: str) -> list:
+    """Split a client-supplied relative path into validated components.
+
+    '' resolves to the project root (zero components).
+    """
+    if rel_path is None:
+        raise ProjectFilesError("path is required")
+    if not isinstance(rel_path, str):
+        raise ProjectFilesError("path must be a string")
+    rel_path = rel_path.strip("/")
+    if rel_path == "":
+        return []
+    parts = rel_path.split("/")
+    for part in parts:
+        _validate_component(part)
+    return parts
+
+
+def resolve(root: str, rel_path: str) -> str:
+    """Resolve a relative path against the project root, safely.
+
+    Containment is checked on the realpath of the nearest EXISTING
+    ancestor, so a symlink anywhere along the way that points outside the
+    root is rejected even when the final path doesn't exist yet.
+    """
+    parts = split_rel_path(rel_path)
+    abs_path = os.path.join(root, *parts) if parts else root
+
+    probe = abs_path
+    while not os.path.exists(probe):
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            break
+        probe = parent
+    real_root = os.path.realpath(root)
+    real_probe = os.path.realpath(probe)
+    if real_probe != real_root and not real_probe.startswith(real_root + os.sep):
+        raise ProjectFilesError("path escapes project root", status=400)
+    return abs_path
+
+
+def _node(abs_path: str, rel_path: str) -> dict:
+    st = os.lstat(abs_path)
+    is_dir = os.path.isdir(abs_path) and not os.path.islink(abs_path)
+    node = {
+        "name": os.path.basename(abs_path) or "/",
+        "path": rel_path,
+        "type": "dir" if is_dir else "file",
+    }
+    if not is_dir:
+        node["size"] = st.st_size
+    node["modified_at"] = int(st.st_mtime)
+    return node
+
+
+def build_tree(root: str, rel_path: str = "") -> list:
+    """Nested listing of a directory, dirs first then files, both sorted
+    case-insensitively. Symlinks are listed as files and never followed
+    (their content is unreachable through resolve()'s realpath check if
+    they point outside the root)."""
+    abs_dir = resolve(root, rel_path)
+    if not os.path.isdir(abs_dir):
+        raise ProjectFilesError("not a directory", status=404)
+    entries = []
+    for name in os.listdir(abs_dir):
+        child_rel = f"{rel_path}/{name}" if rel_path else name
+        child_abs = os.path.join(abs_dir, name)
+        node = _node(child_abs, child_rel)
+        if node["type"] == "dir":
+            node["children"] = build_tree(root, child_rel)
+        entries.append(node)
+    entries.sort(key=lambda n: (n["type"] != "dir", n["name"].lower()))
+    return entries
+
+
+def stat_file(root: str, rel_path: str) -> str:
+    """Resolve rel_path and require it to be an existing regular file.
+    Returns the absolute path (for send_file)."""
+    abs_path = resolve(root, rel_path)
+    if not os.path.exists(abs_path):
+        raise ProjectFilesError("file not found", status=404)
+    if os.path.isdir(abs_path):
+        raise ProjectFilesError("path is a directory", status=400)
+    return abs_path
+
+
+def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool = False) -> dict:
+    """Write an uploaded file into dir_rel. The target directory must
+    already exist (create it with mkdir first). Refuses to replace an
+    existing file unless overwrite is set; never replaces a directory."""
+    _validate_component(filename)
+    abs_dir = resolve(root, dir_rel)
+    if not os.path.isdir(abs_dir):
+        raise ProjectFilesError("target directory not found", status=404)
+    rel_target = f"{dir_rel.strip('/')}/{filename}" if dir_rel.strip("/") else filename
+    abs_target = resolve(root, rel_target)
+    if os.path.isdir(abs_target):
+        raise ProjectFilesError("a directory with that name exists", status=409)
+    if os.path.exists(abs_target) and not overwrite:
+        raise ProjectFilesError("file already exists", status=409)
+
+    written = 0
+    tmp_path = abs_target + ".uploading"
+    try:
+        with open(tmp_path, "wb") as f:
+            while True:
+                chunk = stream.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > MAX_UPLOAD_BYTES:
+                    raise ProjectFilesError("file too large", status=413)
+                f.write(chunk)
+        os.replace(tmp_path, abs_target)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+    return _node(abs_target, rel_target)
+
+
+def mkdir(root: str, rel_path: str) -> dict:
+    parts = split_rel_path(rel_path)
+    if not parts:
+        raise ProjectFilesError("path is required")
+    abs_path = resolve(root, rel_path)
+    if os.path.exists(abs_path):
+        raise ProjectFilesError("path already exists", status=409)
+    os.makedirs(abs_path)
+    rel = "/".join(parts)
+    return _node(abs_path, rel)
+
+
+def move(root: str, rel_src: str, rel_dst: str) -> dict:
+    """Rename/move a file or directory to a new relative path. The
+    destination's parent must exist; the destination itself must not."""
+    src_parts = split_rel_path(rel_src)
+    dst_parts = split_rel_path(rel_dst)
+    if not src_parts:
+        raise ProjectFilesError("cannot move project root")
+    if not dst_parts:
+        raise ProjectFilesError("destination is required")
+    abs_src = resolve(root, rel_src)
+    abs_dst = resolve(root, rel_dst)
+    if not os.path.exists(abs_src):
+        raise ProjectFilesError("source not found", status=404)
+    if os.path.exists(abs_dst):
+        raise ProjectFilesError("destination already exists", status=409)
+    if dst_parts[:len(src_parts)] == src_parts:
+        raise ProjectFilesError("cannot move a directory into itself")
+    if not os.path.isdir(os.path.dirname(abs_dst)):
+        raise ProjectFilesError("destination directory not found", status=404)
+    shutil.move(abs_src, abs_dst)
+    return _node(abs_dst, "/".join(dst_parts))
+
+
+def delete(root: str, rel_path: str):
+    parts = split_rel_path(rel_path)
+    if not parts:
+        raise ProjectFilesError("cannot delete project root")
+    abs_path = resolve(root, rel_path)
+    if not os.path.exists(abs_path) and not os.path.islink(abs_path):
+        raise ProjectFilesError("path not found", status=404)
+    if os.path.isdir(abs_path) and not os.path.islink(abs_path):
+        shutil.rmtree(abs_path)
+    else:
+        os.unlink(abs_path)

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -213,13 +213,21 @@ def build_tree(root: str, rel_path: str = "") -> list:
 
 
 def stat_file(root: str, rel_path: str) -> str:
-    """Resolve rel_path and require it to be an existing regular file.
-    Returns the absolute path (for send_file)."""
+    """Resolve rel_path and require it to be an existing REGULAR file
+    (lstat: symlinks are never followed, matching the tree contract, and
+    FIFOs/sockets/devices are rejected rather than handed to send_file —
+    opening a FIFO would block the worker indefinitely). Returns the
+    absolute path (for send_file)."""
+    import stat as stat_mod
     abs_path = resolve(root, rel_path)
-    if not os.path.exists(abs_path):
+    try:
+        st = os.lstat(abs_path)
+    except FileNotFoundError:
         raise ProjectFilesError("file not found", status=404)
-    if os.path.isdir(abs_path):
+    if stat_mod.S_ISDIR(st.st_mode):
         raise ProjectFilesError("path is a directory", status=400)
+    if not stat_mod.S_ISREG(st.st_mode):
+        raise ProjectFilesError("not a regular file", status=400)
     return abs_path
 
 

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -14,6 +14,7 @@ project root.
 import os
 import shutil
 import logging
+import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -173,10 +174,14 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
     if os.path.exists(abs_target) and not overwrite:
         raise ProjectFilesError("file already exists", status=409)
 
+    # Stage in a UNIQUE, exclusively-created temp file in the destination
+    # directory (same filesystem → atomic publication). A deterministic
+    # "<target>.uploading" name would collide with a legitimate user file
+    # of that name and with a concurrent upload of the same target.
     written = 0
-    tmp_path = abs_target + ".uploading"
+    fd, tmp_path = tempfile.mkstemp(prefix=".upload-", suffix=".tmp", dir=abs_dir)
     try:
-        with open(tmp_path, "wb") as f:
+        with os.fdopen(fd, "wb") as f:
             while True:
                 chunk = stream.read(1024 * 1024)
                 if not chunk:
@@ -185,7 +190,16 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
                 if written > MAX_UPLOAD_BYTES:
                     raise ProjectFilesError("file too large", status=413)
                 f.write(chunk)
-        os.replace(tmp_path, abs_target)
+        if overwrite:
+            os.replace(tmp_path, abs_target)
+        else:
+            # Atomic no-replace publication: link() fails with EEXIST if the
+            # target appeared since the pre-check, upholding the 409 contract
+            # even against a concurrent upload of the same name.
+            try:
+                os.link(tmp_path, abs_target)
+            except FileExistsError:
+                raise ProjectFilesError("file already exists", status=409)
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -22,6 +22,22 @@ logger = logging.getLogger(__name__)
 # context material for chat, not bulk storage.
 MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
 MAX_NAME_LENGTH = 255
+# Path depth cap: keeps recursive tree walks and rmtree far away from
+# Python's recursion limit no matter what gets created through the API.
+MAX_PATH_DEPTH = 32
+
+
+def configure_max_content_length(app):
+    """Give the Flask app a request-body cap keyed to the upload limit.
+
+    Flask pre-seeds MAX_CONTENT_LENGTH with None in every app's default
+    config, so setdefault() would be a no-op — assign only when it is
+    still None, preserving an explicit deployment override. Werkzeug then
+    enforces the cap DURING multipart parsing, covering chunked bodies
+    that carry no Content-Length.
+    """
+    if app.config.get("MAX_CONTENT_LENGTH") is None:
+        app.config["MAX_CONTENT_LENGTH"] = int(MAX_UPLOAD_BYTES * 1.05)
 
 
 class ProjectFilesError(Exception):
@@ -86,6 +102,8 @@ def split_rel_path(rel_path: str) -> list:
     if rel_path == "":
         return []
     parts = rel_path.split("/")
+    if len(parts) > MAX_PATH_DEPTH:
+        raise ProjectFilesError("path too deep")
     for part in parts:
         _validate_component(part)
     return parts

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -5,6 +5,7 @@ mcp_admin_routes) so the routes attach before the blueprint is
 registered on the app.
 """
 import logging
+import os
 
 from flask import jsonify, request, current_app, send_file
 
@@ -19,13 +20,33 @@ def _storage_root() -> str:
     return current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
 
 
-def _project_root_or_404(project_id):
-    """Returns (root, error_response). The project must exist in the DB;
-    its directory is created lazily."""
+def _project_root_or_404(project_id, create=False):
+    """Returns (root, error_response). The project must exist in the DB.
+
+    Only MUTATING routes pass create=True — read-only routes must never
+    (re)create the directory, or a GET racing a project delete would leave
+    an orphan directory behind.
+    """
     if _get_db().get_project(project_id) is None:
         return None, (jsonify({"error": "Project not found"}), 404)
-    root = pf.ensure_project_root(_storage_root(), project_id)
+    if create:
+        root = pf.ensure_project_root(_storage_root(), project_id)
+    else:
+        root = pf.project_root(_storage_root(), project_id)
     return root, None
+
+
+def _revalidate_or_cleanup(project_id):
+    """Commit-point check for mutating routes: if the project row vanished
+    while the file operation ran (concurrent project delete — its rmtree
+    may have run before our write recreated paths), remove the project's
+    directory again and report 404. Whichever side acts last cleans up, so
+    no orphan directory survives the race in either interleaving.
+    """
+    if _get_db().get_project(project_id) is None:
+        pf.delete_project_root(_storage_root(), project_id)
+        return jsonify({"error": "Project not found"}), 404
+    return None
 
 
 @chat_bp.errorhandler(pf.ProjectFilesError)
@@ -39,13 +60,24 @@ def project_files_tree(project_id):
     root, err = _project_root_or_404(project_id)
     if err:
         return err
+    # Directory is created lazily by the first mutating operation; before
+    # that, the project simply has no files.
+    if not os.path.isdir(root):
+        return jsonify({"tree": []})
     return jsonify({"tree": pf.build_tree(root)})
 
 
 @chat_bp.route("/api/chat/projects/<project_id>/files/upload", methods=["POST"])
 @require_auth
 def project_files_upload(project_id):
-    root, err = _project_root_or_404(project_id)
+    # Reject oversized requests BEFORE touching request.files/form —
+    # multipart parsing consumes (and spools) the whole body. The app-level
+    # MAX_CONTENT_LENGTH (set in init_chat) makes Werkzeug enforce this
+    # during parsing too, covering chunked bodies with no Content-Length;
+    # the byte counter inside save_stream is the last line of defense.
+    if request.content_length and request.content_length > pf.MAX_UPLOAD_BYTES * 1.05:
+        return jsonify({"error": "file too large"}), 413
+    root, err = _project_root_or_404(project_id, create=True)
     if err:
         return err
     if "file" not in request.files:
@@ -53,11 +85,12 @@ def project_files_upload(project_id):
     upload = request.files["file"]
     if not upload.filename:
         return jsonify({"error": "filename is required"}), 400
-    if request.content_length and request.content_length > pf.MAX_UPLOAD_BYTES * 1.05:
-        return jsonify({"error": "file too large"}), 413
     dir_rel = request.form.get("dir", "")
     overwrite = request.form.get("overwrite", "").lower() in ("1", "true", "yes")
     node = pf.save_stream(root, dir_rel, upload.filename, upload.stream, overwrite=overwrite)
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
     logger.info("project %s: uploaded %s (%d bytes)", project_id, node["path"], node.get("size", 0))
     return jsonify(node), 201
 
@@ -75,34 +108,43 @@ def project_files_download(project_id):
 @chat_bp.route("/api/chat/projects/<project_id>/files/mkdir", methods=["POST"])
 @require_auth
 def project_files_mkdir(project_id):
-    root, err = _project_root_or_404(project_id)
+    root, err = _project_root_or_404(project_id, create=True)
     if err:
         return err
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return jsonify({"error": "body must be {path: string}"}), 400
     node = pf.mkdir(root, data.get("path"))
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
     return jsonify(node), 201
 
 
 @chat_bp.route("/api/chat/projects/<project_id>/files/move", methods=["POST"])
 @require_auth
 def project_files_move(project_id):
-    root, err = _project_root_or_404(project_id)
+    root, err = _project_root_or_404(project_id, create=True)
     if err:
         return err
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return jsonify({"error": "body must be {path, new_path}"}), 400
     node = pf.move(root, data.get("path"), data.get("new_path"))
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
     return jsonify(node)
 
 
 @chat_bp.route("/api/chat/projects/<project_id>/files", methods=["DELETE"])
 @require_auth
 def project_files_delete(project_id):
-    root, err = _project_root_or_404(project_id)
+    root, err = _project_root_or_404(project_id, create=True)
     if err:
         return err
     pf.delete(root, request.args.get("path", ""))
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
     return jsonify({"ok": True})

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -101,7 +101,16 @@ def project_files_download(project_id):
     root, err = _project_root_or_404(project_id)
     if err:
         return err
-    abs_path = pf.stat_file(root, request.args.get("path", ""))
+    rel_path = request.args.get("path", "")
+    # Validate the path shape FIRST so traversal attempts stay 400s, then
+    # handle the lazily-created root: before the first mutation any
+    # requested file is simply absent — without this guard resolve() would
+    # walk up past the missing root and misreport 400 "escapes project
+    # root" for an ordinary 404.
+    pf.split_rel_path(rel_path)
+    if not os.path.isdir(root):
+        return jsonify({"error": "file not found"}), 404
+    abs_path = pf.stat_file(root, rel_path)
     return send_file(abs_path, as_attachment=True)
 
 

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -1,0 +1,108 @@
+"""HTTP surface for project files, registered onto chat_bp.
+
+Imported at the bottom of chat/routes.py (same pattern as
+mcp_admin_routes) so the routes attach before the blueprint is
+registered on the app.
+"""
+import logging
+
+from flask import jsonify, request, current_app, send_file
+
+from auth import require_auth
+from . import project_files as pf
+from .routes import chat_bp, _get_db
+
+logger = logging.getLogger(__name__)
+
+
+def _storage_root() -> str:
+    return current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
+
+
+def _project_root_or_404(project_id):
+    """Returns (root, error_response). The project must exist in the DB;
+    its directory is created lazily."""
+    if _get_db().get_project(project_id) is None:
+        return None, (jsonify({"error": "Project not found"}), 404)
+    root = pf.ensure_project_root(_storage_root(), project_id)
+    return root, None
+
+
+@chat_bp.errorhandler(pf.ProjectFilesError)
+def _handle_pf_error(e):
+    return jsonify({"error": str(e)}), e.status
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files", methods=["GET"])
+@require_auth
+def project_files_tree(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    return jsonify({"tree": pf.build_tree(root)})
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files/upload", methods=["POST"])
+@require_auth
+def project_files_upload(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    if "file" not in request.files:
+        return jsonify({"error": "multipart 'file' field is required"}), 400
+    upload = request.files["file"]
+    if not upload.filename:
+        return jsonify({"error": "filename is required"}), 400
+    if request.content_length and request.content_length > pf.MAX_UPLOAD_BYTES * 1.05:
+        return jsonify({"error": "file too large"}), 413
+    dir_rel = request.form.get("dir", "")
+    overwrite = request.form.get("overwrite", "").lower() in ("1", "true", "yes")
+    node = pf.save_stream(root, dir_rel, upload.filename, upload.stream, overwrite=overwrite)
+    logger.info("project %s: uploaded %s (%d bytes)", project_id, node["path"], node.get("size", 0))
+    return jsonify(node), 201
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files/download", methods=["GET"])
+@require_auth
+def project_files_download(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    abs_path = pf.stat_file(root, request.args.get("path", ""))
+    return send_file(abs_path, as_attachment=True)
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files/mkdir", methods=["POST"])
+@require_auth
+def project_files_mkdir(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be {path: string}"}), 400
+    node = pf.mkdir(root, data.get("path"))
+    return jsonify(node), 201
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files/move", methods=["POST"])
+@require_auth
+def project_files_move(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be {path, new_path}"}), 400
+    node = pf.move(root, data.get("path"), data.get("new_path"))
+    return jsonify(node)
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files", methods=["DELETE"])
+@require_auth
+def project_files_delete(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    pf.delete(root, request.args.get("path", ""))
+    return jsonify({"ok": True})

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -43,10 +43,10 @@ def init_chat(app, db_path: str = None):
     # Cap request bodies so Werkzeug rejects an oversized upload DURING
     # multipart parsing (before it is fully spooled to disk) — covers
     # chunked bodies that carry no Content-Length. Slightly above the
-    # per-file cap to leave room for multipart framing. setdefault so a
-    # deployment can still override it in app config.
-    from .project_files import MAX_UPLOAD_BYTES
-    app.config.setdefault("MAX_CONTENT_LENGTH", int(MAX_UPLOAD_BYTES * 1.05))
+    # per-file cap to leave room for multipart framing; an explicit
+    # deployment override is preserved.
+    from .project_files import configure_max_content_length
+    configure_max_content_length(app)
 
     bus = EventBus()
     run_manager = ChatRunManager(db, bus)

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -239,8 +239,11 @@ def update_project(project_id):
 @require_auth
 def delete_project(project_id):
     """Delete a project. Its conversations are detached (become unfiled),
-    not deleted."""
+    not deleted; its files directory IS removed."""
     if _get_db().delete_project(project_id):
+        from . import project_files as pf
+        storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
+        pf.delete_project_root(storage_root, project_id)
         return jsonify({"ok": True})
     return jsonify({"error": "Project not found"}), 404
 
@@ -663,3 +666,4 @@ def spinoff():
 # the blueprint 'chat'". This bottom-of-file import runs while chat.routes
 # is being imported by app.py — before the blueprint is registered.
 from . import mcp_admin_routes  # noqa: E402,F401
+from . import project_files_routes  # noqa: E402,F401

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -40,6 +40,14 @@ def init_chat(app, db_path: str = None):
     # Background-run infrastructure (#58): an event bus for live observers and
     # a manager owning the worker pool. Runs from a previous process that died
     # mid-flight are marked failed so they don't linger as stuck active runs.
+    # Cap request bodies so Werkzeug rejects an oversized upload DURING
+    # multipart parsing (before it is fully spooled to disk) — covers
+    # chunked bodies that carry no Content-Length. Slightly above the
+    # per-file cap to leave room for multipart framing. setdefault so a
+    # deployment can still override it in app config.
+    from .project_files import MAX_UPLOAD_BYTES
+    app.config.setdefault("MAX_CONTENT_LENGTH", int(MAX_UPLOAD_BYTES * 1.05))
+
     bus = EventBus()
     run_manager = ChatRunManager(db, bus)
     run_manager.recover_interrupted_runs()

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -247,11 +247,26 @@ def update_project(project_id):
 @require_auth
 def delete_project(project_id):
     """Delete a project. Its conversations are detached (become unfiled),
-    not deleted; its files directory IS removed."""
-    if _get_db().delete_project(project_id):
-        from . import project_files as pf
-        storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
-        pf.delete_project_root(storage_root, project_id)
+    not deleted; its files directory IS removed.
+
+    Files are removed BEFORE the DB row, strictly: if cleanup fails
+    (permissions, IO), the row survives and the delete stays retryable —
+    otherwise the data would be orphaned with no API path back to it. The
+    post-delete sweep is best-effort and only mops up a directory that a
+    concurrent file write recreated in the window.
+    """
+    from . import project_files as pf
+    db = _get_db()
+    if db.get_project(project_id) is None:
+        return jsonify({"error": "Project not found"}), 404
+    storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
+    try:
+        pf.delete_project_root(storage_root, project_id, strict=True)
+    except OSError as e:
+        logger.error("project %s: files cleanup failed, aborting delete: %s", project_id, e)
+        return jsonify({"error": f"failed to remove project files: {e}"}), 500
+    if db.delete_project(project_id):
+        pf.delete_project_root(storage_root, project_id)  # sweep, best-effort
         return jsonify({"ok": True})
     return jsonify({"error": "Project not found"}), 404
 

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -33,6 +33,12 @@ function App() {
               pendingMsgRef holding the empty-state composer's first
               message. */}
           <Route path="/chat/:conversationId?" element={<ChatPage />} />
+          {/* Project page (files & folders). A separate pattern means
+              ChatPage remounts when crossing between a conversation and a
+              project view — acceptable: pendingMsgRef only matters inside
+              the empty-composer create-then-send flow, which never routes
+              through a project URL. */}
+          <Route path="/chat/project/:projectId" element={<ChatPage />} />
           <Route path="/tools" element={<DefaultLayout><ToolsPage /></DefaultLayout>} />
           <Route path="/" element={<DefaultLayout><GpuMonitor /><ServicesTable /></DefaultLayout>} />
           <Route path="/services/:serviceName/*" element={<DefaultLayout><ServiceDetailsPage /></DefaultLayout>} />

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
+import ProjectPage from './ProjectPage'
 import useConversations from '../../hooks/useConversations'
 import useProjects from '../../hooks/useProjects'
 import useChat from '../../hooks/useChat'
@@ -12,7 +13,7 @@ import { serviceNameForModel, formatModelLabel } from '../../utils/openrouter'
 import { pendingFlushDecision } from './pendingFlush'
 
 export default function ChatPage() {
-  const { conversationId } = useParams()
+  const { conversationId, projectId } = useParams()
   const convId = conversationId || null
   const navigate = useNavigate()
 
@@ -142,7 +143,9 @@ export default function ChatPage() {
     // list so they reappear as unfiled.
     await removeProject(id)
     await refresh()
-  }, [removeProject, refresh])
+    // Don't leave the URL pointing at the project page we just deleted.
+    if (projectId === id) navigate('/chat')
+  }, [removeProject, refresh, projectId, navigate])
 
   const handleMoveMany = useCallback(async (ids, projectId) => {
     await Promise.all(ids.map(id => updateConversation(id, { project_id: projectId })))
@@ -163,6 +166,10 @@ export default function ChatPage() {
 
   const handleSelect = useCallback((id) => {
     navigate(`/chat/${id}`)
+  }, [navigate])
+
+  const handleOpenProject = useCallback((id) => {
+    navigate(`/chat/project/${id}`)
   }, [navigate])
 
   // Deletes cascade to descendant spinoffs server-side. If the active
@@ -211,12 +218,17 @@ export default function ChatPage() {
         onDeleteMany={handleDeleteMany}
         onRename={handleRename}
         projects={projects}
+        activeProjectId={projectId || null}
+        onOpenProject={handleOpenProject}
         onCreateProject={handleCreateProject}
         onRenameProject={renameProject}
         onDeleteProject={handleDeleteProject}
         onCreateInProject={handleCreateInProject}
         onMoveMany={handleMoveMany}
       />
+      {projectId ? (
+        <ProjectPage project={projects.find(p => p.id === projectId) || null} />
+      ) : (
       <ChatArea
         conversation={conversation}
         awaitingConversation={!!convId && (!conversation || conversation.id !== convId)}
@@ -243,6 +255,7 @@ export default function ChatPage() {
         onReloadConversation={loadConversation}
         onRefreshConversations={refresh}
       />
+      )}
     </div>
   )
 }

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -187,7 +187,7 @@ function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggl
   )
 }
 
-function ProjectHeader({ project, collapsed, onToggleCollapse, onCreateInProject, confirmDeleteProject, setConfirmDeleteProject, onDeleteProject, renamingProject, onRenameProjectStart, onRenameProjectConfirm, count }) {
+function ProjectHeader({ project, collapsed, active, onToggleCollapse, onOpenProject, onCreateInProject, confirmDeleteProject, setConfirmDeleteProject, onDeleteProject, renamingProject, onRenameProjectStart, onRenameProjectConfirm, count }) {
   const inputRef = useRef(null)
 
   useEffect(() => {
@@ -221,7 +221,9 @@ function ProjectHeader({ project, collapsed, onToggleCollapse, onCreateInProject
   return (
     <div
       onClick={() => onToggleCollapse(project.id)}
-      className="group flex items-center gap-2 py-2 px-3 cursor-pointer border-b border-border-subtle bg-surface-muted/50 text-fg-muted hover:bg-surface-muted"
+      className={`group flex items-center gap-2 py-2 px-3 cursor-pointer border-b border-border-subtle ${
+        active ? 'bg-surface text-fg' : 'bg-surface-muted/50 text-fg-muted hover:bg-surface-muted'
+      }`}
       data-testid={`project-header-${project.id}`}
     >
       <i className={`fa-solid fa-chevron-${collapsed ? 'right' : 'down'} text-[9px] w-3 flex-shrink-0 text-fg-faint`}></i>
@@ -261,6 +263,16 @@ function ProjectHeader({ project, collapsed, onToggleCollapse, onCreateInProject
         </div>
       ) : renamingProject === project.id ? null : (
         <>
+          {onOpenProject && (
+            <button
+              onClick={e => { e.stopPropagation(); onOpenProject(project.id) }}
+              className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
+              title="Open project files"
+              aria-label="Open project files"
+            >
+              <i className="fa-solid fa-folder-open text-xs"></i>
+            </button>
+          )}
           <button
             onClick={e => { e.stopPropagation(); onCreateInProject(project.id) }}
             className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg flex-shrink-0 p-1.5 -m-1.5 cursor-pointer"
@@ -291,7 +303,7 @@ function ProjectHeader({ project, collapsed, onToggleCollapse, onCreateInProject
   )
 }
 
-export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
+export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], activeProjectId = null, onOpenProject, onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [renaming, setRenaming] = useState(null)
   const [confirmDeleteProject, setConfirmDeleteProject] = useState(null)
@@ -598,7 +610,9 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
                 project={project}
                 count={count}
                 collapsed={collapsed}
+                active={activeProjectId === project.id}
                 onToggleCollapse={toggleCollapse}
+                onOpenProject={onOpenProject}
                 onCreateInProject={onCreateInProject}
                 confirmDeleteProject={confirmDeleteProject}
                 setConfirmDeleteProject={setConfirmDeleteProject}

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -112,6 +112,10 @@ export default function ProjectPage({ project }) {
   const refresh = useCallback(async () => {
     const pid = project?.id
     if (!pid) return
+    // A stale closure (a previous project's mutation follow-up) must not
+    // claim a generation at all — it would invalidate the CURRENT
+    // project's in-flight fetch and strand the page empty.
+    if (projectIdRef.current !== pid) return
     const gen = ++genRef.current
     const stillCurrent = () => genRef.current === gen && projectIdRef.current === pid
     try {

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -1,0 +1,289 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  getProjectFilesTree, uploadProjectFile, mkdirProjectPath,
+  moveProjectPath, deleteProjectPath, downloadProjectFile,
+} from '../../services/chat'
+
+function formatSize(bytes) {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, onRename, onDelete, onDownload }) {
+  const isDir = node.type === 'dir'
+  return (
+    <>
+      <div
+        onClick={isDir ? () => onToggle(node.path) : undefined}
+        className={`group flex items-center gap-2 py-1.5 pr-3 border-b border-border-subtle text-sm ${
+          isDir ? 'cursor-pointer text-fg' : 'text-fg-muted'
+        } hover:bg-surface-muted`}
+        style={{ paddingLeft: `${12 + depth * 18}px` }}
+        data-testid={`file-row-${node.path}`}
+      >
+        {isDir ? (
+          <>
+            <i className={`fa-solid fa-chevron-${expanded.has(node.path) ? 'down' : 'right'} text-[9px] w-3 text-fg-faint flex-shrink-0`}></i>
+            <i className="fa-solid fa-folder text-xs text-amber-500/80 flex-shrink-0"></i>
+          </>
+        ) : (
+          <>
+            <span className="w-3 flex-shrink-0"></span>
+            <i className="fa-regular fa-file text-xs text-fg-faint flex-shrink-0"></i>
+          </>
+        )}
+        <span className="flex-1 min-w-0 truncate">{node.name}</span>
+        {!isDir && <span className="text-[10px] text-fg-faint flex-shrink-0">{formatSize(node.size)}</span>}
+        <span className="flex items-center gap-0.5 flex-shrink-0">
+          {isDir && (
+            <>
+              <button
+                onClick={e => { e.stopPropagation(); onUploadInto(node.path) }}
+                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+                title="Upload into folder" aria-label={`Upload into ${node.path}`}
+              ><i className="fa-solid fa-file-arrow-up text-xs"></i></button>
+              <button
+                onClick={e => { e.stopPropagation(); onNewFolder(node.path) }}
+                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+                title="New subfolder" aria-label={`New subfolder in ${node.path}`}
+              ><i className="fa-solid fa-folder-plus text-xs"></i></button>
+            </>
+          )}
+          {!isDir && (
+            <button
+              onClick={e => { e.stopPropagation(); onDownload(node) }}
+              className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+              title="Download" aria-label={`Download ${node.path}`}
+            ><i className="fa-solid fa-download text-xs"></i></button>
+          )}
+          <button
+            onClick={e => { e.stopPropagation(); onRename(node) }}
+            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+            title="Rename / move" aria-label={`Rename ${node.path}`}
+          ><i className="fa-solid fa-pen text-xs"></i></button>
+          <button
+            onClick={e => { e.stopPropagation(); onDelete(node) }}
+            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-danger-fg p-1 cursor-pointer"
+            title="Delete" aria-label={`Delete ${node.path}`}
+          ><i className="fa-solid fa-trash text-xs"></i></button>
+        </span>
+      </div>
+      {isDir && expanded.has(node.path) && (node.children || []).map(child => (
+        <NodeRow
+          key={child.path}
+          node={child}
+          depth={depth + 1}
+          expanded={expanded}
+          onToggle={onToggle}
+          onUploadInto={onUploadInto}
+          onNewFolder={onNewFolder}
+          onRename={onRename}
+          onDelete={onDelete}
+          onDownload={onDownload}
+        />
+      ))}
+    </>
+  )
+}
+
+export default function ProjectPage({ project }) {
+  const [tree, setTree] = useState([])
+  const [expanded, setExpanded] = useState(() => new Set())
+  const [error, setError] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const fileInputRef = useRef(null)
+  // Directory the next file-picker selection uploads into.
+  const uploadDirRef = useRef('')
+
+  const refresh = useCallback(async () => {
+    if (!project?.id) return
+    try {
+      const data = await getProjectFilesTree(project.id)
+      setTree(data.tree || [])
+      setError(null)
+    } catch (err) {
+      setError(err.message)
+    }
+  }, [project?.id])
+
+  useEffect(() => {
+    setTree([])
+    setExpanded(new Set())
+    setError(null)
+    refresh()
+  }, [refresh])
+
+  const run = useCallback(async (fn) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+      await refresh()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const toggle = useCallback((path) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  const pickUpload = useCallback((dir) => {
+    uploadDirRef.current = dir
+    fileInputRef.current?.click()
+  }, [])
+
+  const handleFilesPicked = useCallback(async (e) => {
+    const files = Array.from(e.target.files || [])
+    e.target.value = '' // allow re-picking the same file later
+    if (files.length === 0) return
+    const dir = uploadDirRef.current
+    await run(async () => {
+      for (const file of files) {
+        try {
+          await uploadProjectFile(project.id, file, { dir })
+        } catch (err) {
+          if (err.message === 'file already exists' &&
+              window.confirm(`"${file.name}" already exists. Overwrite?`)) {
+            await uploadProjectFile(project.id, file, { dir, overwrite: true })
+          } else if (err.message !== 'file already exists') {
+            throw err
+          }
+        }
+      }
+    })
+    if (dir) setExpanded(prev => new Set(prev).add(dir))
+  }, [project?.id, run])
+
+  const handleNewFolder = useCallback(async (parentDir) => {
+    const name = window.prompt('Folder name')
+    if (!name || !name.trim()) return
+    const path = parentDir ? `${parentDir}/${name.trim()}` : name.trim()
+    await run(() => mkdirProjectPath(project.id, path))
+    if (parentDir) setExpanded(prev => new Set(prev).add(parentDir))
+  }, [project?.id, run])
+
+  const handleRename = useCallback(async (node) => {
+    const newPath = window.prompt('New path (relative to project root)', node.path)
+    if (!newPath || !newPath.trim() || newPath.trim() === node.path) return
+    await run(() => moveProjectPath(project.id, node.path, newPath.trim()))
+  }, [project?.id, run])
+
+  const handleDelete = useCallback(async (node) => {
+    const label = node.type === 'dir' ? `folder "${node.path}" and everything in it` : `"${node.path}"`
+    if (!window.confirm(`Delete ${label}?`)) return
+    await run(() => deleteProjectPath(project.id, node.path))
+  }, [project?.id, run])
+
+  const handleDownload = useCallback(async (node) => {
+    try {
+      const url = await downloadProjectFile(project.id, node.path)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = node.name
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setError(err.message)
+    }
+  }, [project?.id])
+
+  if (!project) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-fg-subtle text-sm">
+        Project not found
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden bg-app">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        onChange={handleFilesPicked}
+        className="hidden"
+        data-testid="file-input"
+      />
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-border">
+        <div className="flex items-center gap-3">
+          <i className="fa-solid fa-folder-open text-amber-500/80"></i>
+          <h1 className="text-lg font-semibold text-fg truncate">{project.name}</h1>
+        </div>
+        {project.description && (
+          <p className="mt-1 text-sm text-fg-muted">{project.description}</p>
+        )}
+      </div>
+
+      {/* Toolbar */}
+      <div className="px-6 py-2 border-b border-border flex items-center gap-2">
+        <button
+          onClick={() => pickUpload('')}
+          disabled={busy}
+          className="px-3 py-1.5 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-xs font-medium transition-colors flex items-center gap-2 disabled:opacity-50"
+        >
+          <i className="fa-solid fa-file-arrow-up"></i>
+          Upload files
+        </button>
+        <button
+          onClick={() => handleNewFolder('')}
+          disabled={busy}
+          className="px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center gap-2 disabled:opacity-50"
+        >
+          <i className="fa-solid fa-folder-plus"></i>
+          New folder
+        </button>
+        <button
+          onClick={refresh}
+          disabled={busy}
+          className="ml-auto px-2 py-1.5 text-fg-subtle hover:text-fg text-xs disabled:opacity-50"
+          title="Refresh" aria-label="Refresh file tree"
+        >
+          <i className="fa-solid fa-rotate-right"></i>
+        </button>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-3 px-3 py-2 bg-danger-subtle text-danger-fg rounded text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* Tree */}
+      <div className="flex-1 overflow-auto py-1">
+        {tree.length === 0 && !error && (
+          <div className="p-8 text-center text-xs text-fg-subtle">
+            No files yet. Upload files or create a folder to get started.
+          </div>
+        )}
+        {tree.map(node => (
+          <NodeRow
+            key={node.path}
+            node={node}
+            depth={0}
+            expanded={expanded}
+            onToggle={toggle}
+            onUploadInto={pickUpload}
+            onNewFolder={handleNewFolder}
+            onRename={handleRename}
+            onDelete={handleDelete}
+            onDownload={handleDownload}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -96,14 +96,22 @@ export default function ProjectPage({ project }) {
   const fileInputRef = useRef(null)
   // Directory the next file-picker selection uploads into.
   const uploadDirRef = useRef('')
+  // Monotonic request generation. A tree fetch only commits if it is still
+  // the latest — otherwise a slow response for project A, resolving after
+  // the user switched to project B, would install A's rows under B and
+  // route row actions (which close over B's id) at the wrong project.
+  const genRef = useRef(0)
 
   const refresh = useCallback(async () => {
     if (!project?.id) return
+    const gen = ++genRef.current
     try {
       const data = await getProjectFilesTree(project.id)
+      if (genRef.current !== gen) return
       setTree(data.tree || [])
       setError(null)
     } catch (err) {
+      if (genRef.current !== gen) return
       setError(err.message)
     }
   }, [project?.id])

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -101,17 +101,26 @@ export default function ProjectPage({ project }) {
   // the user switched to project B, would install A's rows under B and
   // route row actions (which close over B's id) at the wrong project.
   const genRef = useRef(0)
+  // The project currently rendered, updated every render. The generation
+  // alone is outrunnable: a stale A-closure (e.g. a mutation's follow-up
+  // refresh) that STARTS after B's refresh claims a newer generation and
+  // would win — so every commit is also bound to the project id captured
+  // when the request began.
+  const projectIdRef = useRef(project?.id)
+  projectIdRef.current = project?.id
 
   const refresh = useCallback(async () => {
-    if (!project?.id) return
+    const pid = project?.id
+    if (!pid) return
     const gen = ++genRef.current
+    const stillCurrent = () => genRef.current === gen && projectIdRef.current === pid
     try {
-      const data = await getProjectFilesTree(project.id)
-      if (genRef.current !== gen) return
+      const data = await getProjectFilesTree(pid)
+      if (!stillCurrent()) return
       setTree(data.tree || [])
       setError(null)
     } catch (err) {
-      if (genRef.current !== gen) return
+      if (!stillCurrent()) return
       setError(err.message)
     }
   }, [project?.id])
@@ -120,21 +129,26 @@ export default function ProjectPage({ project }) {
     setTree([])
     setExpanded(new Set())
     setError(null)
+    setBusy(false)
     refresh()
   }, [refresh])
 
   const run = useCallback(async (fn) => {
+    // Same binding as refresh: a slow mutation for the previous project
+    // must not flip busy/error state on the project now displayed (its
+    // follow-up refresh is already id-bound and commits nothing).
+    const pid = project?.id
     setBusy(true)
     setError(null)
     try {
       await fn()
       await refresh()
     } catch (err) {
-      setError(err.message)
+      if (projectIdRef.current === pid) setError(err.message)
     } finally {
-      setBusy(false)
+      if (projectIdRef.current === pid) setBusy(false)
     }
-  }, [refresh])
+  }, [project?.id, refresh])
 
   const toggle = useCallback((path) => {
     setExpanded(prev => {

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -167,6 +167,36 @@ describe('ProjectPage stale-response guard', () => {
   })
 })
 
+describe('ProjectPage stale-mutation guard', () => {
+  it('a mutation finishing after a project switch cannot repopulate the page with old rows', async () => {
+    // Start a slow mkdir on project A, switch to B, then let A's mutation
+    // (and its follow-up refresh) resolve. The follow-up refresh claims a
+    // NEWER generation than B's fetch, so the generation guard alone would
+    // let it commit — the project-id binding must reject it.
+    const treeA = [{ name: 'a-only.txt', path: 'a-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    const treeB = [{ name: 'b-only.txt', path: 'b-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    mockTree.mockImplementation((pid) =>
+      Promise.resolve({ tree: pid === 'pa' ? treeA : treeB }))
+    let resolveMkdir
+    mockMkdir.mockImplementation(() => new Promise(res => { resolveMkdir = res }))
+    vi.spyOn(window, 'prompt').mockReturnValue('slow-dir')
+
+    const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
+    await screen.findByText('a-only.txt')
+    fireEvent.click(screen.getByText('New folder'))         // A's mutation, pending
+    await waitFor(() => expect(mockMkdir).toHaveBeenCalled())
+
+    rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
+    await screen.findByText('b-only.txt')
+
+    resolveMkdir({})                                        // A's run() resumes: refresh('pa')
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+    expect(screen.queryByText('a-only.txt')).toBeNull()
+    expect(screen.getByText('b-only.txt')).toBeTruthy()
+  })
+})
+
 describe('ProjectPage upload row visibility', () => {
   it('expands the target dir after uploading into it', async () => {
     await renderPage()

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -140,6 +140,33 @@ describe('ProjectPage file tree', () => {
   })
 })
 
+describe('ProjectPage stale-response guard', () => {
+  it('a slow tree response for the previous project never commits after switching', async () => {
+    // Project A's fetch is slow; the user switches to B; A resolves LAST.
+    // Without the generation guard, A's rows would render under B and row
+    // actions (closing over B's id) would target the wrong project.
+    let resolveA
+    const treeA = [{ name: 'a-only.txt', path: 'a-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    const treeB = [{ name: 'b-only.txt', path: 'b-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    mockTree.mockImplementation((pid) => {
+      if (pid === 'pa') return new Promise(res => { resolveA = res })
+      return Promise.resolve({ tree: treeB })
+    })
+
+    const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
+    await waitFor(() => expect(mockTree).toHaveBeenCalledWith('pa'))
+
+    rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
+    await screen.findByText('b-only.txt')
+
+    resolveA({ tree: treeA })
+    // Give the late resolution a tick to (incorrectly) commit.
+    await new Promise(r => setTimeout(r, 0))
+    expect(screen.queryByText('a-only.txt')).toBeNull()
+    expect(screen.getByText('b-only.txt')).toBeTruthy()
+  })
+})
+
 describe('ProjectPage upload row visibility', () => {
   it('expands the target dir after uploading into it', async () => {
     await renderPage()

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -197,6 +197,40 @@ describe('ProjectPage stale-mutation guard', () => {
   })
 })
 
+describe('ProjectPage stale-refresh generation theft', () => {
+  it('a stale mutation follow-up cannot invalidate the pending fetch of the current project', async () => {
+    // Ordering: A's mutation pending → switch to B (B's tree fetch stays
+    // pending) → A's mutation resolves and its follow-up refresh runs →
+    // THEN B's fetch resolves. The stale refresh must not claim a newer
+    // generation, or B's own result would be rejected and the page would
+    // strand on the empty state.
+    const treeA = [{ name: 'a-only.txt', path: 'a-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    const treeB = [{ name: 'b-only.txt', path: 'b-only.txt', type: 'file', size: 1, modified_at: 1 }]
+    let resolveB
+    mockTree.mockImplementation((pid) => {
+      if (pid === 'pb') return new Promise(res => { resolveB = res })
+      return Promise.resolve({ tree: treeA })
+    })
+    let resolveMkdir
+    mockMkdir.mockImplementation(() => new Promise(res => { resolveMkdir = res }))
+    vi.spyOn(window, 'prompt').mockReturnValue('slow-dir')
+
+    const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
+    await screen.findByText('a-only.txt')
+    fireEvent.click(screen.getByText('New folder'))          // A's mutation, pending
+    await waitFor(() => expect(mockMkdir).toHaveBeenCalled())
+
+    rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
+    await waitFor(() => expect(resolveB).toBeTruthy())       // B's fetch in flight
+
+    resolveMkdir({})                                         // stale A follow-up refresh runs first
+    await new Promise(r => setTimeout(r, 0))
+    resolveB({ tree: treeB })                                // B resolves LAST
+    expect(await screen.findByText('b-only.txt')).toBeTruthy()
+    expect(screen.queryByText('a-only.txt')).toBeNull()
+  })
+})
+
 describe('ProjectPage upload row visibility', () => {
   it('expands the target dir after uploading into it', async () => {
     await renderPage()

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react'
+import ProjectPage from './ProjectPage'
+
+const { mockTree, mockUpload, mockMkdir, mockMove, mockDelete } = vi.hoisted(() => ({
+  mockTree: vi.fn(),
+  mockUpload: vi.fn(),
+  mockMkdir: vi.fn(),
+  mockMove: vi.fn(),
+  mockDelete: vi.fn(),
+}))
+vi.mock('../../services/chat', () => ({
+  getProjectFilesTree: (...a) => mockTree(...a),
+  uploadProjectFile: (...a) => mockUpload(...a),
+  mkdirProjectPath: (...a) => mockMkdir(...a),
+  moveProjectPath: (...a) => mockMove(...a),
+  deleteProjectPath: (...a) => mockDelete(...a),
+  downloadProjectFile: vi.fn(),
+}))
+
+const project = { id: 'p1', name: 'Research', description: 'notes & data' }
+
+const TREE = [
+  {
+    name: 'docs', path: 'docs', type: 'dir', modified_at: 1, children: [
+      { name: 'a.txt', path: 'docs/a.txt', type: 'file', size: 5, modified_at: 1 },
+    ],
+  },
+  { name: 'readme.md', path: 'readme.md', type: 'file', size: 12, modified_at: 1 },
+]
+
+beforeEach(() => {
+  mockTree.mockReset().mockResolvedValue({ tree: TREE })
+  mockUpload.mockReset().mockResolvedValue({})
+  mockMkdir.mockReset().mockResolvedValue({})
+  mockMove.mockReset().mockResolvedValue({})
+  mockDelete.mockReset().mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+async function renderPage() {
+  render(<ProjectPage project={project} />)
+  await waitFor(() => expect(mockTree).toHaveBeenCalledWith('p1'))
+  await screen.findByText('readme.md')
+}
+
+describe('ProjectPage file tree', () => {
+  it('renders header, root entries, and dir contents after expand', async () => {
+    await renderPage()
+    expect(screen.getByText('Research')).toBeTruthy()
+    expect(screen.getByText('notes & data')).toBeTruthy()
+    expect(screen.getByText('docs')).toBeTruthy()
+    // Children hidden until the dir is expanded.
+    expect(screen.queryByText('a.txt')).toBeNull()
+    fireEvent.click(screen.getByTestId('file-row-docs'))
+    expect(screen.getByText('a.txt')).toBeTruthy()
+  })
+
+  it('renders a "Project not found" state without a project', () => {
+    render(<ProjectPage project={null} />)
+    expect(screen.getByText('Project not found')).toBeTruthy()
+    expect(mockTree).not.toHaveBeenCalled()
+  })
+
+  it('creates a folder at root via prompt and refreshes', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('new-folder')
+    fireEvent.click(screen.getByText('New folder'))
+    await waitFor(() => expect(mockMkdir).toHaveBeenCalledWith('p1', 'new-folder'))
+    expect(mockTree).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a subfolder inside a dir from its hover action', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('sub')
+    fireEvent.click(screen.getByLabelText('New subfolder in docs'))
+    await waitFor(() => expect(mockMkdir).toHaveBeenCalledWith('p1', 'docs/sub'))
+  })
+
+  it('uploads picked files into the chosen directory', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByLabelText('Upload into docs'))
+    const file = new File(['hello'], 'up.txt', { type: 'text/plain' })
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledWith('p1', file, { dir: 'docs' }))
+    expect(mockTree).toHaveBeenCalledTimes(2)
+  })
+
+  it('offers overwrite when the upload conflicts', async () => {
+    mockUpload
+      .mockRejectedValueOnce(new Error('file already exists'))
+      .mockResolvedValueOnce({})
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await renderPage()
+    fireEvent.click(screen.getByText('Upload files'))
+    const file = new File(['x'], 'readme.md', { type: 'text/plain' })
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(2))
+    expect(mockUpload).toHaveBeenLastCalledWith('p1', file, { dir: '', overwrite: true })
+  })
+
+  it('renames via prompt with the current path prefilled', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('README.md')
+    fireEvent.click(screen.getByLabelText('Rename readme.md'))
+    expect(window.prompt).toHaveBeenCalledWith(expect.any(String), 'readme.md')
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'readme.md', 'README.md'))
+  })
+
+  it('deletes after confirmation', async () => {
+    await renderPage()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.click(screen.getByLabelText('Delete readme.md'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('p1', 'readme.md'))
+  })
+
+  it('does not delete when confirmation is declined', async () => {
+    await renderPage()
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getByLabelText('Delete readme.md'))
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('surfaces API errors', async () => {
+    await renderPage()
+    mockMkdir.mockRejectedValue(new Error('path escapes project root'))
+    vi.spyOn(window, 'prompt').mockReturnValue('../evil')
+    fireEvent.click(screen.getByText('New folder'))
+    expect(await screen.findByText('path escapes project root')).toBeTruthy()
+  })
+
+  it('shows the empty state when the project has no files', async () => {
+    mockTree.mockResolvedValue({ tree: [] })
+    render(<ProjectPage project={project} />)
+    expect(await screen.findByText(/No files yet/)).toBeTruthy()
+  })
+})
+
+describe('ProjectPage upload row visibility', () => {
+  it('expands the target dir after uploading into it', async () => {
+    await renderPage()
+    fireEvent.click(within(screen.getByTestId('file-row-docs')).getByLabelText('Upload into docs'))
+    const file = new File(['hello'], 'up.txt', { type: 'text/plain' })
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalled())
+    // docs auto-expanded → its child is visible.
+    expect(await screen.findByText('a.txt')).toBeTruthy()
+  })
+})

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -1,4 +1,4 @@
-import { fetchAPI } from '../api'
+import { fetchAPI, API_BASE, getToken } from '../api'
 
 export async function createConversation(data) {
   return fetchAPI('/chat/conversations', {
@@ -59,6 +59,71 @@ export async function deleteProject(id) {
   return fetchAPI(`/chat/projects/${id}`, {
     method: 'DELETE',
   })
+}
+
+// -- Project files --
+
+export async function getProjectFilesTree(projectId) {
+  return fetchAPI(`/chat/projects/${projectId}/files`)
+}
+
+// Multipart upload — bypasses fetchAPI because Content-Type must be set by
+// the browser (multipart boundary), not forced to application/json.
+export async function uploadProjectFile(projectId, file, { dir = '', overwrite = false } = {}) {
+  const token = getToken()
+  if (!token) throw new Error('Not authenticated')
+  const form = new FormData()
+  form.append('file', file)
+  form.append('dir', dir)
+  if (overwrite) form.append('overwrite', 'true')
+  const response = await fetch(`${API_BASE}/chat/projects/${projectId}/files/upload`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}` },
+    body: form,
+  })
+  if (!response.ok) {
+    let msg = `HTTP ${response.status}`
+    try { msg = (await response.json()).error || msg } catch { /* not JSON */ }
+    throw new Error(msg)
+  }
+  return response.json()
+}
+
+export async function mkdirProjectPath(projectId, path) {
+  return fetchAPI(`/chat/projects/${projectId}/files/mkdir`, {
+    method: 'POST',
+    body: JSON.stringify({ path }),
+  })
+}
+
+export async function moveProjectPath(projectId, path, newPath) {
+  return fetchAPI(`/chat/projects/${projectId}/files/move`, {
+    method: 'POST',
+    body: JSON.stringify({ path, new_path: newPath }),
+  })
+}
+
+export async function deleteProjectPath(projectId, path) {
+  return fetchAPI(`/chat/projects/${projectId}/files?path=${encodeURIComponent(path)}`, {
+    method: 'DELETE',
+  })
+}
+
+// Fetches the file with auth and hands back a blob URL the caller must
+// revoke after use (a plain <a href> can't carry the bearer token).
+export async function downloadProjectFile(projectId, path) {
+  const token = getToken()
+  if (!token) throw new Error('Not authenticated')
+  const response = await fetch(
+    `${API_BASE}/chat/projects/${projectId}/files/download?path=${encodeURIComponent(path)}`,
+    { headers: { 'Authorization': `Bearer ${token}` } },
+  )
+  if (!response.ok) {
+    let msg = `HTTP ${response.status}`
+    try { msg = (await response.json()).error || msg } catch { /* not JSON */ }
+    throw new Error(msg)
+  }
+  return URL.createObjectURL(await response.blob())
 }
 
 export async function requestCritique(messageId, { contextWindow = 10, extraInstructions = '' } = {}) {

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -403,6 +403,60 @@ def test_mutating_op_racing_project_delete_cleans_up(client, tmp_path, monkeypat
     assert not files_dir.exists()
 
 
+def test_upload_multibyte_name_over_255_bytes_400(client):
+    """255 characters of emoji is ~4x the filesystem's 255-BYTE component
+    cap — must be a validation 400, not an ENAMETOOLONG 500."""
+    pid = _mkproject(client)
+    name = "😀" * 100  # 100 chars, 400 UTF-8 bytes
+    r = _upload(client, pid, name, b"x")
+    assert r.status_code == 400
+
+
+def test_total_path_over_path_max_400(client):
+    """Within the depth cap, components can still sum past PATH_MAX —
+    the ENAMETOOLONG from the syscall maps to a 400."""
+    pid = _mkproject(client)
+    deep = "/".join(["x" * 250] * 17)  # ~4.2 KB > PATH_MAX (4096)
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": deep},
+                    headers=_auth())
+    assert r.status_code == 400
+
+
+def test_mkdir_through_regular_file_400(client):
+    """mkdir with an intermediate component that is a regular file is
+    ordinary bad input: 400, not NotADirectoryError → 500."""
+    pid = _mkproject(client)
+    assert _upload(client, pid, "parent", b"x").status_code == 201
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir",
+                    json={"path": "parent/child"}, headers=_auth())
+    assert r.status_code == 400
+    # Upload into the file-as-dir path gets the same treatment.
+    r = _upload(client, pid, "f.txt", b"x", dir="parent")
+    assert r.status_code == 404  # save_stream's isdir pre-check
+
+
+def test_project_delete_aborts_when_files_cleanup_fails(client, tmp_path, monkeypatch):
+    """A failed files cleanup must not claim success: the DB row survives
+    so the delete can be retried once the filesystem problem is fixed."""
+    import shutil as _shutil
+
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt")
+
+    def failing_rmtree(path, *a, **kw):
+        raise PermissionError(13, "Permission denied", str(path))
+
+    monkeypatch.setattr(_shutil, "rmtree", failing_rmtree)
+    r = client.delete(f"{PROJECTS_PATH}/{pid}", headers=_auth())
+    assert r.status_code == 500
+    monkeypatch.undo()
+
+    # Row survived → retry succeeds and removes everything.
+    r = client.delete(f"{PROJECTS_PATH}/{pid}", headers=_auth())
+    assert r.status_code == 200
+    assert not (tmp_path / "storage" / pid).exists()
+
+
 def test_project_delete_removes_files_dir(client, tmp_path):
     pid = _mkproject(client)
     _upload(client, pid, "a.txt")

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -422,6 +422,20 @@ def test_total_path_over_path_max_400(client):
     assert r.status_code == 400
 
 
+def test_lone_surrogate_path_400(client):
+    """JSON delivers escaped lone surrogates that are not UTF-8-encodable;
+    validation must 400, not UnicodeEncodeError → 500."""
+    pid = _mkproject(client)
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir",
+                    data='{"path": "\\ud800"}', headers=_auth(),
+                    content_type="application/json")
+    assert r.status_code == 400
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/move",
+                    data='{"path": "\\ud800", "new_path": "x"}', headers=_auth(),
+                    content_type="application/json")
+    assert r.status_code == 400
+
+
 def test_mkdir_through_regular_file_400(client):
     """mkdir with an intermediate component that is a regular file is
     ordinary bad input: 400, not NotADirectoryError → 500."""

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -220,6 +220,28 @@ class TestOps:
             pf.delete(made_root, "nope")
         assert e.value.status == 404
 
+    def test_dangling_symlink_is_a_first_class_entry(self, made_root):
+        """A broken symlink is an ordinary tree entry: renamable, occupying
+        its name for mkdir and as a move destination (exists() would follow
+        the link and misreport the slot as free)."""
+        os.symlink("no-such-target", os.path.join(made_root, "broken"))
+
+        # mkdir at its path: 409, not FileExistsError → 500.
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.mkdir(made_root, "broken")
+        assert e.value.status == 409
+
+        # It can't be silently replaced as a move destination.
+        pf.save_stream(made_root, "", "f.txt", io.BytesIO(b"x"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.move(made_root, "f.txt", "broken")
+        assert e.value.status == 409
+
+        # And it is itself movable (the link, not its target).
+        node = pf.move(made_root, "broken", "renamed-link")
+        assert node["path"] == "renamed-link"
+        assert os.path.islink(os.path.join(made_root, "renamed-link"))
+
     def test_symlink_listed_as_file_never_followed(self, made_root, tmp_path):
         outside = tmp_path / "out"
         outside.mkdir()

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -1,0 +1,305 @@
+"""Tests for project files: the path-safe filesystem layer and its HTTP
+surface. Path traversal and symlink-escape rejection are the critical
+properties here — every route funnels through project_files.resolve().
+"""
+import io
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-project-files")
+
+from chat import project_files as pf
+from chat.db import ChatDB
+from chat.routes import chat_bp
+
+TOKEN = "test-token-project-files"
+PROJECTS_PATH = "/api/chat/projects"
+
+
+# ---------------------------------------------------------------------------
+# Pure filesystem layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def root(tmp_path):
+    return str(tmp_path / "proj")
+
+
+@pytest.fixture
+def made_root(root):
+    os.makedirs(root)
+    return root
+
+
+class TestResolve:
+    def test_resolves_inside_root(self, made_root):
+        assert pf.resolve(made_root, "a/b.txt") == os.path.join(made_root, "a", "b.txt")
+
+    def test_empty_path_is_root(self, made_root):
+        assert pf.resolve(made_root, "") == made_root
+
+    @pytest.mark.parametrize("bad", [
+        "../x", "a/../../x", "..", "a/..", "./x", "a//b", "a/./b",
+        "a\\b", "a\x00b",
+    ])
+    def test_rejects_traversal_components(self, made_root, bad):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, bad)
+
+    def test_rejects_non_string(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, None)
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, ["a"])
+
+    def test_rejects_symlink_escape(self, made_root, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("s")
+        os.symlink(str(outside), os.path.join(made_root, "link"))
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, "link/secret.txt")
+
+    def test_rejects_symlink_escape_for_nonexistent_target(self, made_root, tmp_path):
+        outside = tmp_path / "outside2"
+        outside.mkdir()
+        os.symlink(str(outside), os.path.join(made_root, "link"))
+        # Target doesn't exist yet — the nearest existing ancestor is the
+        # escaping symlink, which must still be rejected (upload path).
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, "link/new.txt")
+
+    def test_component_too_long(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, "x" * 256)
+
+
+class TestOps:
+    def test_mkdir_and_tree(self, made_root):
+        pf.mkdir(made_root, "docs")
+        pf.mkdir(made_root, "docs/notes")
+        with open(os.path.join(made_root, "docs", "a.txt"), "w") as f:
+            f.write("hello")
+        tree = pf.build_tree(made_root)
+        assert [n["name"] for n in tree] == ["docs"]
+        docs = tree[0]
+        assert docs["type"] == "dir"
+        assert [n["name"] for n in docs["children"]] == ["notes", "a.txt"]  # dirs first
+        a = docs["children"][1]
+        assert a["type"] == "file" and a["size"] == 5 and a["path"] == "docs/a.txt"
+
+    def test_mkdir_existing_409(self, made_root):
+        pf.mkdir(made_root, "d")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.mkdir(made_root, "d")
+        assert e.value.status == 409
+
+    def test_mkdir_empty_path_rejected(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.mkdir(made_root, "")
+
+    def test_save_stream_and_overwrite_semantics(self, made_root):
+        node = pf.save_stream(made_root, "", "f.txt", io.BytesIO(b"one"))
+        assert node["size"] == 3
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.save_stream(made_root, "", "f.txt", io.BytesIO(b"two"))
+        assert e.value.status == 409
+        node = pf.save_stream(made_root, "", "f.txt", io.BytesIO(b"twoo"), overwrite=True)
+        assert node["size"] == 4
+
+    def test_save_stream_missing_dir_404(self, made_root):
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.save_stream(made_root, "nope", "f.txt", io.BytesIO(b"x"))
+        assert e.value.status == 404
+
+    def test_save_stream_size_cap(self, made_root, monkeypatch):
+        monkeypatch.setattr(pf, "MAX_UPLOAD_BYTES", 10)
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.save_stream(made_root, "", "big.bin", io.BytesIO(b"x" * 11))
+        assert e.value.status == 413
+        # Nothing left behind — neither the file nor the temp.
+        assert os.listdir(made_root) == []
+
+    def test_move_and_conflicts(self, made_root):
+        pf.mkdir(made_root, "a")
+        pf.save_stream(made_root, "a", "f.txt", io.BytesIO(b"x"))
+        node = pf.move(made_root, "a/f.txt", "a/g.txt")
+        assert node["path"] == "a/g.txt"
+        pf.save_stream(made_root, "a", "f.txt", io.BytesIO(b"y"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.move(made_root, "a/f.txt", "a/g.txt")
+        assert e.value.status == 409
+
+    def test_move_dir_into_itself_rejected(self, made_root):
+        pf.mkdir(made_root, "a")
+        with pytest.raises(pf.ProjectFilesError):
+            pf.move(made_root, "a", "a/b")
+
+    def test_move_source_missing_404(self, made_root):
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.move(made_root, "nope.txt", "x.txt")
+        assert e.value.status == 404
+
+    def test_delete_file_and_dir(self, made_root):
+        pf.mkdir(made_root, "d")
+        pf.save_stream(made_root, "d", "f.txt", io.BytesIO(b"x"))
+        pf.delete(made_root, "d/f.txt")
+        assert os.listdir(os.path.join(made_root, "d")) == []
+        pf.save_stream(made_root, "d", "g.txt", io.BytesIO(b"x"))
+        pf.delete(made_root, "d")  # recursive
+        assert os.listdir(made_root) == []
+
+    def test_delete_root_rejected(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.delete(made_root, "")
+
+    def test_delete_missing_404(self, made_root):
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.delete(made_root, "nope")
+        assert e.value.status == 404
+
+    def test_symlink_listed_as_file_never_followed(self, made_root, tmp_path):
+        outside = tmp_path / "out"
+        outside.mkdir()
+        (outside / "x.txt").write_text("x")
+        os.symlink(str(outside), os.path.join(made_root, "link"))
+        tree = pf.build_tree(made_root)
+        assert tree[0]["name"] == "link"
+        assert tree[0]["type"] == "file"  # not recursed into
+        assert "children" not in tree[0]
+
+
+# ---------------------------------------------------------------------------
+# HTTP surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(tmp_path):
+    app = Flask(__name__)
+    app.config["DASHBOARD_TOKEN"] = TOKEN
+    app.config["CHAT_DB"] = ChatDB(":memory:")
+    app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
+    app.register_blueprint(chat_bp)
+    app.testing = True
+    return app.test_client()
+
+
+def _auth():
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _mkproject(client, name="P"):
+    r = client.post(PROJECTS_PATH, json={"name": name}, headers=_auth())
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _upload(client, pid, name, content=b"data", dir="", **form):
+    return client.post(
+        f"{PROJECTS_PATH}/{pid}/files/upload",
+        data={"file": (io.BytesIO(content), name), "dir": dir, **form},
+        headers=_auth(),
+        content_type="multipart/form-data",
+    )
+
+
+def test_files_require_auth(client):
+    pid = _mkproject(client)
+    assert client.get(f"{PROJECTS_PATH}/{pid}/files").status_code == 401
+    assert client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": "x"}).status_code == 401
+    assert client.delete(f"{PROJECTS_PATH}/{pid}/files?path=x").status_code == 401
+
+
+def test_files_unknown_project_404(client):
+    r = client.get(f"{PROJECTS_PATH}/nope/files", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_upload_tree_download_roundtrip(client):
+    pid = _mkproject(client)
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": "docs"}, headers=_auth())
+    assert r.status_code == 201
+    r = _upload(client, pid, "a.txt", b"hello", dir="docs")
+    assert r.status_code == 201
+    assert r.get_json()["path"] == "docs/a.txt"
+
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files", headers=_auth())
+    tree = r.get_json()["tree"]
+    assert tree[0]["name"] == "docs"
+    assert tree[0]["children"][0]["name"] == "a.txt"
+
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/download?path=docs/a.txt", headers=_auth())
+    assert r.status_code == 200
+    assert r.data == b"hello"
+
+
+def test_upload_duplicate_409_then_overwrite(client):
+    pid = _mkproject(client)
+    assert _upload(client, pid, "f.txt", b"one").status_code == 201
+    assert _upload(client, pid, "f.txt", b"two").status_code == 409
+    assert _upload(client, pid, "f.txt", b"two", overwrite="true").status_code == 201
+
+
+def test_upload_missing_file_field_400(client):
+    pid = _mkproject(client)
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/upload", data={},
+                    headers=_auth(), content_type="multipart/form-data")
+    assert r.status_code == 400
+
+
+def test_traversal_rejected_on_all_routes(client):
+    pid = _mkproject(client)
+    bad = "../../etc/passwd"
+    assert client.get(f"{PROJECTS_PATH}/{pid}/files/download?path={bad}",
+                      headers=_auth()).status_code == 400
+    assert client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": bad},
+                       headers=_auth()).status_code == 400
+    assert client.post(f"{PROJECTS_PATH}/{pid}/files/move",
+                       json={"path": bad, "new_path": "x"},
+                       headers=_auth()).status_code == 400
+    assert client.delete(f"{PROJECTS_PATH}/{pid}/files?path={bad}",
+                         headers=_auth()).status_code == 400
+    r = _upload(client, pid, "f.txt", b"x", dir=bad)
+    assert r.status_code == 400
+
+
+def test_download_of_directory_400(client):
+    pid = _mkproject(client)
+    client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": "d"}, headers=_auth())
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/download?path=d", headers=_auth())
+    assert r.status_code == 400
+
+
+def test_move_via_http(client):
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt")
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/move",
+                    json={"path": "a.txt", "new_path": "b.txt"}, headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["path"] == "b.txt"
+
+
+def test_delete_via_http(client):
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt")
+    r = client.delete(f"{PROJECTS_PATH}/{pid}/files?path=a.txt", headers=_auth())
+    assert r.status_code == 200
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files", headers=_auth())
+    assert r.get_json()["tree"] == []
+
+
+def test_project_delete_removes_files_dir(client, tmp_path):
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt")
+    files_dir = tmp_path / "storage" / pid
+    assert files_dir.exists()
+    r = client.delete(f"{PROJECTS_PATH}/{pid}", headers=_auth())
+    assert r.status_code == 200
+    assert not files_dir.exists()

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -126,6 +126,37 @@ class TestOps:
         # Nothing left behind — neither the file nor the temp.
         assert os.listdir(made_root) == []
 
+    def test_upload_never_clobbers_dot_uploading_user_file(self, made_root):
+        """Regression: a deterministic '<target>.uploading' staging name
+        would open-truncate a legitimate user file of that name."""
+        pf.save_stream(made_root, "", "report.uploading", io.BytesIO(b"user data"))
+        pf.save_stream(made_root, "", "report", io.BytesIO(b"new"))
+        with open(os.path.join(made_root, "report.uploading"), "rb") as f:
+            assert f.read() == b"user data"
+        with open(os.path.join(made_root, "report"), "rb") as f:
+            assert f.read() == b"new"
+
+    def test_no_overwrite_publication_is_atomic(self, made_root, monkeypatch):
+        """The 409 contract holds even when the target appears AFTER the
+        pre-check (concurrent upload of the same name): the final link()
+        is no-replace, so the existing file survives untouched."""
+        real_mkstemp = pf.tempfile.mkstemp
+
+        def racing_mkstemp(*args, **kwargs):
+            # The competing upload wins between pre-check and publication.
+            with open(os.path.join(made_root, "f.txt"), "wb") as f:
+                f.write(b"winner")
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr(pf.tempfile, "mkstemp", racing_mkstemp)
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.save_stream(made_root, "", "f.txt", io.BytesIO(b"loser"))
+        assert e.value.status == 409
+        with open(os.path.join(made_root, "f.txt"), "rb") as f:
+            assert f.read() == b"winner"
+        # No stray temp files left behind.
+        assert os.listdir(made_root) == ["f.txt"]
+
     def test_move_and_conflicts(self, made_root):
         pf.mkdir(made_root, "a")
         pf.save_stream(made_root, "a", "f.txt", io.BytesIO(b"x"))
@@ -293,6 +324,58 @@ def test_delete_via_http(client):
     assert r.status_code == 200
     r = client.get(f"{PROJECTS_PATH}/{pid}/files", headers=_auth())
     assert r.get_json()["tree"] == []
+
+
+def test_upload_oversized_request_rejected_before_parsing(client, monkeypatch):
+    """HTTP-level 413: the Content-Length check runs BEFORE request.files
+    is touched, so an oversized body is refused without multipart parsing."""
+    monkeypatch.setattr(pf, "MAX_UPLOAD_BYTES", 10)
+    pid = _mkproject(client)
+    r = _upload(client, pid, "big.bin", b"x" * 1000)
+    assert r.status_code == 413
+
+
+def test_tree_get_does_not_create_project_dir(client, tmp_path):
+    """Read-only routes must never (re)create the files directory — a GET
+    racing a project delete would otherwise leave an orphan dir."""
+    pid = _mkproject(client)
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["tree"] == []
+    assert not (tmp_path / "storage" / pid).exists()
+
+
+def test_mutating_op_racing_project_delete_cleans_up(client, tmp_path, monkeypatch):
+    """A mutating file op that races a project delete must not leave an
+    orphan directory: the commit-point revalidation notices the row is
+    gone, removes the directory it recreated, and returns 404.
+
+    NOTE: patch the module-level `pf` imported at the top of THIS file —
+    it is the same module object the blueprint's route functions closed
+    over. Re-importing chat.project_files_routes here would grab a fresh
+    module copy when another test file (test_mcp_admin_routes) has purged
+    chat.* from sys.modules, and the patch would miss the routes.
+    """
+    pid = _mkproject(client)
+    files_dir = tmp_path / "storage" / pid
+
+    real_mkdir = pf.mkdir
+    state = {"deleted": False}
+
+    def racing_mkdir(root, rel_path):
+        node = real_mkdir(root, rel_path)
+        if not state["deleted"]:
+            state["deleted"] = True
+            # The concurrent project delete wins mid-operation: row gone,
+            # directory rmtree'd — but our mkdir already recreated paths.
+            client.delete(f"{PROJECTS_PATH}/{pid}", headers=_auth())
+        return node
+
+    monkeypatch.setattr(pf, "mkdir", racing_mkdir)
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": "d"},
+                    headers=_auth())
+    assert r.status_code == 404
+    assert not files_dir.exists()
 
 
 def test_project_delete_removes_files_dir(client, tmp_path):

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -242,6 +242,26 @@ class TestOps:
         assert node["path"] == "renamed-link"
         assert os.path.islink(os.path.join(made_root, "renamed-link"))
 
+    def test_download_rejects_non_regular_files(self, made_root, tmp_path):
+        """stat_file only serves regular files: symlinks are never followed
+        (even in-root ones) and FIFOs would block the worker forever."""
+        (tmp_path / "target.txt").write_text("outside")
+        os.symlink(str(tmp_path / "target.txt"), os.path.join(made_root, "link.txt"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.stat_file(made_root, "link.txt")
+        assert e.value.status == 400
+
+        os.mkfifo(os.path.join(made_root, "pipe"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.stat_file(made_root, "pipe")
+        assert e.value.status == 400
+
+        # Dangling symlink: still 400 (an entry, but not a regular file).
+        os.symlink("gone", os.path.join(made_root, "broken"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.stat_file(made_root, "broken")
+        assert e.value.status == 400
+
     def test_symlink_listed_as_file_never_followed(self, made_root, tmp_path):
         outside = tmp_path / "out"
         outside.mkdir()

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -79,6 +79,31 @@ class TestResolve:
         with pytest.raises(pf.ProjectFilesError):
             pf.resolve(made_root, "x" * 256)
 
+    def test_path_depth_cap(self, made_root):
+        ok = "/".join(["d"] * pf.MAX_PATH_DEPTH)
+        assert pf.resolve(made_root, ok)
+        too_deep = "/".join(["d"] * (pf.MAX_PATH_DEPTH + 1))
+        with pytest.raises(pf.ProjectFilesError):
+            pf.resolve(made_root, too_deep)
+        # mkdir creates missing parents, so it must respect the same cap.
+        with pytest.raises(pf.ProjectFilesError):
+            pf.mkdir(made_root, too_deep)
+
+
+def test_configure_max_content_length():
+    """Flask pre-seeds MAX_CONTENT_LENGTH=None, so a setdefault would be a
+    no-op — the helper must assign over None but preserve an explicit
+    deployment override."""
+    app = Flask(__name__)
+    assert app.config["MAX_CONTENT_LENGTH"] is None  # Flask default
+    pf.configure_max_content_length(app)
+    assert app.config["MAX_CONTENT_LENGTH"] == int(pf.MAX_UPLOAD_BYTES * 1.05)
+
+    app2 = Flask(__name__)
+    app2.config["MAX_CONTENT_LENGTH"] = 12345
+    pf.configure_max_content_length(app2)
+    assert app2.config["MAX_CONTENT_LENGTH"] == 12345
+
 
 class TestOps:
     def test_mkdir_and_tree(self, made_root):

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -326,6 +326,17 @@ def test_traversal_rejected_on_all_routes(client):
     assert r.status_code == 400
 
 
+def test_download_from_fresh_project_is_404_not_traversal(client):
+    """Before any mutation the project root doesn't exist on disk; a
+    download of a missing file must be an ordinary 404, not a
+    'path escapes project root' 400."""
+    pid = _mkproject(client)
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/download?path=missing.txt",
+                   headers=_auth())
+    assert r.status_code == 404
+    assert r.get_json()["error"] == "file not found"
+
+
 def test_download_of_directory_400(client):
     pid = _mkproject(client)
     client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir", json={"path": "d"}, headers=_auth())


### PR DESCRIPTION
Phase 2 of the projects feature: each project owns a real directory tree on disk, browsable and manageable from the dashboard.

## What's in
- **Filesystem layer** (`chat/project_files.py`): the filesystem is the source of truth — no files table. All operations funnel through `resolve()`: per-component validation (no `..`/`.`/empty/backslash/NUL, 255-char cap) plus a realpath containment check against the nearest *existing* ancestor, so both `../` traversal and symlinks planted inside the tree are rejected — including for upload targets that don't exist yet. Symlinks are listed as files and never followed (no cycle risk, no escape).
- **API** under `/api/chat/projects/<id>/files`: GET tree, multipart upload (100 MB cap, streamed to a temp file then atomically renamed, 409 unless `overwrite`), download, mkdir, move/rename (409 on existing destination, refuses dir-into-itself), recursive delete. Storage root defaults to `dashboard/project_files/<project_id>` (gitignored); override via `PROJECT_FILES_DIR` app config or `LLM_DOCK_PROJECT_FILES_DIR`.
- **Delete semantics**: deleting a project removes its files directory (conversations still survive, as in phase 1).
- **UI**: new project page at `/chat/project/<id>` (sidebar layout preserved) — file tree with expand/collapse, upload to root or into any folder, new folder/subfolder, rename/move, download (auth-carrying blob fetch), delete with confirm. Project headers in the sidebar get an open-project button and an active highlight.

## Tests
- `dashboard/tests/test_project_files.py` — 38 tests: resolve()-level traversal + symlink-escape rejection (existing and non-existing targets), all ops incl. size-cap cleanup, HTTP surface incl. traversal on every route, project-delete cleanup. Full backend: 445 passed.
- `ProjectPage.test.jsx` — 12 tests (tree render, mkdir, upload + overwrite-conflict flow, rename, delete confirm, error surfacing). Full frontend: 170 passed, build OK.

## Next phases
- Phase 3: in-browser text editor for project files
- Phase 4: `project-files` MCP server scoped to the conversation's project