### PR TITLE
feat(chat): lightweight text editor for project files (phase 3)

### DIFF
--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -13,6 +13,7 @@ project root.
 """
 import errno
 import os
+import stat as stat_mod
 import shutil
 import logging
 import tempfile
@@ -27,6 +28,9 @@ MAX_NAME_LENGTH = 255
 # Path depth cap: keeps recursive tree walks and rmtree far away from
 # Python's recursion limit no matter what gets created through the API.
 MAX_PATH_DEPTH = 32
+# Editor cap — the in-browser editor is for notes/configs/snippets, not
+# for logs; a textarea with more than this is unusable anyway.
+MAX_TEXT_EDIT_BYTES = 2 * 1024 * 1024  # 2 MB
 
 
 def configure_max_content_length(app):
@@ -218,7 +222,6 @@ def stat_file(root: str, rel_path: str) -> str:
     FIFOs/sockets/devices are rejected rather than handed to send_file —
     opening a FIFO would block the worker indefinitely). Returns the
     absolute path (for send_file)."""
-    import stat as stat_mod
     abs_path = resolve(root, rel_path)
     try:
         st = os.lstat(abs_path)
@@ -277,6 +280,79 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
     return _node(abs_target, rel_target)
+
+
+def read_text(root: str, rel_path: str) -> dict:
+    """Read a regular file as UTF-8 text for the editor. Rejects
+    non-regular files (via stat_file), oversized files, and binary
+    content (NUL byte or invalid UTF-8)."""
+    abs_path = stat_file(root, rel_path)
+    st = os.lstat(abs_path)
+    if st.st_size > MAX_TEXT_EDIT_BYTES:
+        raise ProjectFilesError("file too large to edit", status=413)
+    with open(abs_path, "rb") as f:
+        data = f.read()
+    if b"\x00" in data:
+        raise ProjectFilesError("not a text file", status=400)
+    try:
+        content = data.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ProjectFilesError("not a text file (not valid UTF-8)", status=400)
+    return {
+        "path": "/".join(split_rel_path(rel_path)),
+        "content": content,
+        "size": st.st_size,
+        "modified_at": int(st.st_mtime),
+    }
+
+
+def write_text(root: str, rel_path: str, content: str,
+               base_modified_at: int = None) -> dict:
+    """Write UTF-8 text to a file (create or overwrite), atomically via a
+    temp file in the same directory. The target's parent must exist and
+    the target itself must be absent or a regular file — symlinks and
+    special files are never written through or replaced.
+
+    base_modified_at (optional) is the mtime the client loaded: if the
+    file changed on disk since, the save is rejected with 409 so an edit
+    from another tab/editor isn't silently overwritten.
+    """
+    parts = split_rel_path(rel_path)
+    if not parts:
+        raise ProjectFilesError("path is required")
+    if not isinstance(content, str):
+        raise ProjectFilesError("content must be a string")
+    try:
+        encoded = content.encode("utf-8")
+    except UnicodeEncodeError:
+        raise ProjectFilesError("content is not valid unicode")
+    if len(encoded) > MAX_TEXT_EDIT_BYTES:
+        raise ProjectFilesError("content too large", status=413)
+
+    abs_path = resolve(root, rel_path)
+    abs_dir = os.path.dirname(abs_path)
+    if not os.path.isdir(abs_dir):
+        raise ProjectFilesError("parent directory not found", status=404)
+    if os.path.lexists(abs_path):
+        st = os.lstat(abs_path)
+        if not stat_mod.S_ISREG(st.st_mode):
+            raise ProjectFilesError("not a regular file", status=409)
+        if base_modified_at is not None and int(st.st_mtime) != int(base_modified_at):
+            raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+    elif base_modified_at is not None:
+        # Client edited a file that has since been deleted/renamed.
+        raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+
+    with _fs_errors():
+        fd, tmp_path = tempfile.mkstemp(prefix=".edit-", suffix=".tmp", dir=abs_dir)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(encoded)
+            os.replace(tmp_path, abs_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+    return _node(abs_path, "/".join(parts))
 
 
 def mkdir(root: str, rel_path: str) -> dict:

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -317,7 +317,7 @@ def read_text(root: str, rel_path: str) -> dict:
 
 
 def write_text(root: str, rel_path: str, content: str,
-               base_revision: str = None) -> dict:
+               base_revision: str = None, create_only: bool = False) -> dict:
     """Write UTF-8 text to a file (create or overwrite), atomically via a
     temp file in the same directory. The target's parent must exist and
     the target itself must be absent or a regular file — symlinks and
@@ -327,6 +327,11 @@ def write_text(root: str, rel_path: str, content: str,
     (read_text's ``revision``, a content hash): if the file's bytes
     changed on disk since, the save is rejected with 409 so an edit from
     another tab/editor isn't silently overwritten.
+
+    create_only=True is the new-file precondition: the save is rejected
+    with 409 if the path already exists (the client believed it was
+    creating a file, but its tree snapshot was stale). Publication is an
+    atomic no-replace link, mirroring save_stream's upload contract.
     """
     parts = split_rel_path(rel_path)
     if not parts:
@@ -345,6 +350,8 @@ def write_text(root: str, rel_path: str, content: str,
     if not os.path.isdir(abs_dir):
         raise ProjectFilesError("parent directory not found", status=404)
     if os.path.lexists(abs_path):
+        if create_only:
+            raise ProjectFilesError("file already exists", status=409)
         st = os.lstat(abs_path)
         if not stat_mod.S_ISREG(st.st_mode):
             raise ProjectFilesError("not a regular file", status=409)
@@ -366,7 +373,14 @@ def write_text(root: str, rel_path: str, content: str,
         try:
             with os.fdopen(fd, "wb") as f:
                 f.write(encoded)
-            os.replace(tmp_path, abs_path)
+            if create_only:
+                # Atomic no-replace publication, same as upload's contract.
+                try:
+                    os.link(tmp_path, abs_path)
+                except FileExistsError:
+                    raise ProjectFilesError("file already exists", status=409)
+            else:
+                os.replace(tmp_path, abs_path)
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -12,6 +12,7 @@ component validation plus a realpath containment check, so neither
 project root.
 """
 import errno
+import hashlib
 import os
 import stat as stat_mod
 import shutil
@@ -282,6 +283,14 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
     return _node(abs_target, rel_target)
 
 
+def _content_revision(data: bytes) -> str:
+    """Opaque optimistic-concurrency token for the editor. Content-based:
+    mtime — even at nanosecond precision — is unreliable, because Linux
+    timestamps consecutive writes within one kernel timer tick
+    identically. A hash only matches when the bytes actually match."""
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
 def read_text(root: str, rel_path: str) -> dict:
     """Read a regular file as UTF-8 text for the editor. Rejects
     non-regular files (via stat_file), oversized files, and binary
@@ -303,19 +312,21 @@ def read_text(root: str, rel_path: str) -> dict:
         "content": content,
         "size": st.st_size,
         "modified_at": int(st.st_mtime),
+        "revision": _content_revision(data),
     }
 
 
 def write_text(root: str, rel_path: str, content: str,
-               base_modified_at: int = None) -> dict:
+               base_revision: str = None) -> dict:
     """Write UTF-8 text to a file (create or overwrite), atomically via a
     temp file in the same directory. The target's parent must exist and
     the target itself must be absent or a regular file — symlinks and
     special files are never written through or replaced.
 
-    base_modified_at (optional) is the mtime the client loaded: if the
-    file changed on disk since, the save is rejected with 409 so an edit
-    from another tab/editor isn't silently overwritten.
+    base_revision (optional) is the opaque revision the client loaded
+    (read_text's ``revision``, a content hash): if the file's bytes
+    changed on disk since, the save is rejected with 409 so an edit from
+    another tab/editor isn't silently overwritten.
     """
     parts = split_rel_path(rel_path)
     if not parts:
