### PR TITLE
feat(chat): project-files MCP server scoped to the conversation's project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Rules enforced at load time:
 - `id` must not contain `__` (collides with `server_id__tool_name`
   namespacing in `mcp_client.py`).
 - `id` must not collide with a built-in (`sympy-math`, `schemdraw-circuits`,
-  `render-html`). Built-ins always win.
+  `render-html`, `project-files`). Built-ins always win.
 - `name`, `description`, `icon`, `tool_hint` are always required.
 - `enabled` defaults to `true`.
 - `transport` defaults to `"stdio"`. Accepted values: `"stdio"`, `"http"`.

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -322,6 +322,31 @@ class ChatDB:
         finally:
             self._close_conn(conn)
 
+    def resolve_project_id(self, conv_id: str) -> Optional[str]:
+        """Effective project of a conversation: its own project_id, or the
+        nearest ancestor's. Project membership is root-only — spin-off rows
+        keep project_id NULL and follow their root ancestor — so this is
+        what tool scoping must use, not the row's own column. The visited
+        set guards against a parent cycle (impossible through the API, but
+        a walk must never be the thing that hangs on corrupt data)."""
+        seen = set()
+        conn = self._get_conn()
+        try:
+            while conv_id and conv_id not in seen:
+                seen.add(conv_id)
+                row = conn.execute(
+                    "SELECT project_id, parent_conversation_id FROM conversations WHERE id = ?",
+                    (conv_id,),
+                ).fetchone()
+                if row is None:
+                    return None
+                if row["project_id"]:
+                    return row["project_id"]
+                conv_id = row["parent_conversation_id"]
+            return None
+        finally:
+            self._close_conn(conn)
+
     def list_conversations(self, limit: int = 50, offset: int = 0) -> Tuple[List[Conversation], int]:
         """List conversations, newest-updated first.
 

--- a/dashboard/chat/mcp_client.py
+++ b/dashboard/chat/mcp_client.py
@@ -85,19 +85,13 @@ class MCPClientManager:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
-    def _run_async(self, coro):
-        """Run an async coroutine from sync code."""
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout=30)
+    def _run_async(self, coro, timeout: float = 30):
+        """Run an async coroutine from sync code.
 
-    def run_with_timeout(self, coro, timeout: float):
-        """Run a coroutine on the manager's event loop with a custom timeout.
-
-        Exposed for one-shot admin operations (the Tools page test endpoint)
-        that want a tighter deadline than the 30s default and don't want to
-        touch the cached chat path. On timeout, cancel the future so the
-        running coroutine (and its `stdio_client` subprocess) gets a chance
-        to clean up instead of leaking past the HTTP response.
+        On timeout (or any waiter-side error), cancel the future so the
+        running coroutine — and the `stdio_client` subprocess it holds —
+        gets torn down instead of grinding on after the caller already
+        returned an error (e.g. a search still scanning a huge project).
         """
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         try:
@@ -105,6 +99,15 @@ class MCPClientManager:
         except Exception:
             future.cancel()
             raise
+
+    def run_with_timeout(self, coro, timeout: float):
+        """Run a coroutine on the manager's event loop with a custom timeout.
+
+        Exposed for one-shot admin operations (the Tools page test endpoint)
+        that want a tighter deadline than the 30s default and don't want to
+        touch the cached chat path.
+        """
+        return self._run_async(coro, timeout=timeout)
 
     def get_tools(self, server_id: str) -> list:
         """Get tools for a server in OpenAI format. Uses cache."""

--- a/dashboard/chat/mcp_client.py
+++ b/dashboard/chat/mcp_client.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from typing import Optional
 
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import StdioServerParameters, get_default_environment, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp import ClientSession
 
@@ -31,9 +31,16 @@ async def _open_streams(config: dict):
         async with streamablehttp_client(url, headers=headers) as (read, write, _get_session_id):
             yield read, write
     else:
+        env = config.get("env")
+        if env:
+            # StdioServerParameters treats a provided env as the WHOLE
+            # environment; merge over the SDK's safe default set so PATH,
+            # HOME etc. survive alongside the injected variables.
+            env = {**get_default_environment(), **env}
         params = StdioServerParameters(
             command=config["command"][0],
             args=config["command"][1:],
+            env=env,
         )
         async with stdio_client(params) as (read, write):
             yield read, write
@@ -118,11 +125,20 @@ class MCPClientManager:
             logger.exception(f"Failed to discover tools from {server_id}")
             return []
 
-    def call_tool(self, server_id: str, tool_name: str, arguments: dict) -> tuple:
-        """Execute a tool on an MCP server. Returns (result_text, artifacts)."""
+    def call_tool(self, server_id: str, tool_name: str, arguments: dict,
+                  extra_env: Optional[dict] = None) -> tuple:
+        """Execute a tool on an MCP server. Returns (result_text, artifacts).
+
+        extra_env, when given, is merged into the environment of a
+        stdio server's subprocess for THIS call only — per-call scope
+        (e.g. the project-files server's project directory) without
+        mutating the shared registry config.
+        """
         config = get_server_config(server_id)
         if not config:
             return (f"Error: Unknown MCP server '{server_id}'", [])
+        if extra_env:
+            config = {**config, "env": {**(config.get("env") or {}), **extra_env}}
 
         try:
             return self._run_async(self._execute_tool(config, tool_name, arguments))