@@ -337,9 +348,16 @@ def write_text(root: str, rel_path: str, content: str,
         st = os.lstat(abs_path)
         if not stat_mod.S_ISREG(st.st_mode):
             raise ProjectFilesError("not a regular file", status=409)
-        if base_modified_at is not None and int(st.st_mtime) != int(base_modified_at):
-            raise ProjectFilesError("file changed on disk since it was loaded", status=409)
-    elif base_modified_at is not None:
+        if base_revision is not None:
+            # A file too large for read_text can't be what the client
+            # loaded — it definitely changed. Otherwise compare content.
+            if st.st_size > MAX_TEXT_EDIT_BYTES:
+                raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+            with open(abs_path, "rb") as f:
+                current = f.read()
+            if _content_revision(current) != base_revision:
+                raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+    elif base_revision is not None:
         # Client edited a file that has since been deleted/renamed.
         raise ProjectFilesError("file changed on disk since it was loaded", status=409)
 
@@ -352,7 +370,9 @@ def write_text(root: str, rel_path: str, content: str,
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
-    return _node(abs_path, "/".join(parts))
+    node = _node(abs_path, "/".join(parts))
+    node["revision"] = _content_revision(encoded)
+    return node
 
 
 def mkdir(root: str, rel_path: str) -> dict:

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -249,6 +249,14 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
         raise ProjectFilesError("a directory with that name exists", status=409)
     if os.path.exists(abs_target) and not overwrite:
         raise ProjectFilesError("file already exists", status=409)
+    # Same permission fidelity as write_text: mkstemp stages at 0600, so an
+    # overwriting upload must keep the target's mode and a fresh one gets
+    # a normal default instead of 0600.
+    publish_mode = 0o644
+    if overwrite and os.path.lexists(abs_target):
+        target_st = os.lstat(abs_target)
+        if stat_mod.S_ISREG(target_st.st_mode):
+            publish_mode = stat_mod.S_IMODE(target_st.st_mode)
 
     # Stage in a UNIQUE, exclusively-created temp file in the destination
     # directory (same filesystem → atomic publication). A deterministic
@@ -267,6 +275,7 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
                     if written > MAX_UPLOAD_BYTES:
                         raise ProjectFilesError("file too large", status=413)
                     f.write(chunk)
+            os.chmod(tmp_path, publish_mode)
             if overwrite:
                 os.replace(tmp_path, abs_target)
             else:
@@ -349,12 +358,16 @@ def write_text(root: str, rel_path: str, content: str,
     abs_dir = os.path.dirname(abs_path)
     if not os.path.isdir(abs_dir):
         raise ProjectFilesError("parent directory not found", status=404)
+    # mkstemp stages at 0600; without this an edit would silently strip the
+    # target's permission bits (e.g. a 0755 script losing its exec bit).
+    publish_mode = 0o644
     if os.path.lexists(abs_path):
         if create_only:
             raise ProjectFilesError("file already exists", status=409)
         st = os.lstat(abs_path)
         if not stat_mod.S_ISREG(st.st_mode):
             raise ProjectFilesError("not a regular file", status=409)
+        publish_mode = stat_mod.S_IMODE(st.st_mode)
         if base_revision is not None:
             # A file too large for read_text can't be what the client
             # loaded — it definitely changed. Otherwise compare content.
@@ -373,6 +386,7 @@ def write_text(root: str, rel_path: str, content: str,
         try:
             with os.fdopen(fd, "wb") as f:
                 f.write(encoded)
+            os.chmod(tmp_path, publish_mode)
             if create_only:
                 # Atomic no-replace publication, same as upload's contract.
                 try:

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -347,6 +347,10 @@ def write_text(root: str, rel_path: str, content: str,
         raise ProjectFilesError("path is required")
     if not isinstance(content, str):
         raise ProjectFilesError("content must be a string")
+    if "\x00" in content:
+        # read_text treats NUL as binary; accepting it here would create a
+        # file this editor then refuses to reopen.
+        raise ProjectFilesError("content must not contain NUL bytes")
     try:
         encoded = content.encode("utf-8")
     except UnicodeEncodeError:

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -141,7 +141,13 @@ def project_files_write_content(project_id):
     base = data.get("base_revision")
     if base is not None and not isinstance(base, str):
         return jsonify({"error": "base_revision must be a string"}), 400
-    node = pf.write_text(root, data.get("path"), data.get("content"), base_revision=base)
+    create_only = data.get("create_only", False)
+    if not isinstance(create_only, bool):
+        return jsonify({"error": "create_only must be a boolean"}), 400
+    if create_only and base is not None:
+        return jsonify({"error": "create_only and base_revision are mutually exclusive"}), 400
+    node = pf.write_text(root, data.get("path"), data.get("content"),
+                         base_revision=base, create_only=create_only)
     stale = _revalidate_or_cleanup(project_id)
     if stale:
         return stale

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -114,6 +114,41 @@ def project_files_download(project_id):
     return send_file(abs_path, as_attachment=True)
 
 
+@chat_bp.route("/api/chat/projects/<project_id>/files/content", methods=["GET"])
+@require_auth
+def project_files_read_content(project_id):
+    root, err = _project_root_or_404(project_id)
+    if err:
+        return err
+    rel_path = request.args.get("path", "")
+    # Same shape as download: validate first (traversal stays 400), then a
+    # not-yet-created root means the file is simply absent.
+    pf.split_rel_path(rel_path)
+    if not os.path.isdir(root):
+        return jsonify({"error": "file not found"}), 404
+    return jsonify(pf.read_text(root, rel_path))
+
+
+@chat_bp.route("/api/chat/projects/<project_id>/files/content", methods=["PUT"])
+@require_auth
+def project_files_write_content(project_id):
+    root, err = _project_root_or_404(project_id, create=True)
+    if err:
+        return err
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be {path, content, base_modified_at?}"}), 400
+    base = data.get("base_modified_at")
+    # bool is an int subclass in Python — reject it explicitly.
+    if base is not None and (isinstance(base, bool) or not isinstance(base, int)):
+        return jsonify({"error": "base_modified_at must be an integer"}), 400
+    node = pf.write_text(root, data.get("path"), data.get("content"), base_modified_at=base)
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
+    return jsonify(node)
+
+
 @chat_bp.route("/api/chat/projects/<project_id>/files/mkdir", methods=["POST"])
 @require_auth
 def project_files_mkdir(project_id):

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -137,12 +137,11 @@ def project_files_write_content(project_id):
         return err
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
-        return jsonify({"error": "body must be {path, content, base_modified_at?}"}), 400
-    base = data.get("base_modified_at")
-    # bool is an int subclass in Python — reject it explicitly.
-    if base is not None and (isinstance(base, bool) or not isinstance(base, int)):
-        return jsonify({"error": "base_modified_at must be an integer"}), 400
-    node = pf.write_text(root, data.get("path"), data.get("content"), base_modified_at=base)
+        return jsonify({"error": "body must be {path, content, base_revision?}"}), 400
+    base = data.get("base_revision")
+    if base is not None and not isinstance(base, str):
+        return jsonify({"error": "base_revision must be a string"}), 400
+    node = pf.write_text(root, data.get("path"), data.get("content"), base_revision=base)
     stale = _revalidate_or_cleanup(project_id)
     if stale:
         return stale

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -108,29 +108,43 @@ export default function ChatPage() {
     runningServices[0]?.name ||
     (openRouterModels[0] ? serviceNameForModel(openRouterModels[0].id) : null)
 
+  // True while the project file editor holds unsaved changes. In-app
+  // navigation unmounts the editor without its own close handler, so the
+  // navigation entry points below confirm before discarding. (Browser
+  // close/reload is guarded by the editor's beforeunload handler.)
+  const editorDirtyRef = useRef(false)
+  const confirmDiscardEdits = useCallback(() => {
+    if (!editorDirtyRef.current) return true
+    if (!window.confirm('Discard unsaved changes?')) return false
+    editorDirtyRef.current = false
+    return true
+  }, [])
+
   const handleCreate = useCallback(async () => {
     if (!defaultModelName) {
       window.alert('No model available. Start a local model or configure OpenRouter.')
       return
     }
+    if (!confirmDiscardEdits()) return
     const conv = await create({
       main_service: defaultModelName,
     })
     navigate(`/chat/${conv.id}`)
-  }, [create, navigate, defaultModelName])
+  }, [create, navigate, defaultModelName, confirmDiscardEdits])
 
   const handleCreateInProject = useCallback(async (projectId) => {
     if (!defaultModelName) {
       window.alert('No model available. Start a local model or configure OpenRouter.')
       return
     }
+    if (!confirmDiscardEdits()) return
     const conv = await create({
       main_service: defaultModelName,
       project_id: projectId,
     })
     await refreshProjects()
     navigate(`/chat/${conv.id}`)
-  }, [create, navigate, defaultModelName, refreshProjects])
+  }, [create, navigate, defaultModelName, refreshProjects, confirmDiscardEdits])
 
   const handleCreateProject = useCallback(async () => {
     const name = window.prompt('Project name')
@@ -165,12 +179,14 @@ export default function ChatPage() {
   }, [create, navigate, defaultModelName])
 
   const handleSelect = useCallback((id) => {
+    if (!confirmDiscardEdits()) return
     navigate(`/chat/${id}`)
-  }, [navigate])
+  }, [navigate, confirmDiscardEdits])
 
   const handleOpenProject = useCallback((id) => {
+    if (!confirmDiscardEdits()) return
     navigate(`/chat/project/${id}`)
-  }, [navigate])
+  }, [navigate, confirmDiscardEdits])
 
   // Deletes cascade to descendant spinoffs server-side. If the active
   // conversation is one of the deleted rows OR a descendant of any of
@@ -227,7 +243,10 @@ export default function ChatPage() {
         onMoveMany={handleMoveMany}
       />
       {projectId ? (
-        <ProjectPage project={projects.find(p => p.id === projectId) || null} />
+        <ProjectPage
+          project={projects.find(p => p.id === projectId) || null}
+          onEditorDirtyChange={(d) => { editorDirtyRef.current = d }}
+        />
       ) : (
       <ChatArea
         conversation={conversation}

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -20,13 +20,16 @@ vi.mock('../../hooks/useServicesSSE', () => ({
 }))
 
 const { mockGetConversation, mockListConversations, mockCancelActiveRun,
-        mockListProjects, mockDeleteConversation, mockDeleteConversations } = vi.hoisted(() => ({
+        mockListProjects, mockDeleteConversation, mockDeleteConversations,
+        mockFilesTree, mockGetFileContent } = vi.hoisted(() => ({
   mockGetConversation: vi.fn(),
   mockListConversations: vi.fn(),
   mockCancelActiveRun: vi.fn(),
   mockListProjects: vi.fn(),
   mockDeleteConversation: vi.fn(),
   mockDeleteConversations: vi.fn(),
+  mockFilesTree: vi.fn(),
+  mockGetFileContent: vi.fn(),
 }))
 vi.mock('../../services/chat', async (importActual) => ({
   ...(await importActual()),
@@ -36,6 +39,8 @@ vi.mock('../../services/chat', async (importActual) => ({
   listProjects: (...a) => mockListProjects(...a),
   deleteConversation: (...a) => mockDeleteConversation(...a),
   deleteConversations: (...a) => mockDeleteConversations(...a),
+  getProjectFilesTree: (...a) => mockFilesTree(...a),
+  getProjectFileContent: (...a) => mockGetFileContent(...a),
 }))
 
 // streamChat is never expected to fire here (no active run), but stub it to a
@@ -58,6 +63,10 @@ beforeEach(() => {
   mockDeleteConversation.mockResolvedValue({ ok: true })
   mockDeleteConversations.mockReset()
   mockDeleteConversations.mockResolvedValue({ ok: true, deleted: 1 })
+  mockFilesTree.mockReset().mockResolvedValue({
+    tree: [{ name: 'a.md', path: 'a.md', type: 'file', size: 1, modified_at: 1 }],
+  })
+  mockGetFileContent.mockReset().mockResolvedValue({ path: 'a.md', content: 'body', revision: 'r1' })
   mockStreamChat.mockImplementation(() => new Promise(() => {}))
   sidebarProps.current = null
 })
@@ -98,6 +107,61 @@ describe('ChatPage URL-load effect', () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(mockGetConversation).toHaveBeenCalledTimes(1)
     expect(mockGetConversation).toHaveBeenCalledWith('abc')
+  })
+})
+
+describe('ChatPage dirty-editor navigation guard (regression: PR #79 codex 4.1)', () => {
+  function renderProjectRoute() {
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'P', conversation_count: 0 }],
+    })
+    return render(
+      <MemoryRouter initialEntries={['/chat/project/p1']}>
+        <Routes>
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
+          <Route path="/chat/project/:projectId" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+  }
+
+  async function openAndDirtyEditor() {
+    renderProjectRoute()
+    const { screen: s } = await import('@testing-library/react')
+    const row = await s.findByTestId('file-row-a.md')
+    await act(async () => { s.getByTestId('file-row-a.md').click() })
+    const ta = await s.findByTestId('editor-textarea')
+    const { fireEvent } = await import('@testing-library/react')
+    fireEvent.change(ta, { target: { value: 'unsaved edits' } })
+    return { s, row, ta }
+  }
+
+  it('sidebar navigation while dirty asks first; cancel keeps the editor and text', async () => {
+    const { s } = await openAndDirtyEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onSelect('some-conv') })
+    expect(confirmSpy).toHaveBeenCalled()
+    // Still on the project route, edits intact.
+    expect(s.getByTestId('editor-textarea').value).toBe('unsaved edits')
+  })
+
+  it('confirming the discard navigates away and unmounts the editor', async () => {
+    const { s } = await openAndDirtyEditor()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onSelect('some-conv') })
+    expect(s.queryByTestId('editor-textarea')).toBeNull()
+  })
+
+  it('navigation with a clean editor does not ask', async () => {
+    renderProjectRoute()
+    const { screen: s } = await import('@testing-library/react')
+    await s.findByTestId('file-row-a.md')
+    // spyOn returns the accumulated spy from earlier tests in this file
+    // (no restoreAllMocks here) — clear its history first.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    confirmSpy.mockClear()
+    await act(async () => { await sidebarProps.current.onSelect('some-conv') })
+    expect(confirmSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getProjectFileContent, saveProjectFileContent } from '../../services/chat'
+
+// Lightweight text editor for a single project file: plain textarea,
+// dirty tracking, Ctrl/Cmd+S, and optimistic-concurrency saves (the
+// loaded mtime is sent as base_modified_at; a 409 means the file changed
+// on disk and the user chooses to reload or overwrite).
+export default function ProjectFileEditor({ projectId, path, isNew = false, onClose, onSaved }) {
+  const [content, setContent] = useState('')
+  const [baseModifiedAt, setBaseModifiedAt] = useState(null)
+  const [loading, setLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [dirty, setDirty] = useState(isNew)
+  const [error, setError] = useState(null)
+  const [conflict, setConflict] = useState(false)
+  const textareaRef = useRef(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setConflict(false)
+    try {
+      const doc = await getProjectFileContent(projectId, path)
+      setContent(doc.content)
+      setBaseModifiedAt(doc.modified_at)
+      setDirty(false)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId, path])
+
+  useEffect(() => {
+    if (!isNew) load()
+  }, [load, isNew])
+
+  const save = useCallback(async ({ force = false } = {}) => {
+    setSaving(true)
+    setError(null)
+    setConflict(false)
+    try {
+      const node = await saveProjectFileContent(
+        projectId, path, content,
+        force ? null : baseModifiedAt,
+      )
+      setBaseModifiedAt(node.modified_at)
+      setDirty(false)
+      onSaved?.()
+    } catch (err) {
+      if (err.message.includes('changed on disk')) {
+        setConflict(true)
+      } else {
+        setError(err.message)
+      }
+    } finally {
+      setSaving(false)
+    }
+  }, [projectId, path, content, baseModifiedAt, onSaved])
+
+  const handleKeyDown = useCallback((e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault()
+      if (dirty && !saving) save()
+    }
+  }, [dirty, saving, save])
+
+  const handleClose = useCallback(() => {
+    if (dirty && !window.confirm('Discard unsaved changes?')) return
+    onClose()
+  }, [dirty, onClose])
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden" data-testid="file-editor">
+      {/* Editor header */}
+      <div className="px-6 py-2 border-b border-border flex items-center gap-3">
+        <i className="fa-regular fa-file-lines text-fg-faint text-xs"></i>
+        <span className="text-sm text-fg font-medium truncate">{path}</span>
+        {dirty && (
+          <span className="text-[10px] px-1.5 py-0.5 bg-warning-subtle text-warning-fg rounded"
+                title="Unsaved changes" data-testid="dirty-indicator">modified</span>
+        )}
+        <span className="ml-auto flex items-center gap-2">
+          <button
+            onClick={() => save()}
+            disabled={!dirty || saving || loading}
+            className="px-3 py-1.5 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            onClick={handleClose}
+            className="px-2 py-1.5 text-fg-subtle hover:text-fg text-xs"
+            title="Close editor" aria-label="Close editor"
+          >
+            <i className="fa-solid fa-xmark"></i>
+          </button>
+        </span>
+      </div>
+
+      {conflict && (
+        <div className="mx-6 mt-3 px-3 py-2 bg-warning-subtle text-warning-fg rounded text-xs flex items-center gap-3">
+          <span>The file changed on disk since it was loaded.</span>
+          <button onClick={load} className="underline">Reload (discard my changes)</button>
+          <button onClick={() => save({ force: true })} className="underline">Overwrite anyway</button>
+        </div>
+      )}
+      {error && (
+        <div className="mx-6 mt-3 px-3 py-2 bg-danger-subtle text-danger-fg rounded text-xs">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center text-fg-subtle text-sm">
+          Loading…
+        </div>
+      ) : (
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={e => { setContent(e.target.value); setDirty(true) }}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          className="flex-1 w-full resize-none bg-app text-fg font-mono text-sm leading-relaxed p-6 focus:outline-none"
+          placeholder={isNew ? 'New file — start typing…' : ''}
+          data-testid="editor-textarea"
+        />
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -3,11 +3,11 @@ import { getProjectFileContent, saveProjectFileContent } from '../../services/ch
 
 // Lightweight text editor for a single project file: plain textarea,
 // dirty tracking, Ctrl/Cmd+S, and optimistic-concurrency saves (the
-// loaded mtime is sent as base_modified_at; a 409 means the file changed
+// loaded revision is sent as base_revision; a 409 means the file changed
 // on disk and the user chooses to reload or overwrite).
 export default function ProjectFileEditor({ projectId, path, isNew = false, onClose, onSaved }) {
   const [content, setContent] = useState('')
-  const [baseModifiedAt, setBaseModifiedAt] = useState(null)
+  const [baseRevision, setBaseRevision] = useState(null)
   const [loading, setLoading] = useState(!isNew)
   const [saving, setSaving] = useState(false)
   const [dirty, setDirty] = useState(isNew)
@@ -22,7 +22,7 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
     try {
       const doc = await getProjectFileContent(projectId, path)
       setContent(doc.content)
-      setBaseModifiedAt(doc.modified_at)
+      setBaseRevision(doc.revision)
       setDirty(false)
     } catch (err) {
       setError(err.message)
@@ -42,9 +42,9 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
     try {
       const node = await saveProjectFileContent(
         projectId, path, content,
-        force ? null : baseModifiedAt,
+        force ? null : baseRevision,
       )
-      setBaseModifiedAt(node.modified_at)
+      setBaseRevision(node.revision)
       setDirty(false)
       onSaved?.()
     } catch (err) {
@@ -56,7 +56,7 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
     } finally {
       setSaving(false)
     }
-  }, [projectId, path, content, baseModifiedAt, onSaved])
+  }, [projectId, path, content, baseRevision, onSaved])
 
   const handleKeyDown = useCallback((e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 's') {

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -12,16 +12,27 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
   const [saving, setSaving] = useState(false)
   const [dirty, setDirty] = useState(isNew)
   const [error, setError] = useState(null)
-  const [conflict, setConflict] = useState(false)
+  const [conflict, setConflict] = useState(null) // conflict message | null
   const textareaRef = useRef(null)
+  // Latest textarea content, for comparing against the snapshot a save
+  // actually submitted — the user may keep typing while a save is in
+  // flight, and that newer content must stay marked dirty.
+  const contentRef = useRef('')
+  // Whether the next save should carry the create-only precondition.
+  // Starts from isNew, and drops permanently once the file demonstrably
+  // exists — after any successful save OR after loading it from disk
+  // (the reload path of an already-exists conflict).
+  const createModeRef = useRef(isNew)
 
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
-    setConflict(false)
+    setConflict(null)
     try {
       const doc = await getProjectFileContent(projectId, path)
       setContent(doc.content)
+      contentRef.current = doc.content
+      createModeRef.current = false
       setBaseRevision(doc.revision)
       setDirty(false)
     } catch (err) {
@@ -36,20 +47,32 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
   }, [load, isNew])
 
   const save = useCallback(async ({ force = false } = {}) => {
+    // `content` is the snapshot this save submits. The user can keep
+    // typing while the request is in flight — only clear dirty if the
+    // textarea still holds exactly what was saved.
+    const submitted = content
     setSaving(true)
     setError(null)
-    setConflict(false)
+    setConflict(null)
     try {
       const node = await saveProjectFileContent(
-        projectId, path, content,
+        projectId, path, submitted,
         force ? null : baseRevision,
+        // New-file precondition: the tree snapshot said this path is free,
+        // but the filesystem is the source of truth — create-only turns a
+        // stale snapshot into a 409 instead of a silent overwrite. A
+        // forced save is the explicit overwrite escape hatch.
+        createModeRef.current && !force,
       )
+      createModeRef.current = false
       setBaseRevision(node.revision)
-      setDirty(false)
+      setDirty(contentRef.current !== submitted)
       onSaved?.()
     } catch (err) {
-      if (err.message.includes('changed on disk')) {
-        setConflict(true)
+      if (err.message.includes('changed on disk') || err.message.includes('already exists')) {
+        setConflict(err.message.includes('already exists')
+          ? 'A file with this name already exists on disk.'
+          : 'The file changed on disk since it was loaded.')
       } else {
         setError(err.message)
       }
@@ -100,7 +123,7 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
 
       {conflict && (
         <div className="mx-6 mt-3 px-3 py-2 bg-warning-subtle text-warning-fg rounded text-xs flex items-center gap-3">
-          <span>The file changed on disk since it was loaded.</span>
+          <span>{conflict}</span>
           <button onClick={load} className="underline">Reload (discard my changes)</button>
           <button onClick={() => save({ force: true })} className="underline">Overwrite anyway</button>
         </div>
@@ -119,7 +142,7 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
         <textarea
           ref={textareaRef}
           value={content}
-          onChange={e => { setContent(e.target.value); setDirty(true) }}
+          onChange={e => { setContent(e.target.value); contentRef.current = e.target.value; setDirty(true) }}
           onKeyDown={handleKeyDown}
           spellCheck={false}
           className="flex-1 w-full resize-none bg-app text-fg font-mono text-sm leading-relaxed p-6 focus:outline-none"

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -13,6 +13,11 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
   const [dirty, setDirty] = useState(isNew)
   const [error, setError] = useState(null)
   const [conflict, setConflict] = useState(null) // conflict message | null
+  // True when the INITIAL content load failed (binary, oversized,
+  // transient error). The textarea must not render in that state: a blank
+  // editable buffer over an unread file would save as an unconditional
+  // overwrite of content the user never saw.
+  const [loadFailed, setLoadFailed] = useState(false)
   const textareaRef = useRef(null)
   // Latest textarea content, for comparing against the snapshot a save
   // actually submitted — the user may keep typing while a save is in
@@ -35,8 +40,10 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
       createModeRef.current = false
       setBaseRevision(doc.revision)
       setDirty(false)
+      setLoadFailed(false)
     } catch (err) {
       setError(err.message)
+      setLoadFailed(true)
     } finally {
       setLoading(false)
     }
@@ -164,6 +171,11 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
       {loading ? (
         <div className="flex-1 flex items-center justify-center text-fg-subtle text-sm">
           Loading…
+        </div>
+      ) : loadFailed ? (
+        <div className="flex-1 flex items-center justify-center gap-3 text-fg-subtle text-sm">
+          <span>Could not open this file.</span>
+          <button onClick={load} className="underline" aria-label="Retry loading file">Retry</button>
         </div>
       ) : (
         <textarea

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -5,7 +5,7 @@ import { getProjectFileContent, saveProjectFileContent } from '../../services/ch
 // dirty tracking, Ctrl/Cmd+S, and optimistic-concurrency saves (the
 // loaded revision is sent as base_revision; a 409 means the file changed
 // on disk and the user chooses to reload or overwrite).
-export default function ProjectFileEditor({ projectId, path, isNew = false, onClose, onSaved }) {
+export default function ProjectFileEditor({ projectId, path, isNew = false, onClose, onSaved, onDirtyChange }) {
   const [content, setContent] = useState('')
   const [baseRevision, setBaseRevision] = useState(null)
   const [loading, setLoading] = useState(!isNew)
@@ -98,6 +98,27 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
     if (dirty && !window.confirm('Discard unsaved changes?')) return
     onClose()
   }, [dirty, onClose])
+
+  // Surface dirty state to the parent so in-app navigation (sidebar
+  // clicks route away and unmount this editor without handleClose) can
+  // guard against silent discards. Reset on unmount.
+  const onDirtyChangeRef = useRef(onDirtyChange)
+  onDirtyChangeRef.current = onDirtyChange
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty)
+  }, [dirty])
+  useEffect(() => () => onDirtyChangeRef.current?.(false), [])
+
+  // Browser close/reload guard while dirty.
+  useEffect(() => {
+    if (!dirty) return
+    const handler = (e) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [dirty])
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden" data-testid="file-editor">

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -42,9 +42,15 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
     }
   }, [projectId, path])
 
+  // Initial load decision is taken from createModeRef, NOT the isNew prop:
+  // after the first successful save the parent flips isNew to false, and a
+  // prop-driven load() would refetch the just-saved snapshot and clobber
+  // anything typed while that save was in flight. The effect re-runs only
+  // when projectId/path change — which remounts the editor anyway (keyed
+  // by path in ProjectPage).
   useEffect(() => {
-    if (!isNew) load()
-  }, [load, isNew])
+    if (!createModeRef.current) load()
+  }, [load])
 
   const save = useCallback(async ({ force = false } = {}) => {
     // `content` is the snapshot this save submits. The user can keep

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -196,9 +196,23 @@ describe('ProjectFileEditor', () => {
     expect(onDirtyChange).toHaveBeenLastCalledWith(false)
   })
 
-  it('shows a load error for binary files', async () => {
+  it('a failed load shows the error WITHOUT a writable textarea (regression: codex 6.1)', async () => {
+    // A blank editable buffer over an unread file would save as an
+    // unconditional overwrite of content the user never saw.
     mockGet.mockRejectedValue(new Error('not a text file'))
     render(<ProjectFileEditor projectId="p1" path="img.png" onClose={() => {}} />)
     expect(await screen.findByText('not a text file')).toBeTruthy()
+    expect(screen.queryByTestId('editor-textarea')).toBeNull()
+    expect(screen.getByText('Save').disabled).toBe(true)
+  })
+
+  it('Retry after a transient load failure opens the editor normally', async () => {
+    mockGet
+      .mockRejectedValueOnce(new Error('HTTP 500'))
+      .mockResolvedValueOnce({ path: 'notes.md', content: 'recovered', revision: 'rr' })
+    render(<ProjectFileEditor projectId="p1" path="notes.md" onClose={() => {}} />)
+    await screen.findByText('HTTP 500')
+    fireEvent.click(screen.getByLabelText('Retry loading file'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea').value).toBe('recovered'))
   })
 })

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -45,7 +45,7 @@ describe('ProjectFileEditor', () => {
     expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
 
     fireEvent.click(screen.getByText('Save'))
-    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'hello world', 'r100'))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'hello world', 'r100', false))
     await waitFor(() => expect(screen.queryByTestId('dirty-indicator')).toBeNull())
     expect(onSaved).toHaveBeenCalled()
   })
@@ -73,7 +73,7 @@ describe('ProjectFileEditor', () => {
     await screen.findByText(/changed on disk/)
 
     fireEvent.click(screen.getByText('Overwrite anyway'))
-    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'mine', null))
+    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'mine', null, false))
     await waitFor(() => expect(screen.queryByText(/changed on disk/)).toBeNull())
   })
 