--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -126,6 +126,13 @@ Important rules:
 
 The diagram will be rendered automatically as an artifact.""",
     },
+    "project-files": {
+        "name": "Project Files",
+        "description": "Read this conversation's project files — list, read, search. Auto-enabled for conversations inside a project; does nothing outside one.",
+        "command": [sys.executable, os.path.join(_SERVERS_DIR, "project_files_server.py")],
+        "icon": "fa-folder-tree",
+        "tool_hint": "This conversation belongs to a project with a file area (documents, notes, data the user keeps alongside the project's conversations). You have read-only access to it: list_files shows the file tree, read_file returns a text file's content, search_files finds a substring across file names and contents. Paths are relative to the project root, e.g. 'docs/plan.md' — use them exactly as list_files prints them. When the user refers to project files or material \"in the project\", consult these tools instead of guessing.",
+    },
     "render-html": {
         "name": "Render HTML",
         "description": "Render HTML or Markdown as an artifact in the chat",

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -1,0 +1,153 @@
+"""Project Files MCP server — read-only view of one project's file area.
+
+Spawned per tool call by MCPClientManager like the other built-ins, but
+scoped: the dashboard injects LLM_DOCK_PROJECT_ROOT (the absolute
+directory of the conversation's project) into the subprocess environment
+at spawn time (see chat/project_files_mcp.py). Without it, every tool
+answers with a clear error instead of guessing a directory.
+
+All path handling is delegated to chat.project_files — the same layer the
+HTTP file routes use — so `..` traversal, absolute paths and symlink
+escapes are rejected here exactly as they are in the UI.
+"""
+import os
+import sys
+
+# Runs as a bare script, not a package member; make the dashboard
+# directory importable so `chat.project_files` resolves.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from chat import project_files as pf  # noqa: E402
+from chat.project_files_mcp import PROJECT_ROOT_ENV  # noqa: E402
+
+mcp = FastMCP("project-files")
+
+MAX_SEARCH_RESULTS = 200
+MAX_MATCH_LINE_CHARS = 200
+
+NO_PROJECT_ERROR = (
+    "Error: this conversation is not part of a project, so there are no "
+    "project files to access."
+)
+
+
+def _project_root():
+    """The scoped project directory, or None when unscoped."""
+    return os.environ.get(PROJECT_ROOT_ENV) or None
+
+
+def _flatten(nodes: list) -> list:
+    """Depth-first (path, node) pairs over a build_tree() result."""
+    out = []
+    for node in nodes:
+        out.append(node)
+        if node["type"] == "dir":
+            out.extend(_flatten(node.get("children", [])))
+    return out
+
+
+@mcp.tool()
+def list_files(path: str = "") -> str:
+    """List the project's files and folders.
+
+    Optionally pass a directory path (relative to the project root) to
+    list only that subtree. Returns one entry per line: directories end
+    with '/', files show their size. Use the printed paths verbatim with
+    read_file / search_files.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not os.path.isdir(root):
+        return "(the project has no files yet)"
+    try:
+        tree = pf.build_tree(root, path)
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+    lines = []
+    for node in _flatten(tree):
+        if node["type"] == "dir":
+            lines.append(f"{node['path']}/")
+        else:
+            lines.append(f"{node['path']} ({node['size']} bytes)")
+    if not lines:
+        return "(no files here)"
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def read_file(path: str) -> str:
+    """Read a text file from the project (UTF-8, up to 2 MB).
+
+    path is relative to the project root, e.g. 'docs/plan.md'. Binary
+    files and files over the size cap are rejected — use list_files to
+    check sizes first.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not os.path.isdir(root):
+        return "Error: file not found (the project has no files yet)"
+    try:
+        return pf.read_text(root, path)["content"]
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+
+
+@mcp.tool()
+def search_files(query: str, path: str = "") -> str:
+    """Search the project's files for a substring (case-insensitive).
+
+    Matches file names and the contents of text files (binary and
+    oversized files are skipped). Optionally restrict the search to a
+    subdirectory via path. Content matches are returned as
+    'path:line_number: line text'.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not isinstance(query, str) or not query.strip():
+        return "Error: query must be a non-empty string"
+    if not os.path.isdir(root):
+        return "No matches (the project has no files yet)."
+    try:
+        tree = pf.build_tree(root, path)
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+
+    needle = query.lower()
+    matches = []
+    truncated = False
+    for node in _flatten(tree):
+        if len(matches) >= MAX_SEARCH_RESULTS:
+            truncated = True
+            break
+        if needle in node["name"].lower():
+            suffix = "/" if node["type"] == "dir" else ""
+            matches.append(f"{node['path']}{suffix} (name match)")
+        if node["type"] != "file":
+            continue
+        try:
+            content = pf.read_text(root, node["path"])["content"]
+        except pf.ProjectFilesError:
+            continue  # binary, oversized, or a symlink — not searchable
+        for lineno, line in enumerate(content.splitlines(), start=1):
+            if needle in line.lower():
+                matches.append(
+                    f"{node['path']}:{lineno}: {line.strip()[:MAX_MATCH_LINE_CHARS]}"
+                )
+                if len(matches) >= MAX_SEARCH_RESULTS:
+                    truncated = True
+                    break
+
+    if not matches:
+        return "No matches."
+    result = "\n".join(matches)
+    if truncated:
+        result += f"\n(truncated at {MAX_SEARCH_RESULTS} matches — refine the query)"
+    return result
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -25,6 +25,11 @@ mcp = FastMCP("project-files")
 
 MAX_SEARCH_RESULTS = 200
 MAX_MATCH_LINE_CHARS = 200
+# Tool output feeds straight into the model context; a big-but-legitimate
+# project must degrade into an explicit truncation notice, not a
+# context-blowing (or 30s-timeout-hitting) response.
+MAX_LIST_ENTRIES = 500
+MAX_SEARCH_SCAN_BYTES = 64 * 1024 * 1024
 
 NO_PROJECT_ERROR = (
     "Error: this conversation is not part of a project, so there are no "
@@ -73,6 +78,13 @@ def list_files(path: str = "") -> str:
             lines.append(f"{node['path']} ({node['size']} bytes)")
     if not lines:
         return "(no files here)"
+    if len(lines) > MAX_LIST_ENTRIES:
+        total = len(lines)
+        lines = lines[:MAX_LIST_ENTRIES]
+        lines.append(
+            f"(truncated at {MAX_LIST_ENTRIES} of {total} entries — "
+            f"pass a subdirectory path to list less)"
+        )
     return "\n".join(lines)
 
 
@@ -119,19 +131,31 @@ def search_files(query: str, path: str = "") -> str:
     needle = query.lower()
     matches = []
     truncated = False
+    scan_capped = False
+    scanned_bytes = 0
     for node in _flatten(tree):
-        if len(matches) >= MAX_SEARCH_RESULTS:
-            truncated = True
-            break
         if needle in node["name"].lower():
             suffix = "/" if node["type"] == "dir" else ""
             matches.append(f"{node['path']}{suffix} (name match)")
+            if len(matches) >= MAX_SEARCH_RESULTS:
+                truncated = True
+                break
         if node["type"] != "file":
             continue
+        # Total read budget: a no-match query over a big-but-legitimate
+        # project must stop scanning instead of grinding past the MCP
+        # call timeout. Only count files read_text will actually accept.
+        size = node.get("size", 0)
+        if size > pf.MAX_TEXT_EDIT_BYTES:
+            continue  # read_text would reject it anyway — skip the call
+        if scanned_bytes + size > MAX_SEARCH_SCAN_BYTES:
+            scan_capped = True
+            break
+        scanned_bytes += size
         try:
             content = pf.read_text(root, node["path"])["content"]
         except pf.ProjectFilesError:
-            continue  # binary, oversized, or a symlink — not searchable
+            continue  # binary or a symlink — not searchable
         for lineno, line in enumerate(content.splitlines(), start=1):
             if needle in line.lower():
                 matches.append(
@@ -140,12 +164,20 @@ def search_files(query: str, path: str = "") -> str:
                 if len(matches) >= MAX_SEARCH_RESULTS:
                     truncated = True
                     break
+        if truncated:
+            break
 
     if not matches:
-        return "No matches."
-    result = "\n".join(matches)
+        result = "No matches."
+    else:
+        result = "\n".join(matches)
     if truncated:
         result += f"\n(truncated at {MAX_SEARCH_RESULTS} matches — refine the query)"
+    if scan_capped:
+        result += (
+            f"\n(search stopped early: {MAX_SEARCH_SCAN_BYTES // (1024 * 1024)} MB "
+            f"scan budget reached — narrow the search with a subdirectory path)"
+        )
     return result
 
 

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -30,6 +30,7 @@ MAX_MATCH_LINE_CHARS = 200
 # context-blowing (or 30s-timeout-hitting) response.
 MAX_LIST_ENTRIES = 500
 MAX_SEARCH_SCAN_BYTES = 64 * 1024 * 1024
+MAX_READ_CHARS = 64 * 1024
 
 NO_PROJECT_ERROR = (
     "Error: this conversation is not part of a project, so there are no "
@@ -89,10 +90,12 @@ def list_files(path: str = "") -> str:
 
 
 @mcp.tool()
-def read_file(path: str) -> str:
+def read_file(path: str, offset: int = 0) -> str:
     """Read a text file from the project (UTF-8, up to 2 MB).
 
-    path is relative to the project root, e.g. 'docs/plan.md'. Binary
+    path is relative to the project root, e.g. 'docs/plan.md'. At most
+    ~64k characters are returned per call; a longer file ends with a
+    notice giving the offset to pass to read the next chunk. Binary
     files and files over the size cap are rejected — use list_files to
     check sizes first.
     """
@@ -101,10 +104,22 @@ def read_file(path: str) -> str:
         return NO_PROJECT_ERROR
     if not os.path.isdir(root):
         return "Error: file not found (the project has no files yet)"
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        return "Error: offset must be a non-negative integer"
     try:
-        return pf.read_text(root, path)["content"]
+        content = pf.read_text(root, path)["content"]
     except pf.ProjectFilesError as e:
         return f"Error: {e}"
+    if offset > 0 and offset >= len(content):
+        return f"Error: offset {offset} is past the end of the file ({len(content)} characters)"
+    chunk = content[offset:offset + MAX_READ_CHARS]
+    end = offset + len(chunk)
+    if end < len(content):
+        chunk += (
+            f"\n(truncated: showing characters {offset}–{end} of {len(content)} — "
+            f"call read_file again with offset={end} to continue)"
+        )
+    return chunk
 
 
 @mcp.tool()

--- a/dashboard/chat/project_files_mcp.py
+++ b/dashboard/chat/project_files_mcp.py
@@ -1,0 +1,54 @@
+"""Glue between chat runs and the built-in project-files MCP server.
+
+The project-files server is spawned per tool call like every other
+built-in, but it is *scoped*: it must know which project's directory the
+current conversation belongs to. That scope travels as an environment
+variable injected into the subprocess at spawn time — the model never
+sees or supplies a project id.
+
+Kept import-light on purpose: the server script
+(`mcp_servers/project_files_server.py`) imports the constants from here,
+and it runs outside Flask.
+"""
+
+SERVER_ID = "project-files"
+
+# Absolute path of the conversation's project directory, injected into the
+# server subprocess. Absent (e.g. the server was manually enabled on a
+# conversation that belongs to no project) every tool answers with a clear
+# error instead of guessing a directory.
+PROJECT_ROOT_ENV = "LLM_DOCK_PROJECT_ROOT"
+
+
+def with_project_files(enabled_servers: list) -> list:
+    """Effective server list for a project conversation: project-files is
+    always on — membership in a project IS the toggle."""
+    if SERVER_ID in enabled_servers:
+        return list(enabled_servers)
+    return [*enabled_servers, SERVER_ID]
+
+
+class ProjectScopedMCPManager:
+    """Delegating wrapper around MCPClientManager that injects the
+    conversation's project root into project-files server spawns.
+
+    Built per run (in routes, where the conversation is known) so the same
+    process-wide manager — and its tool cache — serves every conversation;
+    only the spawn environment differs.
+    """
+
+    def __init__(self, inner, project_root: str):
+        self._inner = inner
+        self._project_root = project_root
+
+    def get_tools(self, server_id: str) -> list:
+        return self._inner.get_tools(server_id)
+
+    def get_all_tools(self, server_ids: list) -> list:
+        return self._inner.get_all_tools(server_ids)
+
+    def call_tool(self, server_id: str, tool_name: str, arguments: dict) -> tuple:
+        extra_env = None
+        if server_id == SERVER_ID:
+            extra_env = {PROJECT_ROOT_ENV: self._project_root}
+        return self._inner.call_tool(server_id, tool_name, arguments, extra_env=extra_env)

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -79,12 +79,17 @@ def _mcp_for_conversation(conv, enabled_servers):
     from . import project_files as pf
     from .project_files_mcp import ProjectScopedMCPManager
 
-    if not (enabled_servers or conv.project_id):
+    # Membership is root-only: a spin-off keeps project_id NULL and follows
+    # its root ancestor, so scoping must use the resolved project.
+    project_id = conv.project_id
+    if project_id is None and conv.parent_conversation_id:
+        project_id = _get_db().resolve_project_id(conv.id)
+    if not (enabled_servers or project_id):
         return None
     manager = _get_mcp()
-    if conv.project_id:
+    if project_id:
         storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
-        manager = ProjectScopedMCPManager(manager, pf.project_root(storage_root, conv.project_id))
+        manager = ProjectScopedMCPManager(manager, pf.project_root(storage_root, project_id))
     return manager
 
 

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -69,6 +69,25 @@ def _get_run_manager():
     return current_app.config["CHAT_RUN_MANAGER"]
 
 
+def _mcp_for_conversation(conv, enabled_servers):
+    """MCP manager for a run, or None when the turn has no tools.
+
+    Project conversations always get a manager — the project-files server
+    is auto-enabled for them (see runtime._build_stream) — wrapped so its
+    subprocess spawns learn the project's directory via the environment.
+    """
+    from . import project_files as pf
+    from .project_files_mcp import ProjectScopedMCPManager
+
+    if not (enabled_servers or conv.project_id):
+        return None
+    manager = _get_mcp()
+    if conv.project_id:
+        storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
+        manager = ProjectScopedMCPManager(manager, pf.project_root(storage_root, conv.project_id))
+    return manager
+
+
 @chat_bp.route("/api/chat/mcp-servers", methods=["GET"])
 @require_auth
 def get_mcp_servers():
@@ -467,7 +486,7 @@ def send_message(conv_id):
     )
 
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-    mcp_manager = _get_mcp() if enabled_servers else None
+    mcp_manager = _mcp_for_conversation(conv, enabled_servers)
 
     return _start_run_response(db, conv, user_msg, mcp_manager, is_first, content)
 
@@ -495,7 +514,7 @@ def edit_message(conv_id, msg_id):
     images_json = json.dumps(images) if images else None
 
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-    mcp_mgr = _get_mcp() if enabled_servers else None
+    mcp_mgr = _mcp_for_conversation(conv, enabled_servers)
 
     new_msg = Message(
         id=str(uuid.uuid4()),

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -34,6 +34,7 @@ from .llm_proxy import stream_chat_completion
 from .tool_loop import stream_with_tools
 from .prompt_builder import build_chat_messages
 from .persistence import DbPersistencePolicy
+from .project_files_mcp import with_project_files
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,11 @@ class ChatRunner:
     def _build_stream(self, conv: Conversation, mcp_manager):
         messages = self.persistence.load_messages(conv)
         enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
+        if conv.project_id:
+            # Project conversations always get the project-files tools —
+            # membership in a project IS the toggle. This also pulls the
+            # server's tool_hint into the system prompt below.
+            enabled_servers = with_project_files(enabled_servers)
         messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
         tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None
         if tools:

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -125,10 +125,15 @@ class ChatRunner:
     def _build_stream(self, conv: Conversation, mcp_manager):
         messages = self.persistence.load_messages(conv)
         enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-        if conv.project_id:
-            # Project conversations always get the project-files tools —
-            # membership in a project IS the toggle. This also pulls the
-            # server's tool_hint into the system prompt below.
+        # Project conversations always get the project-files tools —
+        # membership in a project IS the toggle. This also pulls the
+        # server's tool_hint into the system prompt below. Membership is
+        # root-only, so spin-offs (project_id NULL) resolve through their
+        # root ancestor.
+        project_id = conv.project_id
+        if project_id is None and conv.parent_conversation_id and self.db is not None:
+            project_id = self.db.resolve_project_id(conv.id)
+        if project_id:
             enabled_servers = with_project_files(enabled_servers)
         messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
         tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -1,0 +1,332 @@
+"""Tests for the project-files MCP server and its scoping plumbing.
+
+Three layers:
+  1. The server's tool functions, called directly (FastMCP's decorator
+     returns the plain function) with LLM_DOCK_PROJECT_ROOT pointed at a
+     tmp directory — listing, reading, searching, and the unscoped /
+     traversal error paths.
+  2. The glue: ProjectScopedMCPManager env injection, with_project_files,
+     runtime._build_stream auto-enable, and routes._mcp_for_conversation.
+  3. One end-to-end call through a real MCPClientManager, spawning the
+     actual server subprocess with the env injected — proves the
+     stdio env plumbing works against the installed MCP SDK.
+"""
+import json
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("DASHBOARD_TOKEN", "test-token-pf-mcp")
+
+from chat import project_files as pf
+from chat import project_files_mcp
+from chat.project_files_mcp import (
+    PROJECT_ROOT_ENV,
+    SERVER_ID,
+    ProjectScopedMCPManager,
+    with_project_files,
+)
+from chat.mcp_servers import project_files_server as srv
+from chat.models import Conversation
+from chat.runtime import ChatRunner
+
+
+# ---------------------------------------------------------------------------
+# Server tool functions (direct calls)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def proj_root(tmp_path, monkeypatch):
+    root = tmp_path / "proj-1"
+    root.mkdir()
+    (root / "notes.md").write_text("hello project\nsecond LINE with Needle\n")
+    (root / "docs").mkdir()
+    (root / "docs" / "plan.txt").write_text("the needle is here\n")
+    (root / "docs" / "image.bin").write_bytes(b"\x00\x01\x02binary")
+    monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+    return root
+
+
+class TestUnscoped:
+    """Without the env var every tool refuses with a clear message."""
+
+    @pytest.fixture(autouse=True)
+    def no_env(self, monkeypatch):
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+
+    def test_list_files(self):
+        assert "not part of a project" in srv.list_files()
+
+    def test_read_file(self):
+        assert "not part of a project" in srv.read_file("notes.md")
+
+    def test_search_files(self):
+        assert "not part of a project" in srv.search_files("x")
+
+
+class TestListFiles:
+    def test_lists_tree_with_relative_paths(self, proj_root):
+        out = srv.list_files()
+        lines = out.splitlines()
+        assert "docs/" in lines
+        assert any(l.startswith("docs/plan.txt (") for l in lines)
+        assert any(l.startswith("notes.md (") for l in lines)
+
+    def test_subdirectory_listing(self, proj_root):
+        out = srv.list_files("docs")
+        assert "docs/plan.txt" in out
+        assert "notes.md" not in out
+
+    def test_missing_root_reads_as_no_files_yet(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(tmp_path / "never-created"))
+        assert srv.list_files() == "(the project has no files yet)"
+
+    def test_empty_root(self, tmp_path, monkeypatch):
+        root = tmp_path / "empty"
+        root.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        assert srv.list_files() == "(no files here)"
+
+    def test_traversal_rejected(self, proj_root):
+        out = srv.list_files("../..")
+        assert out.startswith("Error:")
+
+    def test_missing_subdir_is_an_error_not_a_crash(self, proj_root):
+        assert srv.list_files("nope").startswith("Error:")
+
+
+class TestReadFile:
+    def test_reads_content(self, proj_root):
+        assert srv.read_file("docs/plan.txt") == "the needle is here\n"
+
+    def test_missing_file(self, proj_root):
+        assert srv.read_file("nope.txt").startswith("Error:")
+
+    def test_binary_file_rejected(self, proj_root):
+        assert srv.read_file("docs/image.bin").startswith("Error:")
+
+    def test_traversal_rejected(self, proj_root):
+        assert srv.read_file("../outside.txt").startswith("Error:")
+
+    def test_symlink_rejected(self, proj_root, tmp_path):
+        secret = tmp_path / "secret.txt"
+        secret.write_text("outside")
+        os.symlink(secret, proj_root / "link.txt")
+        assert srv.read_file("link.txt").startswith("Error:")
+
+    def test_missing_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(tmp_path / "never-created"))
+        assert srv.read_file("x.txt").startswith("Error:")
+
+
+class TestSearchFiles:
+    def test_content_match_case_insensitive_with_line_numbers(self, proj_root):
+        out = srv.search_files("NEEDLE")
+        assert "docs/plan.txt:1: the needle is here" in out
+        assert "notes.md:2: second LINE with Needle" in out
+
+    def test_name_match(self, proj_root):
+        out = srv.search_files("plan")
+        assert "docs/plan.txt (name match)" in out
+
+    def test_binary_files_skipped(self, proj_root):
+        out = srv.search_files("binary")
+        assert "image.bin:" not in out
+
+    def test_scoped_to_subdirectory(self, proj_root):
+        out = srv.search_files("needle", path="docs")
+        assert "docs/plan.txt:1:" in out
+        assert "notes.md" not in out
+
+    def test_no_matches(self, proj_root):
+        assert srv.search_files("zzz-not-there") == "No matches."
+
+    def test_empty_query_rejected(self, proj_root):
+        assert srv.search_files("  ").startswith("Error:")
+
+    def test_traversal_rejected(self, proj_root):
+        assert srv.search_files("x", path="../..").startswith("Error:")
+
+    def test_missing_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(tmp_path / "never-created"))
+        assert "no files yet" in srv.search_files("x")
+
+    def test_truncation_cap(self, proj_root, monkeypatch):
+        monkeypatch.setattr(srv, "MAX_SEARCH_RESULTS", 2)
+        (proj_root / "many.txt").write_text("needle\n" * 10)
+        out = srv.search_files("needle")
+        assert "truncated at 2 matches" in out
+        # cap counts matches, not lines scanned: 2 matches + the notice
+        assert len(out.splitlines()) == 3
+
+
+# ---------------------------------------------------------------------------
+# Glue: scoped manager, auto-enable, routes helper
+# ---------------------------------------------------------------------------
+
+
+class FakeManager:
+    def __init__(self):
+        self.calls = []
+
+    def get_tools(self, server_id):
+        return [{"id": server_id}]
+
+    def get_all_tools(self, server_ids):
+        self.calls.append(("get_all_tools", list(server_ids)))
+        return [{"id": sid} for sid in server_ids]
+
+    def call_tool(self, server_id, tool_name, arguments, extra_env=None):
+        self.calls.append(("call_tool", server_id, tool_name, arguments, extra_env))
+        return ("ok", [])
+
+
+class TestScopedManager:
+    def test_injects_env_for_project_files_only(self):
+        inner = FakeManager()
+        scoped = ProjectScopedMCPManager(inner, "/data/projects/p1")
+        scoped.call_tool(SERVER_ID, "list_files", {})
+        scoped.call_tool("sympy-math", "solve_equation", {"equation": "x"})
+        assert inner.calls[0] == (
+            "call_tool", SERVER_ID, "list_files", {},
+            {PROJECT_ROOT_ENV: "/data/projects/p1"},
+        )
+        assert inner.calls[1][4] is None
+
+    def test_delegates_tool_listing(self):
+        inner = FakeManager()
+        scoped = ProjectScopedMCPManager(inner, "/p")
+        assert scoped.get_all_tools(["a", "b"]) == [{"id": "a"}, {"id": "b"}]
+        assert scoped.get_tools("a") == [{"id": "a"}]
+
+
+class TestWithProjectFiles:
+    def test_appends_when_absent(self):
+        assert with_project_files(["sympy-math"]) == ["sympy-math", SERVER_ID]
+
+    def test_no_duplicate_when_present(self):
+        assert with_project_files([SERVER_ID]) == [SERVER_ID]
+
+    def test_empty(self):
+        assert with_project_files([]) == [SERVER_ID]
+
+
+def _conv(**kw):
+    return Conversation(id="c1", title="t", main_service="svc", **kw)
+
+
+class FakePersistence:
+    def load_messages(self, conv):
+        return []
+
+
+class TestRuntimeAutoEnable:
+    def test_project_conversation_gets_project_files_tools_and_hint(self):
+        runner = ChatRunner(persistence=FakePersistence())
+        mgr = FakeManager()
+        conv = _conv(project_id="p1", mcp_servers_json=json.dumps(["sympy-math"]))
+        runner._build_stream(conv, mgr)
+        assert ("get_all_tools", ["sympy-math", SERVER_ID]) in mgr.calls
+
+    def test_project_conversation_with_no_toggles_still_gets_tools(self):
+        runner = ChatRunner(persistence=FakePersistence())
+        mgr = FakeManager()
+        runner._build_stream(_conv(project_id="p1"), mgr)
+        assert ("get_all_tools", [SERVER_ID]) in mgr.calls
+
+    def test_hint_lands_in_system_prompt(self):
+        from chat.prompt_builder import build_chat_messages
+        messages = build_chat_messages("base prompt", [], [SERVER_ID])
+        assert "list_files" in messages[0]["content"]
+
+    def test_non_project_conversation_unchanged(self):
+        runner = ChatRunner(persistence=FakePersistence())
+        mgr = FakeManager()
+        runner._build_stream(_conv(), mgr)
+        assert mgr.calls == []  # no enabled servers -> no tool discovery
+
+
+class TestRoutesHelper:
+    @pytest.fixture
+    def app(self, tmp_path):
+        app = Flask(__name__)
+        app.config["MCP_MANAGER"] = FakeManager()
+        app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
+        return app
+
+    def test_none_without_servers_or_project(self, app):
+        from chat.routes import _mcp_for_conversation
+        with app.app_context():
+            assert _mcp_for_conversation(_conv(), []) is None
+
+    def test_plain_manager_for_toggled_non_project_conversation(self, app):
+        from chat.routes import _mcp_for_conversation
+        with app.app_context():
+            mgr = _mcp_for_conversation(_conv(), ["sympy-math"])
+        assert mgr is app.config["MCP_MANAGER"]
+
+    def test_scoped_manager_for_project_conversation(self, app, tmp_path):
+        # NOTE: import the class inside the test, not at module top —
+        # test_mcp_admin_routes purges chat.* from sys.modules and
+        # re-imports, so the top-level binding can be a different class
+        # object than the one chat.routes instantiates (isinstance against
+        # it fails on suite ordering, not on behavior).
+        from chat.routes import _mcp_for_conversation
+        from chat.project_files_mcp import ProjectScopedMCPManager as CurrentScoped
+        with app.app_context():
+            mgr = _mcp_for_conversation(_conv(project_id="p1"), [])
+        assert isinstance(mgr, CurrentScoped)
+        mgr.call_tool(SERVER_ID, "list_files", {})
+        call = app.config["MCP_MANAGER"].calls[-1]
+        assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real subprocess spawn with env injection
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_call_tool_spawns_scoped_server(self, tmp_path):
+        from chat.mcp_client import MCPClientManager
+
+        root = tmp_path / "p-e2e"
+        root.mkdir()
+        (root / "hello.txt").write_text("end to end needle\n")
+
+        manager = MCPClientManager()
+        scoped = ProjectScopedMCPManager(manager, str(root))
+
+        text, artifacts = scoped.call_tool(SERVER_ID, "list_files", {})
+        assert "hello.txt" in text
+        assert artifacts == []
+
+        text, _ = scoped.call_tool(SERVER_ID, "read_file", {"path": "hello.txt"})
+        assert text == "end to end needle\n"
+
+        text, _ = scoped.call_tool(SERVER_ID, "search_files", {"query": "NEEDLE"})
+        assert "hello.txt:1: end to end needle" in text
+
+    def test_unscoped_call_reports_no_project(self):
+        from chat.mcp_client import MCPClientManager
+
+        manager = MCPClientManager()
+        text, _ = manager.call_tool(SERVER_ID, "list_files", {})
+        assert "not part of a project" in text
+
+    def test_tool_discovery_lists_all_three(self):
+        from chat.mcp_client import MCPClientManager
+
+        manager = MCPClientManager()
+        tools = manager.get_tools(SERVER_ID)
+        names = {t["function"]["name"] for t in tools}
+        assert names == {
+            f"{SERVER_ID}__list_files",
+            f"{SERVER_ID}__read_file",
+            f"{SERVER_ID}__search_files",
+        }

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -312,6 +312,10 @@ def _conv(**kw):
     return Conversation(id="c1", title="t", main_service="svc", **kw)
 
 
+def _conv2(conv_id, **kw):
+    return Conversation(id=conv_id, title="t", main_service="svc", **kw)
+
+
 class FakePersistence:
     def load_messages(self, conv):
         return []
@@ -376,6 +380,72 @@ class TestRoutesHelper:
         mgr.call_tool(SERVER_ID, "list_files", {})
         call = app.config["MCP_MANAGER"].calls[-1]
         assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
+
+
+class TestSpinoffInheritance:
+    """Membership is root-only: spin-offs keep project_id NULL and follow
+    their root ancestor. Tool scoping must resolve through the chain
+    (regression: codex 3.1)."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        from chat.db import ChatDB
+        from chat.models import Project
+        db = ChatDB(str(tmp_path / "chat.db"))
+        db.create_project(Project(id="p1", name="P"))
+        db.create_conversation(_conv2("root", project_id="p1"))
+        db.create_conversation(_conv2("child", parent_conversation_id="root"))
+        db.create_conversation(_conv2("grand", parent_conversation_id="child"))
+        db.create_conversation(_conv2("loner"))
+        return db
+
+    def test_resolve_project_id(self, db):
+        assert db.resolve_project_id("root") == "p1"
+        assert db.resolve_project_id("child") == "p1"
+        assert db.resolve_project_id("grand") == "p1"
+        assert db.resolve_project_id("loner") is None
+        assert db.resolve_project_id("missing") is None
+
+    def test_resolve_survives_a_parent_cycle(self, db):
+        # Impossible through the API; the walk must still terminate on
+        # corrupt data instead of hanging the request.
+        conn = db._get_conn()
+        try:
+            conn.execute(
+                "UPDATE conversations SET parent_conversation_id = 'grand' WHERE id = 'child'"
+            )
+            conn.commit()
+        finally:
+            db._close_conn(conn)
+        assert db.resolve_project_id("child") is None
+
+    def test_routes_scope_spinoff_to_root_project(self, db, tmp_path):
+        from chat.routes import _mcp_for_conversation
+        app = Flask(__name__)
+        app.config["MCP_MANAGER"] = FakeManager()
+        app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
+        app.config["CHAT_DB"] = db
+        child = db.get_conversation("child")
+        assert child.project_id is None  # root-only membership held
+        with app.app_context():
+            mgr = _mcp_for_conversation(child, [])
+        assert mgr is not None
+        mgr.call_tool(SERVER_ID, "list_files", {})
+        call = app.config["MCP_MANAGER"].calls[-1]
+        assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
+
+    def test_runtime_auto_enables_for_spinoff(self, db):
+        runner = ChatRunner(db=db, persistence=FakePersistence())
+        mgr = FakeManager()
+        runner._build_stream(db.get_conversation("grand"), mgr)
+        assert ("get_all_tools", [SERVER_ID]) in mgr.calls
+
+    def test_runtime_without_db_still_works_for_direct_membership(self, db):
+        # Ghost-chat shape: no db wired. Direct project_id still enables.
+        runner = ChatRunner(db=None, persistence=FakePersistence())
+        mgr = FakeManager()
+        runner._build_stream(db.get_conversation("root"), mgr)
+        assert ("get_all_tools", [SERVER_ID]) in mgr.calls
 
 
 class TestRunAsyncTimeout:

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -96,6 +96,17 @@ class TestListFiles:
         out = srv.list_files("../..")
         assert out.startswith("Error:")
 
+    def test_entry_cap_truncates_with_notice(self, proj_root, monkeypatch):
+        # regression: codex 1.1 — unbounded listings would blow the model
+        # context on a big-but-legitimate project
+        monkeypatch.setattr(srv, "MAX_LIST_ENTRIES", 3)
+        for i in range(6):
+            (proj_root / f"file-{i}.txt").write_text("x")
+        out = srv.list_files()
+        lines = out.splitlines()
+        assert len(lines) == 4  # 3 entries + notice
+        assert "truncated at 3 of" in lines[-1]
+
     def test_missing_subdir_is_an_error_not_a_crash(self, proj_root):
         assert srv.list_files("nope").startswith("Error:")
 
@@ -163,6 +174,59 @@ class TestSearchFiles:
         assert "truncated at 2 matches" in out
         # cap counts matches, not lines scanned: 2 matches + the notice
         assert len(out.splitlines()) == 3
+
+    def test_cap_enforced_after_name_match(self, tmp_path, monkeypatch):
+        # regression: codex 1.3 — a name match landing exactly on the cap
+        # let the same file's content matches overshoot it
+        root = tmp_path / "cap-proj"
+        root.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        monkeypatch.setattr(srv, "MAX_SEARCH_RESULTS", 2)
+        (root / "aaa.txt").write_text("needle\n")            # content match 1
+        (root / "needle-b.txt").write_text("needle inside\n")  # name match 2, content would be 3
+        out = srv.search_files("needle")
+        lines = out.splitlines()
+        assert len(lines) == 3  # exactly cap + notice, no overshoot
+        assert "needle-b.txt (name match)" in lines
+        assert not any("needle-b.txt:1:" in l for l in lines)
+        assert "truncated at 2 matches" in lines[-1]
+
+    def test_scan_budget_stops_early_with_notice(self, tmp_path, monkeypatch):
+        # regression: codex 1.2 — a no-match query must stop reading files
+        # once the byte budget is spent instead of grinding to the timeout
+        root = tmp_path / "budget-proj"
+        root.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        monkeypatch.setattr(srv, "MAX_SEARCH_SCAN_BYTES", 10)
+        (root / "aaa.txt").write_text("needle A\n")  # 9 bytes: within budget
+        (root / "bbb.txt").write_text("needle B\n")  # would exceed: not scanned
+        out = srv.search_files("needle")
+        assert "aaa.txt:1:" in out
+        assert "bbb.txt" not in out
+        assert "scan budget reached" in out
+
+    def test_scan_budget_notice_even_with_no_matches(self, tmp_path, monkeypatch):
+        root = tmp_path / "budget-proj-2"
+        root.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        monkeypatch.setattr(srv, "MAX_SEARCH_SCAN_BYTES", 1)
+        (root / "aaa.txt").write_text("nothing here\n")
+        out = srv.search_files("zzz-not-there")
+        assert out.startswith("No matches.")
+        assert "scan budget reached" in out
+
+    def test_oversized_files_do_not_consume_budget(self, tmp_path, monkeypatch):
+        # files read_text would reject are skipped before budget accounting
+        root = tmp_path / "budget-proj-3"
+        root.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        monkeypatch.setattr(srv, "MAX_SEARCH_SCAN_BYTES", 20)
+        big = "x" * (pf.MAX_TEXT_EDIT_BYTES + 1)
+        (root / "aaa-big.txt").write_text(big)
+        (root / "bbb.txt").write_text("needle\n")
+        out = srv.search_files("needle")
+        assert "bbb.txt:1: needle" in out
+        assert "scan budget" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -284,6 +348,31 @@ class TestRoutesHelper:
         mgr.call_tool(SERVER_ID, "list_files", {})
         call = app.config["MCP_MANAGER"].calls[-1]
         assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
+
+
+class TestRunAsyncTimeout:
+    def test_timeout_cancels_the_coroutine(self):
+        # regression: codex 1.2 — a timed-out call must not leave the
+        # coroutine (and the server subprocess it holds) running on the
+        # loop after the caller has already received the error
+        import asyncio
+        import concurrent.futures
+        import threading
+        from chat.mcp_client import MCPClientManager
+
+        manager = MCPClientManager()
+        cancelled = threading.Event()
+
+        async def slow():
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        with pytest.raises(concurrent.futures.TimeoutError):
+            manager._run_async(slow(), timeout=0.2)
+        assert cancelled.wait(timeout=5)
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -134,6 +134,34 @@ class TestReadFile:
         monkeypatch.setenv(PROJECT_ROOT_ENV, str(tmp_path / "never-created"))
         assert srv.read_file("x.txt").startswith("Error:")
 
+    def test_long_file_is_chunked_with_continuation_offset(self, proj_root, monkeypatch):
+        # regression: codex 2.1 — a near-2MB file must not enter the model
+        # context in one tool response
+        monkeypatch.setattr(srv, "MAX_READ_CHARS", 10)
+        (proj_root / "long.txt").write_text("abcdefghijKLMNO")
+        first = srv.read_file("long.txt")
+        assert first.startswith("abcdefghij")
+        assert "offset=10" in first
+        assert "KLMNO" not in first.split("\n(truncated")[0]
+        second = srv.read_file("long.txt", offset=10)
+        assert second == "KLMNO"  # final chunk: no notice
+
+    def test_near_cap_file_response_is_bounded(self, proj_root):
+        big = "x" * (pf.MAX_TEXT_EDIT_BYTES - 100)
+        (proj_root / "big.txt").write_text(big)
+        out = srv.read_file("big.txt")
+        assert len(out) <= srv.MAX_READ_CHARS + 200  # chunk + notice, never the whole file
+        assert "call read_file again with offset=" in out
+
+    def test_offset_validation(self, proj_root):
+        assert srv.read_file("notes.md", offset=-1).startswith("Error:")
+        assert srv.read_file("notes.md", offset=True).startswith("Error:")
+        assert "past the end" in srv.read_file("notes.md", offset=10_000)
+
+    def test_zero_offset_on_empty_file_is_fine(self, proj_root):
+        (proj_root / "empty.txt").write_text("")
+        assert srv.read_file("empty.txt") == ""
+
 
 class TestSearchFiles:
     def test_content_match_case_insensitive_with_line_numbers(self, proj_root):


### PR DESCRIPTION
Phase 4 of the projects feature (#77, #78, #79 shipped phases 1–3): the model can now reach the project's file area through a built-in MCP server.

## What's in here

**New built-in server `project-files`** (`dashboard/chat/mcp_servers/project_files_server.py`) with three read-only tools:
- `list_files(path="")` — file tree with relative paths and sizes
- `read_file(path)` — UTF-8 text files up to 2 MB
- `search_files(query, path="")` — case-insensitive substring over file names and text contents, capped at 200 matches with an explicit truncation notice

All path handling is delegated to `chat/project_files.py` (the same layer behind the HTTP file routes), so `..` traversal, absolute paths, symlink escapes, binary files and oversized files are rejected identically to the UI.

**Per-conversation scoping via spawn environment.** Built-in MCP servers are stdio subprocesses spawned per call from a static registry config, so the project scope travels as `LLM_DOCK_PROJECT_ROOT` in the subprocess environment:
- `_open_streams` passes `config["env"]` merged over the SDK's `get_default_environment()`
- `MCPClientManager.call_tool` grew an `extra_env` parameter (per-call, never mutates the shared config)
- `ProjectScopedMCPManager` (new `chat/project_files_mcp.py`) wraps the process-wide manager per run, injecting the env only for `project-files` calls; built in routes where the conversation is known

The model never sees or supplies a project id. Unscoped calls (server manually enabled on a non-project conversation) get a clear "not part of a project" answer.

**Auto-enable for project conversations.** `runtime._build_stream` appends `project-files` to the enabled servers whenever `conv.project_id` is set — membership in a project is the toggle. This drives both tool discovery and the `tool_hint` in the system prompt. `routes._mcp_for_conversation` builds a manager for project conversations even when no servers are toggled (previously `mcp_manager` was only created when the toggle list was non-empty).

## Tests

39 new tests in `dashboard/tests/test_project_files_mcp.py`:
- direct tool-function coverage: listing (subtree, missing root, empty, traversal), reading (binary/symlink/missing rejection), searching (line numbers, name matches, subdir scope, binary skip, truncation cap)
- glue: env injection targets only `project-files`, `with_project_files` dedup, runtime auto-enable, hint in system prompt, routes helper scoping
- end-to-end: real server subprocess spawned through `MCPClientManager` with injected env — proves the stdio env plumbing against the installed MCP SDK

Full backend suite: 516 passed.