@@ -110,8 +110,63 @@ describe('ProjectFileEditor', () => {
 
     fireEvent.change(ta, { target: { value: 'fresh' } })
     fireEvent.click(screen.getByText('Save'))
-    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'fresh', null))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'fresh', null, true))
     expect(onSaved).toHaveBeenCalled()
+  })
+
+  it('typing during an in-flight save keeps the editor dirty (regression: codex 2.1)', async () => {
+    let resolveSave
+    mockSave.mockImplementation(() => new Promise(res => { resolveSave = res }))
+    await renderEditor()
+    const ta = screen.getByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'content A' } })
+    fireEvent.click(screen.getByText('Save'))                 // save A, pending
+    fireEvent.change(ta, { target: { value: 'content B' } })  // keep typing
+
+    resolveSave({ path: 'notes.md', revision: 'rA' })
+    await waitFor(() => expect(screen.getByText('Save').disabled).toBe(false))
+    // B is newer than the saved snapshot: still dirty, still saveable.
+    expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
+    mockSave.mockResolvedValue({ path: 'notes.md', revision: 'rB' })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'content B', 'rA', false))
+    await waitFor(() => expect(screen.queryByTestId('dirty-indicator')).toBeNull())
+  })
+
+  it('new-file saves carry the create-only precondition (regression: codex 2.2)', async () => {
+    await renderEditor({ isNew: true })
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'fresh' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'fresh', null, true))
+  })
+
+  it('a create-only 409 shows the already-exists conflict; Reload opens the on-disk file and drops create mode', async () => {
+    mockSave.mockRejectedValueOnce(new Error('file already exists'))
+    await renderEditor({ isNew: true })
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
+    fireEvent.click(screen.getByText('Save'))
+    await screen.findByText(/already exists/)
+
+    mockGet.mockResolvedValue({ path: 'notes.md', content: 'on disk', revision: 'rd' })
+    fireEvent.click(screen.getByText('Reload (discard my changes)'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea').value).toBe('on disk'))
+    // Editing and saving again is a normal guarded save now, not create-only.
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+    mockSave.mockResolvedValue({ path: 'notes.md', revision: 're' })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'edited', 'rd', false))
+  })
+
+  it('a create-only 409 Overwrite anyway forces a plain save', async () => {
+    mockSave
+      .mockRejectedValueOnce(new Error('file already exists'))
+      .mockResolvedValueOnce({ path: 'notes.md', revision: 'rf' })
+    await renderEditor({ isNew: true })
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
+    fireEvent.click(screen.getByText('Save'))
+    await screen.findByText(/already exists/)
+    fireEvent.click(screen.getByText('Overwrite anyway'))
+    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'mine', null, false))
   })
 
   it('shows a load error for binary files', async () => {

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import ProjectFileEditor from './ProjectFileEditor'
+
+const { mockGet, mockSave } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSave: vi.fn(),
+}))
+vi.mock('../../services/chat', () => ({
+  getProjectFileContent: (...a) => mockGet(...a),
+  saveProjectFileContent: (...a) => mockSave(...a),
+}))
+
+beforeEach(() => {
+  mockGet.mockReset().mockResolvedValue({ path: 'notes.md', content: 'hello', modified_at: 100 })
+  mockSave.mockReset().mockResolvedValue({ path: 'notes.md', modified_at: 101 })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+async function renderEditor(props = {}) {
+  const onClose = vi.fn()
+  const onSaved = vi.fn()
+  render(
+    <ProjectFileEditor projectId="p1" path="notes.md" onClose={onClose} onSaved={onSaved} {...props} />
+  )
+  if (!props.isNew) {
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('p1', 'notes.md'))
+    await screen.findByTestId('editor-textarea')
+  }
+  return { onClose, onSaved }
+}
+
+describe('ProjectFileEditor', () => {
+  it('loads content and saves with the loaded mtime as conflict base', async () => {
+    const { onSaved } = await renderEditor()
+    const ta = screen.getByTestId('editor-textarea')
+    expect(ta.value).toBe('hello')
+    expect(screen.queryByTestId('dirty-indicator')).toBeNull()
+
+    fireEvent.change(ta, { target: { value: 'hello world' } })
+    expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'hello world', 100))
+    await waitFor(() => expect(screen.queryByTestId('dirty-indicator')).toBeNull())
+    expect(onSaved).toHaveBeenCalled()
+  })
+
+  it('Ctrl+S saves when dirty', async () => {
+    await renderEditor()
+    const ta = screen.getByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'x' } })
+    fireEvent.keyDown(ta, { key: 's', ctrlKey: true })
+    await waitFor(() => expect(mockSave).toHaveBeenCalled())
+  })
+
+  it('save button is disabled while clean', async () => {
+    await renderEditor()
+    expect(screen.getByText('Save').disabled).toBe(true)
+  })
+
+  it('a 409 shows the conflict bar; Overwrite anyway retries without a base', async () => {
+    mockSave
+      .mockRejectedValueOnce(new Error('file changed on disk since it was loaded'))
+      .mockResolvedValueOnce({ path: 'notes.md', modified_at: 102 })
+    await renderEditor()
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
+    fireEvent.click(screen.getByText('Save'))
+    await screen.findByText(/changed on disk/)
+
+    fireEvent.click(screen.getByText('Overwrite anyway'))
+    await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'mine', null))
+    await waitFor(() => expect(screen.queryByText(/changed on disk/)).toBeNull())
+  })
+
+  it('conflict Reload discards local edits and refetches', async () => {
+    mockSave.mockRejectedValueOnce(new Error('file changed on disk since it was loaded'))
+    await renderEditor()
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
+    fireEvent.click(screen.getByText('Save'))
+    await screen.findByText(/changed on disk/)
+
+    mockGet.mockResolvedValue({ path: 'notes.md', content: 'theirs', modified_at: 200 })
+    fireEvent.click(screen.getByText('Reload (discard my changes)'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea').value).toBe('theirs'))
+    expect(screen.queryByTestId('dirty-indicator')).toBeNull()
+  })
+
+  it('closing with unsaved changes asks for confirmation', async () => {
+    const { onClose } = await renderEditor()
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'x' } })
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getByLabelText('Close editor'))
+    expect(onClose).not.toHaveBeenCalled()
+    window.confirm.mockReturnValue(true)
+    fireEvent.click(screen.getByLabelText('Close editor'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('a new file starts empty and dirty, saving without a conflict base', async () => {
+    const { onSaved } = await renderEditor({ isNew: true })
+    expect(mockGet).not.toHaveBeenCalled()
+    const ta = screen.getByTestId('editor-textarea')
+    expect(ta.value).toBe('')
+    expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
+
+    fireEvent.change(ta, { target: { value: 'fresh' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'fresh', null))
+    expect(onSaved).toHaveBeenCalled()
+  })
+
+  it('shows a load error for binary files', async () => {
+    mockGet.mockRejectedValue(new Error('not a text file'))
+    render(<ProjectFileEditor projectId="p1" path="img.png" onClose={() => {}} />)
+    expect(await screen.findByText('not a text file')).toBeTruthy()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -12,8 +12,8 @@ vi.mock('../../services/chat', () => ({
 }))
 
 beforeEach(() => {
-  mockGet.mockReset().mockResolvedValue({ path: 'notes.md', content: 'hello', modified_at: 100 })
-  mockSave.mockReset().mockResolvedValue({ path: 'notes.md', modified_at: 101 })
+  mockGet.mockReset().mockResolvedValue({ path: 'notes.md', content: 'hello', revision: 'r100' })
+  mockSave.mockReset().mockResolvedValue({ path: 'notes.md', revision: 'r101' })
 })
 
 afterEach(() => {
@@ -35,7 +35,7 @@ async function renderEditor(props = {}) {
 }
 
 describe('ProjectFileEditor', () => {
-  it('loads content and saves with the loaded mtime as conflict base', async () => {
+  it('loads content and saves with the loaded revision as conflict base', async () => {
     const { onSaved } = await renderEditor()
     const ta = screen.getByTestId('editor-textarea')
     expect(ta.value).toBe('hello')
@@ -45,7 +45,7 @@ describe('ProjectFileEditor', () => {
     expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
 
     fireEvent.click(screen.getByText('Save'))
-    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'hello world', 100))
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('p1', 'notes.md', 'hello world', 'r100'))
     await waitFor(() => expect(screen.queryByTestId('dirty-indicator')).toBeNull())
     expect(onSaved).toHaveBeenCalled()
   })
@@ -66,7 +66,7 @@ describe('ProjectFileEditor', () => {
   it('a 409 shows the conflict bar; Overwrite anyway retries without a base', async () => {
     mockSave
       .mockRejectedValueOnce(new Error('file changed on disk since it was loaded'))
-      .mockResolvedValueOnce({ path: 'notes.md', modified_at: 102 })
+      .mockResolvedValueOnce({ path: 'notes.md', revision: 'r102' })
     await renderEditor()
     fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
     fireEvent.click(screen.getByText('Save'))
@@ -84,7 +84,7 @@ describe('ProjectFileEditor', () => {
     fireEvent.click(screen.getByText('Save'))
     await screen.findByText(/changed on disk/)
 
-    mockGet.mockResolvedValue({ path: 'notes.md', content: 'theirs', modified_at: 200 })
+    mockGet.mockResolvedValue({ path: 'notes.md', content: 'theirs', revision: 'r200' })
     fireEvent.click(screen.getByText('Reload (discard my changes)'))
     await waitFor(() => expect(screen.getByTestId('editor-textarea').value).toBe('theirs'))
     expect(screen.queryByTestId('dirty-indicator')).toBeNull()

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -169,6 +169,33 @@ describe('ProjectFileEditor', () => {
     await waitFor(() => expect(mockSave).toHaveBeenLastCalledWith('p1', 'notes.md', 'mine', null, false))
   })
 
+  it('arms a beforeunload guard while dirty and disarms after save', async () => {
+    await renderEditor()
+    const fire = () => {
+      const evt = new Event('beforeunload', { cancelable: true })
+      window.dispatchEvent(evt)
+      return evt.defaultPrevented
+    }
+    expect(fire()).toBe(false)                                 // clean: no guard
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'x' } })
+    expect(fire()).toBe(true)                                  // dirty: guarded
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(screen.queryByTestId('dirty-indicator')).toBeNull())
+    expect(fire()).toBe(false)                                 // clean again
+  })
+
+  it('reports dirty transitions via onDirtyChange and resets on unmount', async () => {
+    const onDirtyChange = vi.fn()
+    const { unmount } = render(
+      <ProjectFileEditor projectId="p1" path="notes.md" onClose={() => {}} onDirtyChange={onDirtyChange} />
+    )
+    await screen.findByTestId('editor-textarea')
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'x' } })
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+    unmount()
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+  })
+
   it('shows a load error for binary files', async () => {
     mockGet.mockRejectedValue(new Error('not a text file'))
     render(<ProjectFileEditor projectId="p1" path="img.png" onClose={() => {}} />)

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -3,6 +3,18 @@ import {
   getProjectFilesTree, uploadProjectFile, mkdirProjectPath,
   moveProjectPath, deleteProjectPath, downloadProjectFile,
 } from '../../services/chat'
+import ProjectFileEditor from './ProjectFileEditor'
+
+function findNode(nodes, path) {
+  for (const n of nodes) {
+    if (n.path === path) return n
+    if (n.type === 'dir' && n.children) {
+      const hit = findNode(n.children, path)
+      if (hit) return hit
+    }
+  }
+  return null
+}
 
 function formatSize(bytes) {
   if (bytes == null) return ''
@@ -11,14 +23,14 @@ function formatSize(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, onRename, onDelete, onDownload }) {
+function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, onNewFile, onRename, onDelete, onDownload, onOpenFile }) {
   const isDir = node.type === 'dir'
   return (
     <>
       <div
-        onClick={isDir ? () => onToggle(node.path) : undefined}
-        className={`group flex items-center gap-2 py-1.5 pr-3 border-b border-border-subtle text-sm ${
-          isDir ? 'cursor-pointer text-fg' : 'text-fg-muted'
+        onClick={isDir ? () => onToggle(node.path) : () => onOpenFile(node)}
+        className={`group flex items-center gap-2 py-1.5 pr-3 border-b border-border-subtle text-sm cursor-pointer ${
+          isDir ? 'text-fg' : 'text-fg-muted'
         } hover:bg-surface-muted`}
         style={{ paddingLeft: `${12 + depth * 18}px` }}
         data-testid={`file-row-${node.path}`}
@@ -44,6 +56,11 @@ function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, o
                 className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
                 title="Upload into folder" aria-label={`Upload into ${node.path}`}
               ><i className="fa-solid fa-file-arrow-up text-xs"></i></button>
+              <button
+                onClick={e => { e.stopPropagation(); onNewFile(node.path) }}
+                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+                title="New file" aria-label={`New file in ${node.path}`}
+              ><i className="fa-solid fa-file-circle-plus text-xs"></i></button>
               <button
                 onClick={e => { e.stopPropagation(); onNewFolder(node.path) }}
                 className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
@@ -79,9 +96,11 @@ function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, o
           onToggle={onToggle}
           onUploadInto={onUploadInto}
           onNewFolder={onNewFolder}
+          onNewFile={onNewFile}
           onRename={onRename}
           onDelete={onDelete}
           onDownload={onDownload}
+          onOpenFile={onOpenFile}
         />
       ))}
     </>
@@ -93,6 +112,8 @@ export default function ProjectPage({ project }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const [error, setError] = useState(null)
   const [busy, setBusy] = useState(false)
+  // {path, isNew} when the editor is open; replaces the tree area.
+  const [editing, setEditing] = useState(null)
   const fileInputRef = useRef(null)
   // Directory the next file-picker selection uploads into.
   const uploadDirRef = useRef('')
@@ -134,6 +155,7 @@ export default function ProjectPage({ project }) {
     setExpanded(new Set())
     setError(null)
     setBusy(false)
+    setEditing(null)
     refresh()
   }, [refresh])
 
@@ -210,6 +232,19 @@ export default function ProjectPage({ project }) {
     await run(() => deleteProjectPath(project.id, node.path))
   }, [project?.id, run])
 
+  const handleOpenFile = useCallback((node) => {
+    setEditing({ path: node.path, isNew: false })
+  }, [])
+
+  const handleNewFile = useCallback((parentDir) => {
+    const name = window.prompt('File name')
+    if (!name || !name.trim()) return
+    const path = parentDir ? `${parentDir}/${name.trim()}` : name.trim()
+    // If it already exists, open it instead of silently overwriting on save.
+    const existing = findNode(tree, path)
+    setEditing({ path, isNew: !existing })
+  }, [tree])
+
   const handleDownload = useCallback(async (node) => {
     try {
       const url = await downloadProjectFile(project.id, node.path)
@@ -265,6 +300,14 @@ export default function ProjectPage({ project }) {
           Upload files
         </button>
         <button
+          onClick={() => handleNewFile('')}
+          disabled={busy}
+          className="px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center gap-2 disabled:opacity-50"
+        >
+          <i className="fa-solid fa-file-circle-plus"></i>
+          New file
+        </button>
+        <button
           onClick={() => handleNewFolder('')}
           disabled={busy}
           className="px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center gap-2 disabled:opacity-50"
@@ -288,7 +331,22 @@ export default function ProjectPage({ project }) {
         </div>
       )}
 
-      {/* Tree */}
+      {/* Editor takes over the content area while a file is open */}
+      {editing ? (
+        <ProjectFileEditor
+          key={`${project.id}:${editing.path}`}
+          projectId={project.id}
+          path={editing.path}
+          isNew={editing.isNew}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            // A saved new file now exists on disk; drop the isNew flag so
+            // later saves carry the conflict guard, and refresh the tree.
+            setEditing(prev => (prev ? { ...prev, isNew: false } : prev))
+            refresh()
+          }}
+        />
+      ) : (
       <div className="flex-1 overflow-auto py-1">
         {tree.length === 0 && !error && (
           <div className="p-8 text-center text-xs text-fg-subtle">
@@ -304,12 +362,15 @@ export default function ProjectPage({ project }) {
             onToggle={toggle}
             onUploadInto={pickUpload}
             onNewFolder={handleNewFolder}
+            onNewFile={handleNewFile}
             onRename={handleRename}
             onDelete={handleDelete}
             onDownload={handleDownload}
+            onOpenFile={handleOpenFile}
           />
         ))}
       </div>
+      )}
     </div>
   )
 }

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -107,7 +107,7 @@ function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, o
   )
 }
 
-export default function ProjectPage({ project }) {
+export default function ProjectPage({ project, onEditorDirtyChange }) {
   const [tree, setTree] = useState([])
   const [expanded, setExpanded] = useState(() => new Set())
   const [error, setError] = useState(null)
@@ -338,6 +338,7 @@ export default function ProjectPage({ project }) {
           projectId={project.id}
           path={editing.path}
           isNew={editing.isNew}
+          onDirtyChange={onEditorDirtyChange}
           onClose={() => setEditing(null)}
           onSaved={() => {
             // A saved new file now exists on disk; drop the isNew flag so

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -114,6 +114,19 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
   const [busy, setBusy] = useState(false)
   // {path, isNew} when the editor is open; replaces the tree area.
   const [editing, setEditing] = useState(null)
+  // Local mirror of the editor's dirty state: the toolbar stays visible
+  // while the editor is open, and starting another New file would remount
+  // the keyed editor — an in-page replacement ChatPage's navigation guard
+  // never sees. Guard it here.
+  const editorDirtyRef = useRef(false)
+  const handleEditorDirtyChange = useCallback((d) => {
+    editorDirtyRef.current = d
+    onEditorDirtyChange?.(d)
+  }, [onEditorDirtyChange])
+  const confirmDiscardEdits = useCallback(() => {
+    if (!editing || !editorDirtyRef.current) return true
+    return window.confirm('Discard unsaved changes?')
+  }, [editing])
   const fileInputRef = useRef(null)
   // Directory the next file-picker selection uploads into.
   const uploadDirRef = useRef('')
@@ -237,13 +250,14 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
   }, [])
 
   const handleNewFile = useCallback((parentDir) => {
+    if (!confirmDiscardEdits()) return
     const name = window.prompt('File name')
     if (!name || !name.trim()) return
     const path = parentDir ? `${parentDir}/${name.trim()}` : name.trim()
     // If it already exists, open it instead of silently overwriting on save.
     const existing = findNode(tree, path)
     setEditing({ path, isNew: !existing })
-  }, [tree])
+  }, [tree, confirmDiscardEdits])
 
   const handleDownload = useCallback(async (node) => {
     try {
@@ -338,7 +352,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
           projectId={project.id}
           path={editing.path}
           isNew={editing.isNew}
-          onDirtyChange={onEditorDirtyChange}
+          onDirtyChange={handleEditorDirtyChange}
           onClose={() => setEditing(null)}
           onSaved={() => {
             // A saved new file now exists on disk; drop the isNew flag so

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -188,6 +188,47 @@ describe('ProjectPage editor integration', () => {
   })
 })
 
+describe('ProjectPage in-page editor replacement guard (regression: codex 5.1)', () => {
+  it('New file over a dirty editor asks first; cancel keeps path and text', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-readme.md'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved work' } })
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('b.md')
+    fireEvent.click(screen.getByText('New file'))
+    expect(confirmSpy).toHaveBeenCalled()
+    // Cancelled: same editor, text intact, no name prompt shown.
+    expect(promptSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
+    expect(screen.getByText('readme.md')).toBeTruthy()
+  })
+
+  it('confirming the discard opens the new file editor', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-readme.md'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved work' } })
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    vi.spyOn(window, 'prompt').mockReturnValue('b.md')
+    fireEvent.click(screen.getByText('New file'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea').value).toBe(''))
+    expect(screen.getByText('b.md')).toBeTruthy()
+  })
+
+  it('New file with a clean editor does not ask', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-readme.md'))
+    await screen.findByTestId('editor-textarea')
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    vi.spyOn(window, 'prompt').mockReturnValue('b.md')
+    fireEvent.click(screen.getByText('New file'))
+    expect(confirmSpy).not.toHaveBeenCalled()
+  })
+})
+
 describe('ProjectPage new-file first-save race (regression: codex 3.1)', () => {
   it('typing during the first save of a new file survives the isNew flip', async () => {
     // First save of a new file resolves while the user has already typed

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -39,8 +39,8 @@ beforeEach(() => {
   mockMkdir.mockReset().mockResolvedValue({})
   mockMove.mockReset().mockResolvedValue({})
   mockDelete.mockReset().mockResolvedValue({ ok: true })
-  mockGetContent.mockReset().mockResolvedValue({ path: 'readme.md', content: 'doc', modified_at: 1 })
-  mockSaveContent.mockReset().mockResolvedValue({ path: 'readme.md', modified_at: 2 })
+  mockGetContent.mockReset().mockResolvedValue({ path: 'readme.md', content: 'doc', revision: 'r1' })
+  mockSaveContent.mockReset().mockResolvedValue({ path: 'readme.md', revision: 'r2' })
 })
 
 afterEach(() => {

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -183,7 +183,7 @@ describe('ProjectPage editor integration', () => {
     const ta = await screen.findByTestId('editor-textarea')
     fireEvent.change(ta, { target: { value: 'body' } })
     fireEvent.click(screen.getByText('Save'))
-    await waitFor(() => expect(mockSaveContent).toHaveBeenCalledWith('p1', 'fresh.md', 'body', null))
+    await waitFor(() => expect(mockSaveContent).toHaveBeenCalledWith('p1', 'fresh.md', 'body', null, true))
     await waitFor(() => expect(mockTree).toHaveBeenCalledTimes(2))
   })
 })

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react'
 import ProjectPage from './ProjectPage'
 
-const { mockTree, mockUpload, mockMkdir, mockMove, mockDelete } = vi.hoisted(() => ({
+const { mockTree, mockUpload, mockMkdir, mockMove, mockDelete, mockGetContent, mockSaveContent } = vi.hoisted(() => ({
   mockTree: vi.fn(),
   mockUpload: vi.fn(),
   mockMkdir: vi.fn(),
   mockMove: vi.fn(),
   mockDelete: vi.fn(),
+  mockGetContent: vi.fn(),
+  mockSaveContent: vi.fn(),
 }))
 vi.mock('../../services/chat', () => ({
   getProjectFilesTree: (...a) => mockTree(...a),
@@ -16,6 +18,8 @@ vi.mock('../../services/chat', () => ({
   moveProjectPath: (...a) => mockMove(...a),
   deleteProjectPath: (...a) => mockDelete(...a),
   downloadProjectFile: vi.fn(),
+  getProjectFileContent: (...a) => mockGetContent(...a),
+  saveProjectFileContent: (...a) => mockSaveContent(...a),
 }))
 
 const project = { id: 'p1', name: 'Research', description: 'notes & data' }
@@ -35,6 +39,8 @@ beforeEach(() => {
   mockMkdir.mockReset().mockResolvedValue({})
   mockMove.mockReset().mockResolvedValue({})
   mockDelete.mockReset().mockResolvedValue({ ok: true })
+  mockGetContent.mockReset().mockResolvedValue({ path: 'readme.md', content: 'doc', modified_at: 1 })
+  mockSaveContent.mockReset().mockResolvedValue({ path: 'readme.md', modified_at: 2 })
 })
 
 afterEach(() => {
@@ -137,6 +143,48 @@ describe('ProjectPage file tree', () => {
     mockTree.mockResolvedValue({ tree: [] })
     render(<ProjectPage project={project} />)
     expect(await screen.findByText(/No files yet/)).toBeTruthy()
+  })
+})
+
+describe('ProjectPage editor integration', () => {
+  it('clicking a file row opens the editor with its content; closing returns to the tree', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-readme.md'))
+    await waitFor(() => expect(mockGetContent).toHaveBeenCalledWith('p1', 'readme.md'))
+    expect(await screen.findByTestId('file-editor')).toBeTruthy()
+    expect((await screen.findByTestId('editor-textarea')).value).toBe('doc')
+
+    fireEvent.click(screen.getByLabelText('Close editor'))
+    expect(screen.queryByTestId('file-editor')).toBeNull()
+    expect(screen.getByText('readme.md')).toBeTruthy()
+  })
+
+  it('New file prompts for a name and opens an empty new-file editor', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('fresh.md')
+    fireEvent.click(screen.getByText('New file'))
+    expect(await screen.findByTestId('file-editor')).toBeTruthy()
+    // New file: no content fetch, editor starts dirty for first save.
+    expect(mockGetContent).not.toHaveBeenCalled()
+    expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
+  })
+
+  it('New file with an existing name opens that file instead of a blank editor', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('readme.md')
+    fireEvent.click(screen.getByText('New file'))
+    await waitFor(() => expect(mockGetContent).toHaveBeenCalledWith('p1', 'readme.md'))
+  })
+
+  it('saving a new file refreshes the tree', async () => {
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('fresh.md')
+    fireEvent.click(screen.getByText('New file'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'body' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSaveContent).toHaveBeenCalledWith('p1', 'fresh.md', 'body', null))
+    await waitFor(() => expect(mockTree).toHaveBeenCalledTimes(2))
   })
 })
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -188,6 +188,39 @@ describe('ProjectPage editor integration', () => {
   })
 })
 
+describe('ProjectPage new-file first-save race (regression: codex 3.1)', () => {
+  it('typing during the first save of a new file survives the isNew flip', async () => {
+    // First save of a new file resolves while the user has already typed
+    // newer content. onSaved flips isNew on the editor prop — that flip
+    // must NOT trigger a reload of the just-saved snapshot, which would
+    // clobber the newer text and mark it clean.
+    await renderPage()
+    vi.spyOn(window, 'prompt').mockReturnValue('fresh.md')
+    fireEvent.click(screen.getByText('New file'))
+    const ta = await screen.findByTestId('editor-textarea')
+
+    let resolveSave
+    mockSaveContent.mockImplementation(() => new Promise(res => { resolveSave = res }))
+    fireEvent.change(ta, { target: { value: 'content A' } })
+    fireEvent.click(screen.getByText('Save'))                 // create A, pending
+    fireEvent.change(ta, { target: { value: 'content B' } })  // keep typing
+
+    mockGetContent.mockResolvedValue({ path: 'fresh.md', content: 'content A', revision: 'rA' })
+    resolveSave({ path: 'fresh.md', revision: 'rA' })
+    await waitFor(() => expect(screen.getByText('Save').disabled).toBe(false))
+
+    // B intact, still dirty, and no reload happened.
+    expect(screen.getByTestId('editor-textarea').value).toBe('content B')
+    expect(screen.getByTestId('dirty-indicator')).toBeTruthy()
+    expect(mockGetContent).not.toHaveBeenCalled()
+
+    // And B saves as a normal guarded (non-create) write.
+    mockSaveContent.mockResolvedValue({ path: 'fresh.md', revision: 'rB' })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSaveContent).toHaveBeenLastCalledWith('p1', 'fresh.md', 'content B', 'rA', false))
+  })
+})
+
 describe('ProjectPage stale-response guard', () => {
   it('a slow tree response for the previous project never commits after switching', async () => {
     // Project A's fetch is slow; the user switches to B; A resolves LAST.

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -109,6 +109,19 @@ export async function deleteProjectPath(projectId, path) {
   })
 }
 
+export async function getProjectFileContent(projectId, path) {
+  return fetchAPI(`/chat/projects/${projectId}/files/content?path=${encodeURIComponent(path)}`)
+}
+
+export async function saveProjectFileContent(projectId, path, content, baseModifiedAt = null) {
+  const body = { path, content }
+  if (baseModifiedAt != null) body.base_modified_at = baseModifiedAt
+  return fetchAPI(`/chat/projects/${projectId}/files/content`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  })
+}
+
 // Fetches the file with auth and hands back a blob URL the caller must
 // revoke after use (a plain <a href> can't carry the bearer token).
 export async function downloadProjectFile(projectId, path) {

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -113,9 +113,9 @@ export async function getProjectFileContent(projectId, path) {
   return fetchAPI(`/chat/projects/${projectId}/files/content?path=${encodeURIComponent(path)}`)
 }
 
-export async function saveProjectFileContent(projectId, path, content, baseModifiedAt = null) {
+export async function saveProjectFileContent(projectId, path, content, baseRevision = null) {
   const body = { path, content }
-  if (baseModifiedAt != null) body.base_modified_at = baseModifiedAt
+  if (baseRevision != null) body.base_revision = baseRevision
   return fetchAPI(`/chat/projects/${projectId}/files/content`, {
     method: 'PUT',
     body: JSON.stringify(body),

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -113,9 +113,10 @@ export async function getProjectFileContent(projectId, path) {
   return fetchAPI(`/chat/projects/${projectId}/files/content?path=${encodeURIComponent(path)}`)
 }
 
-export async function saveProjectFileContent(projectId, path, content, baseRevision = null) {
+export async function saveProjectFileContent(projectId, path, content, baseRevision = null, createOnly = false) {
   const body = { path, content }
   if (baseRevision != null) body.base_revision = baseRevision
+  if (createOnly) body.create_only = true
   return fetchAPI(`/chat/projects/${projectId}/files/content`, {
     method: 'PUT',
     body: JSON.stringify(body),

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -265,6 +265,22 @@ class TestOps:
         assert e.value.status == 409
         assert pf.read_text(made_root, "f.txt")["content"] == "other tab"
 
+    def test_write_text_create_only(self, made_root):
+        """Regression (PR #79 codex 2.2): a new-file save carries a
+        create-only precondition, so a stale tree snapshot can't silently
+        overwrite a file that appeared on disk since."""
+        node = pf.write_text(made_root, "f.txt", "created", create_only=True)
+        assert node["path"] == "f.txt"
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "stale create", create_only=True)
+        assert e.value.status == 409
+        assert pf.read_text(made_root, "f.txt")["content"] == "created"
+        # Dangling symlinks occupy their name for create-only too.
+        os.symlink("gone", os.path.join(made_root, "link"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "link", "x", create_only=True)
+        assert e.value.status == 409
+
     def test_write_text_conflict_when_file_deleted(self, made_root):
         node = pf.write_text(made_root, "f.txt", "one")
         pf.delete(made_root, "f.txt")
@@ -634,6 +650,31 @@ def test_content_traversal_and_bad_bodies_400(client):
                    json={"path": "f.txt", "content": "c", "base_revision": 12345},
                    headers=_auth())
     assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "c", "create_only": "yes"},
+                   headers=_auth())
+    assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "c", "create_only": True,
+                         "base_revision": "abc"},
+                   headers=_auth())
+    assert r.status_code == 400
+
+
+def test_content_create_only_http(client):
+    """Stale-tree case end to end: creating over an existing file is a
+    409, not a silent overwrite."""
+    pid = _mkproject(client)
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "original", "create_only": True},
+                   headers=_auth())
+    assert r.status_code == 200
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "stale", "create_only": True},
+                   headers=_auth())
+    assert r.status_code == 409
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=f.txt", headers=_auth())
+    assert r.get_json()["content"] == "original"
 
 
 def test_content_requires_auth(client):

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -332,6 +332,14 @@ class TestOps:
             pf.read_text(made_root, "big.txt")
         assert e.value.status == 413
 
+    def test_write_text_rejects_nul_content(self, made_root):
+        """Regression (PR #79 codex 4.2): read_text calls NUL binary, so
+        accepting it on write would create a file the editor can't reopen."""
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "before\x00after")
+        assert e.value.status == 400
+        assert os.listdir(made_root) == []
+
     def test_write_text_size_cap(self, made_root, monkeypatch):
         monkeypatch.setattr(pf, "MAX_TEXT_EDIT_BYTES", 4)
         with pytest.raises(pf.ProjectFilesError) as e:
@@ -675,6 +683,13 @@ def test_content_traversal_and_bad_bodies_400(client):
                    json={"path": "f.txt", "content": "c", "create_only": True,
                          "base_revision": "abc"},
                    headers=_auth())
+    assert r.status_code == 400
+
+
+def test_content_nul_rejected_http(client):
+    pid = _mkproject(client)
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "a\x00b"}, headers=_auth())
     assert r.status_code == 400
 
 

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -4,6 +4,7 @@ properties here — every route funnels through project_files.resolve().
 """
 import io
 import os
+import stat as stat_mod
 import sys
 
 import pytest
@@ -280,6 +281,22 @@ class TestOps:
         with pytest.raises(pf.ProjectFilesError) as e:
             pf.write_text(made_root, "link", "x", create_only=True)
         assert e.value.status == 409
+
+    def test_writes_preserve_permission_bits(self, made_root):
+        """Regression (PR #79 codex 3.2): mkstemp stages at 0600 — an edit
+        or overwriting upload must not strip the target's mode (e.g. a
+        0755 script's exec bit), and fresh files get 0644, not 0600."""
+        node = pf.write_text(made_root, "run.sh", "#!/bin/sh\n")
+        abs_path = os.path.join(made_root, "run.sh")
+        assert stat_mod.S_IMODE(os.lstat(abs_path).st_mode) == 0o644  # new-file default
+        os.chmod(abs_path, 0o755)
+        pf.write_text(made_root, "run.sh", "#!/bin/sh\necho hi\n")
+        assert stat_mod.S_IMODE(os.lstat(abs_path).st_mode) == 0o755  # edit preserves
+
+        pf.save_stream(made_root, "", "run.sh", io.BytesIO(b"#!/bin/sh\n"), overwrite=True)
+        assert stat_mod.S_IMODE(os.lstat(abs_path).st_mode) == 0o755  # overwrite upload preserves
+        pf.save_stream(made_root, "", "fresh.bin", io.BytesIO(b"x"))
+        assert stat_mod.S_IMODE(os.lstat(os.path.join(made_root, "fresh.bin")).st_mode) == 0o644
 
     def test_write_text_conflict_when_file_deleted(self, made_root):
         node = pf.write_text(made_root, "f.txt", "one")

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -220,6 +220,74 @@ class TestOps:
             pf.delete(made_root, "nope")
         assert e.value.status == 404
 
+    def test_read_write_text_roundtrip(self, made_root):
+        pf.mkdir(made_root, "notes")
+        node = pf.write_text(made_root, "notes/todo.md", "# hello\n")
+        assert node["path"] == "notes/todo.md"
+        doc = pf.read_text(made_root, "notes/todo.md")
+        assert doc["content"] == "# hello\n"
+        assert doc["modified_at"] == node["modified_at"]
+
+    def test_write_text_requires_parent_dir(self, made_root):
+        # notes/ doesn't exist and write_text does NOT create parents
+        # implicitly for a nested path whose parent is missing.
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "nope/deep/f.txt", "x")
+        assert e.value.status == 404
+
+    def test_write_text_conflict_detection(self, made_root):
+        node = pf.write_text(made_root, "f.txt", "one")
+        # Same base → accepted.
+        node2 = pf.write_text(made_root, "f.txt", "two", base_modified_at=node["modified_at"])
+        assert pf.read_text(made_root, "f.txt")["content"] == "two"
+        # Stale base → 409, content untouched.
+        stale = node2["modified_at"] - 10
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "three", base_modified_at=stale)
+        assert e.value.status == 409
+        assert pf.read_text(made_root, "f.txt")["content"] == "two"
+
+    def test_write_text_conflict_when_file_deleted(self, made_root):
+        node = pf.write_text(made_root, "f.txt", "one")
+        pf.delete(made_root, "f.txt")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "two", base_modified_at=node["modified_at"])
+        assert e.value.status == 409
+
+    def test_write_text_never_replaces_special_entries(self, made_root):
+        os.symlink("anywhere", os.path.join(made_root, "link"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "link", "x")
+        assert e.value.status == 409
+        assert os.path.islink(os.path.join(made_root, "link"))
+
+    def test_read_text_rejects_binary_and_oversized(self, made_root, monkeypatch):
+        with open(os.path.join(made_root, "bin.dat"), "wb") as f:
+            f.write(b"ab\x00cd")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.read_text(made_root, "bin.dat")
+        assert e.value.status == 400
+
+        with open(os.path.join(made_root, "latin1.txt"), "wb") as f:
+            f.write("café".encode("latin-1"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.read_text(made_root, "latin1.txt")
+        assert e.value.status == 400
+
+        monkeypatch.setattr(pf, "MAX_TEXT_EDIT_BYTES", 4)
+        with open(os.path.join(made_root, "big.txt"), "w") as f:
+            f.write("12345")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.read_text(made_root, "big.txt")
+        assert e.value.status == 413
+
+    def test_write_text_size_cap(self, made_root, monkeypatch):
+        monkeypatch.setattr(pf, "MAX_TEXT_EDIT_BYTES", 4)
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "12345")
+        assert e.value.status == 413
+        assert os.listdir(made_root) == []
+
     def test_dangling_symlink_is_a_first_class_entry(self, made_root):
         """A broken symlink is an ordinary tree entry: renamable, occupying
         its name for mkdir and as a move destination (exists() would follow
@@ -500,6 +568,57 @@ def test_mkdir_through_regular_file_400(client):
     # Upload into the file-as-dir path gets the same treatment.
     r = _upload(client, pid, "f.txt", b"x", dir="parent")
     assert r.status_code == 404  # save_stream's isdir pre-check
+
+
+def test_content_http_roundtrip(client):
+    pid = _mkproject(client)
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "notes.md", "content": "# hi"}, headers=_auth())
+    assert r.status_code == 200
+    base = r.get_json()["modified_at"]
+
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=notes.md", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["content"] == "# hi"
+
+    # Conflict via HTTP: stale base → 409.
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "notes.md", "content": "x", "base_modified_at": base - 5},
+                   headers=_auth())
+    assert r.status_code == 409
+
+
+def test_content_read_fresh_project_404(client):
+    pid = _mkproject(client)
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=missing.md", headers=_auth())
+    assert r.status_code == 404
+
+
+def test_content_traversal_and_bad_bodies_400(client):
+    pid = _mkproject(client)
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=../../etc/passwd",
+                   headers=_auth())
+    assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "../x", "content": "c"}, headers=_auth())
+    assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json=["nope"], headers=_auth())
+    assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": 42}, headers=_auth())
+    assert r.status_code == 400
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "f.txt", "content": "c", "base_modified_at": True},
+                   headers=_auth())
+    assert r.status_code == 400
+
+
+def test_content_requires_auth(client):
+    pid = _mkproject(client)
+    assert client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=x").status_code == 401
+    assert client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                      json={"path": "x", "content": ""}).status_code == 401
 
 
 def test_project_delete_aborts_when_files_cleanup_fails(client, tmp_path, monkeypatch):

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -226,7 +226,7 @@ class TestOps:
         assert node["path"] == "notes/todo.md"
         doc = pf.read_text(made_root, "notes/todo.md")
         assert doc["content"] == "# hello\n"
-        assert doc["modified_at"] == node["modified_at"]
+        assert doc["revision"] == node["revision"]
 
     def test_write_text_requires_parent_dir(self, made_root):
         # notes/ doesn't exist and write_text does NOT create parents
@@ -238,20 +238,38 @@ class TestOps:
     def test_write_text_conflict_detection(self, made_root):
         node = pf.write_text(made_root, "f.txt", "one")
         # Same base → accepted.
-        node2 = pf.write_text(made_root, "f.txt", "two", base_modified_at=node["modified_at"])
+        pf.write_text(made_root, "f.txt", "two", base_revision=node["revision"])
         assert pf.read_text(made_root, "f.txt")["content"] == "two"
         # Stale base → 409, content untouched.
-        stale = node2["modified_at"] - 10
         with pytest.raises(pf.ProjectFilesError) as e:
-            pf.write_text(made_root, "f.txt", "three", base_modified_at=stale)
+            pf.write_text(made_root, "f.txt", "three", base_revision=node["revision"])
         assert e.value.status == 409
         assert pf.read_text(made_root, "f.txt")["content"] == "two"
+
+    def test_write_text_conflict_even_with_identical_mtime(self, made_root):
+        """Regression (PR #79 codex 1.1): the revision must not be
+        timestamp-based at ANY precision — Linux stamps writes within one
+        kernel timer tick identically, so even mtime_ns collides for quick
+        successive saves. Force the worst case: content changed while the
+        mtime (seconds AND nanoseconds) is byte-for-byte identical. The
+        content-hash revision must still detect the change."""
+        node = pf.write_text(made_root, "f.txt", "one")
+        abs_path = os.path.join(made_root, "f.txt")
+        st = os.lstat(abs_path)
+        with open(abs_path, "w") as f:
+            f.write("other tab")
+        os.utime(abs_path, ns=(st.st_atime_ns, st.st_mtime_ns))
+        assert os.lstat(abs_path).st_mtime_ns == st.st_mtime_ns
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "f.txt", "stale save", base_revision=node["revision"])
+        assert e.value.status == 409
+        assert pf.read_text(made_root, "f.txt")["content"] == "other tab"
 
     def test_write_text_conflict_when_file_deleted(self, made_root):
         node = pf.write_text(made_root, "f.txt", "one")
         pf.delete(made_root, "f.txt")
         with pytest.raises(pf.ProjectFilesError) as e:
-            pf.write_text(made_root, "f.txt", "two", base_modified_at=node["modified_at"])
+            pf.write_text(made_root, "f.txt", "two", base_revision=node["revision"])
         assert e.value.status == 409
 
     def test_write_text_never_replaces_special_entries(self, made_root):
@@ -575,15 +593,19 @@ def test_content_http_roundtrip(client):
     r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
                    json={"path": "notes.md", "content": "# hi"}, headers=_auth())
     assert r.status_code == 200
-    base = r.get_json()["modified_at"]
+    base = r.get_json()["revision"]
 
     r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=notes.md", headers=_auth())
     assert r.status_code == 200
     assert r.get_json()["content"] == "# hi"
 
-    # Conflict via HTTP: stale base → 409.
+    # Save with the current revision → accepted; reusing it → 409.
     r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
-                   json={"path": "notes.md", "content": "x", "base_modified_at": base - 5},
+                   json={"path": "notes.md", "content": "x", "base_revision": base},
+                   headers=_auth())
+    assert r.status_code == 200
+    r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                   json={"path": "notes.md", "content": "y", "base_revision": base},
                    headers=_auth())
     assert r.status_code == 409
 
@@ -609,7 +631,7 @@ def test_content_traversal_and_bad_bodies_400(client):
                    json={"path": "f.txt", "content": 42}, headers=_auth())
     assert r.status_code == 400
     r = client.put(f"{PROJECTS_PATH}/{pid}/files/content",
-                   json={"path": "f.txt", "content": "c", "base_modified_at": True},
+                   json={"path": "f.txt", "content": "c", "base_revision": 12345},
                    headers=_auth())
     assert r.status_code == 400
 


### PR DESCRIPTION
Phase 3 of the projects feature: edit text files in the project tree directly from the browser.

## What's in
- **Files layer** (`chat/project_files.py`): `read_text` / `write_text`. UTF-8 only — binary (NUL byte / invalid UTF-8) and files over the 2 MB editor cap are rejected with 4xx. Writes are atomic (mkstemp in the target dir + replace) and never write through or replace symlinks/special files. `write_text` takes an optional `base_modified_at`: if the file changed on disk since the client loaded it (or was deleted), the save is rejected with 409 instead of silently clobbering the other edit.
- **API**: `GET/PUT /api/chat/projects/<id>/files/content` — same validation ordering (traversal 400s before missing-root 404s) and project-delete revalidation as the phase-2 routes.
- **UI**: clicking a file row opens `ProjectFileEditor` in the content area — plain monospace textarea (deliberately no CodeMirror dependency), dirty indicator, Ctrl/Cmd+S, disabled Save when clean, conflict bar with *Reload* / *Overwrite anyway*, confirm-on-close with unsaved changes. *New file* button in the toolbar and per-folder; choosing an existing name opens that file instead of blanking it.

## Tests
- Backend: 12 new (roundtrip, conflict incl. deleted-file, binary/oversized rejection, symlink protection, HTTP surface incl. traversal + auth). Full suite: 471 passed.
- Frontend: 8 editor tests + 4 ProjectPage integration tests. Full suite: 185 passed, build OK.

## Next
- Phase 4: `project-files` MCP server scoped to the conversation's project