### PR TITLE
refactor(projects): arch hygiene — single project resolution, root-only trigger, stable error codes

### DIFF
--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -109,6 +109,24 @@ WHEN NEW.project_id IS NOT NULL
 BEGIN
     SELECT RAISE(ABORT, 'project not found');
 END;
+
+-- Root-only membership: spin-offs follow their root ancestor and must never
+-- carry their own project_id (resolve_project_id and the sidebar both rely
+-- on this). The HTTP routes reject it too; these make the model
+-- self-defending against any future write path that forgets the rule.
+CREATE TRIGGER IF NOT EXISTS trg_conversations_rootonly_insert
+BEFORE INSERT ON conversations
+WHEN NEW.parent_conversation_id IS NOT NULL AND NEW.project_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'spin-off conversations cannot carry a project');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_conversations_rootonly_update
+BEFORE UPDATE OF project_id, parent_conversation_id ON conversations
+WHEN NEW.parent_conversation_id IS NOT NULL AND NEW.project_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'spin-off conversations cannot carry a project');
+END;
 """
 
 

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -48,11 +48,18 @@ def configure_max_content_length(app):
 
 
 class ProjectFilesError(Exception):
-    """Client-facing error with an HTTP status."""
+    """Client-facing error with an HTTP status.
 
-    def __init__(self, message: str, status: int = 400):
+    `code` is a stable machine-readable identifier for conditions the
+    frontend must branch on (conflict bars, overwrite prompts) — clients
+    match on it, never on the human-readable message, so wording can
+    change freely. Only conditions with a UI behavior get a code.
+    """
+
+    def __init__(self, message: str, status: int = 400, code: str = None):
         super().__init__(message)
         self.status = status
+        self.code = code
 
 
 def default_storage_root() -> str:
@@ -248,7 +255,7 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
     if os.path.isdir(abs_target):
         raise ProjectFilesError("a directory with that name exists", status=409)
     if os.path.exists(abs_target) and not overwrite:
-        raise ProjectFilesError("file already exists", status=409)
+        raise ProjectFilesError("file already exists", status=409, code="already_exists")
     # Same permission fidelity as write_text: mkstemp stages at 0600, so an
     # overwriting upload must keep the target's mode and a fresh one gets
     # a normal default instead of 0600.
@@ -285,7 +292,7 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
                 try:
                     os.link(tmp_path, abs_target)
                 except FileExistsError:
-                    raise ProjectFilesError("file already exists", status=409)
+                    raise ProjectFilesError("file already exists", status=409, code="already_exists")
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -367,7 +374,7 @@ def write_text(root: str, rel_path: str, content: str,
     publish_mode = 0o644
     if os.path.lexists(abs_path):
         if create_only:
-            raise ProjectFilesError("file already exists", status=409)
+            raise ProjectFilesError("file already exists", status=409, code="already_exists")
         st = os.lstat(abs_path)
         if not stat_mod.S_ISREG(st.st_mode):
             raise ProjectFilesError("not a regular file", status=409)
@@ -376,14 +383,14 @@ def write_text(root: str, rel_path: str, content: str,
             # A file too large for read_text can't be what the client
             # loaded — it definitely changed. Otherwise compare content.
             if st.st_size > MAX_TEXT_EDIT_BYTES:
-                raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+                raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
             with open(abs_path, "rb") as f:
                 current = f.read()
             if _content_revision(current) != base_revision:
-                raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+                raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
     elif base_revision is not None:
         # Client edited a file that has since been deleted/renamed.
-        raise ProjectFilesError("file changed on disk since it was loaded", status=409)
+        raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
 
     with _fs_errors():
         fd, tmp_path = tempfile.mkstemp(prefix=".edit-", suffix=".tmp", dir=abs_dir)
@@ -396,7 +403,7 @@ def write_text(root: str, rel_path: str, content: str,
                 try:
                     os.link(tmp_path, abs_path)
                 except FileExistsError:
-                    raise ProjectFilesError("file already exists", status=409)
+                    raise ProjectFilesError("file already exists", status=409, code="already_exists")
             else:
                 os.replace(tmp_path, abs_path)
         finally:
@@ -416,7 +423,7 @@ def mkdir(root: str, rel_path: str) -> dict:
     # by build_tree) and must count as occupying its name — exists() would
     # follow the link and report the slot free.
     if os.path.lexists(abs_path):
-        raise ProjectFilesError("path already exists", status=409)
+        raise ProjectFilesError("path already exists", status=409, code="already_exists")
     with _fs_errors():
         os.makedirs(abs_path)
     rel = "/".join(parts)
@@ -440,7 +447,7 @@ def move(root: str, rel_src: str, rel_dst: str) -> dict:
     if not os.path.lexists(abs_src):
         raise ProjectFilesError("source not found", status=404)
     if os.path.lexists(abs_dst):
-        raise ProjectFilesError("destination already exists", status=409)
+        raise ProjectFilesError("destination already exists", status=409, code="already_exists")
     if dst_parts[:len(src_parts)] == src_parts:
         raise ProjectFilesError("cannot move a directory into itself")
     if not os.path.isdir(os.path.dirname(abs_dst)):

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -51,7 +51,10 @@ def _revalidate_or_cleanup(project_id):
 
 @chat_bp.errorhandler(pf.ProjectFilesError)
 def _handle_pf_error(e):
-    return jsonify({"error": str(e)}), e.status
+    body = {"error": str(e)}
+    if e.code:
+        body["code"] = e.code
+    return jsonify(body), e.status
 
 
 @chat_bp.route("/api/chat/projects/<project_id>/files", methods=["GET"])

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -69,21 +69,34 @@ def _get_run_manager():
     return current_app.config["CHAT_RUN_MANAGER"]
 
 
-def _mcp_for_conversation(conv, enabled_servers):
+def _effective_project_id(conv):
+    """The conversation's effective project. Membership is root-only: a
+    spin-off keeps project_id NULL and follows its root ancestor.
+
+    This is the SINGLE owner of project resolution for a chat turn: it is
+    called once when the run is created, and the result is snapshotted into
+    the run (manager scoping AND tool auto-enable both consume the same
+    value), so a root moved mid-turn cannot split scope from toggles.
+    """
+    if conv.project_id:
+        return conv.project_id
+    if conv.parent_conversation_id:
+        return _get_db().resolve_project_id(conv.id)
+    return None
+
+
+def _mcp_for_conversation(conv, enabled_servers, project_id):
     """MCP manager for a run, or None when the turn has no tools.
 
-    Project conversations always get a manager — the project-files server
-    is auto-enabled for them (see runtime._build_stream) — wrapped so its
-    subprocess spawns learn the project's directory via the environment.
+    project_id is the pre-resolved effective project (see
+    _effective_project_id). Project conversations always get a manager —
+    the project-files server is auto-enabled for them (see
+    runtime._build_stream) — wrapped so its subprocess spawns learn the
+    project's directory via the environment.
     """
     from . import project_files as pf
     from .project_files_mcp import ProjectScopedMCPManager
 
-    # Membership is root-only: a spin-off keeps project_id NULL and follows
-    # its root ancestor, so scoping must use the resolved project.
-    project_id = conv.project_id
-    if project_id is None and conv.parent_conversation_id:
-        project_id = _get_db().resolve_project_id(conv.id)
     if not (enabled_servers or project_id):
         return None
     manager = _get_mcp()
@@ -424,7 +437,8 @@ def delete_conversations_batch():
 
 
 def _start_run_response(db, conv, user_msg, mcp_manager, is_first,
-                        first_user_content, delete_from_seq=None):
+                        first_user_content, delete_from_seq=None,
+                        effective_project_id=None):
     """Atomically persist the user message + a queued run (rejecting a second
     run while one is active), start the background job, and return an SSE
     Response that observes it.
@@ -450,7 +464,8 @@ def _start_run_response(db, conv, user_msg, mcp_manager, is_first,
     manager = _get_run_manager()
     q = manager.subscribe(run.id)
     manager.start(conv, run, mcp_manager=mcp_manager, is_first=is_first,
-                  first_user_content=first_user_content)
+                  first_user_content=first_user_content,
+                  effective_project_id=effective_project_id)
 
     return Response(
         stream_with_context(manager.observe(run.id, q)),
@@ -491,9 +506,11 @@ def send_message(conv_id):
     )
 
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-    mcp_manager = _mcp_for_conversation(conv, enabled_servers)
+    project_id = _effective_project_id(conv)
+    mcp_manager = _mcp_for_conversation(conv, enabled_servers, project_id)
 
-    return _start_run_response(db, conv, user_msg, mcp_manager, is_first, content)
+    return _start_run_response(db, conv, user_msg, mcp_manager, is_first, content,
+                               effective_project_id=project_id)
 
 
 @chat_bp.route("/api/chat/conversations/<conv_id>/messages/<msg_id>", methods=["PUT"])
@@ -519,7 +536,8 @@ def edit_message(conv_id, msg_id):
     images_json = json.dumps(images) if images else None
 
     enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
-    mcp_mgr = _mcp_for_conversation(conv, enabled_servers)
+    project_id = _effective_project_id(conv)
+    mcp_mgr = _mcp_for_conversation(conv, enabled_servers, project_id)
 
     new_msg = Message(
         id=str(uuid.uuid4()),
@@ -534,7 +552,8 @@ def edit_message(conv_id, msg_id):
     # active-run guard), so a rejected edit doesn't destroy the tail. An edit
     # replaces an existing turn, so it never triggers auto-title.
     return _start_run_response(db, conv, new_msg, mcp_mgr, is_first=False,
-                               first_user_content=content, delete_from_seq=msg.seq)
+                               first_user_content=content, delete_from_seq=msg.seq,
+                               effective_project_id=project_id)
 
 
 # -- Runs (observation + cancellation, issue #58) --

--- a/dashboard/chat/run_manager.py
+++ b/dashboard/chat/run_manager.py
@@ -94,14 +94,20 @@ class ChatRunManager:
 
     # -- starting a run ---------------------------------------------------
 
-    def start(self, conv, run, mcp_manager=None, is_first=False, first_user_content=""):
+    def start(self, conv, run, mcp_manager=None, is_first=False, first_user_content="",
+              effective_project_id=None):
         """Submit the run to the worker pool and return immediately.
 
         The caller should already have subscribed an observer to the bus for
         run.id (see subscribe) so no early events are missed.
+
+        effective_project_id is the conversation's resolved project,
+        snapshotted at run creation (routes._effective_project_id) — the
+        runner consumes it verbatim instead of re-resolving.
         """
         self._executor.submit(
             self._execute, conv, run, mcp_manager, is_first, first_user_content,
+            effective_project_id,
         )
 
     def request_cancel(self, run_id):
@@ -145,13 +151,15 @@ class ChatRunManager:
             return None
         return self.request_cancel(run.id)
 
-    def _execute(self, conv, run, mcp_manager, is_first, first_user_content):
+    def _execute(self, conv, run, mcp_manager, is_first, first_user_content,
+                 effective_project_id=None):
         cancel_event = threading.Event()
         with self._flags_lock:
             self._cancel_flags[run.id] = cancel_event
         try:
             msg = self.runner.run(
-                run, ChatTurnRequest(conversation=conv, mcp_manager=mcp_manager),
+                run, ChatTurnRequest(conversation=conv, mcp_manager=mcp_manager,
+                                     effective_project_id=effective_project_id),
                 cancel_check=cancel_event.is_set,
             )
             # Auto-title runs here (not in the SSE response) so a first-message

--- a/dashboard/chat/runtime.py
+++ b/dashboard/chat/runtime.py
@@ -106,6 +106,12 @@ class ChatTurnRequest:
     than read from Flask globals."""
     conversation: Conversation
     mcp_manager: object = None
+    # The conversation's resolved project (root-only membership means a
+    # spin-off's own project_id is NULL), snapshotted when the run was
+    # created — see routes._effective_project_id, the single owner of that
+    # resolution. The runner consumes it verbatim so manager scoping and
+    # tool auto-enable can never disagree about the effective project.
+    effective_project_id: Optional[str] = None
 
 
 class ChatRunner:
@@ -122,18 +128,15 @@ class ChatRunner:
         if self.event_bus is not None:
             self.event_bus.publish(run_id, ChatRuntimeEvent(type, data or {}))
 
-    def _build_stream(self, conv: Conversation, mcp_manager):
+    def _build_stream(self, conv: Conversation, mcp_manager, effective_project_id=None):
         messages = self.persistence.load_messages(conv)
         enabled_servers = json.loads(conv.mcp_servers_json) if conv.mcp_servers_json else []
         # Project conversations always get the project-files tools —
         # membership in a project IS the toggle. This also pulls the
-        # server's tool_hint into the system prompt below. Membership is
-        # root-only, so spin-offs (project_id NULL) resolve through their
-        # root ancestor.
-        project_id = conv.project_id
-        if project_id is None and conv.parent_conversation_id and self.db is not None:
-            project_id = self.db.resolve_project_id(conv.id)
-        if project_id:
+        # server's tool_hint into the system prompt below. The project was
+        # resolved ONCE at run creation (see ChatTurnRequest) — do not
+        # re-resolve here, or scoping and auto-enable could diverge.
+        if effective_project_id:
             enabled_servers = with_project_files(enabled_servers)
         messages_array = build_chat_messages(conv.main_system_prompt, messages, enabled_servers)
         tools = mcp_manager.get_all_tools(enabled_servers) if mcp_manager and enabled_servers else None
@@ -190,7 +193,7 @@ class ChatRunner:
         last_parse_warning = None
 
         try:
-            stream = self._build_stream(conv, mcp_manager)
+            stream = self._build_stream(conv, mcp_manager, request.effective_project_id)
             for event_type, data in stream:
                 if cancel_check is not None and cancel_check():
                     # Stop the model/tool loop promptly: closing the generator

--- a/dashboard/frontend/src/api.js
+++ b/dashboard/frontend/src/api.js
@@ -29,11 +29,18 @@ export async function fetchAPI(endpoint, options = {}) {
   if (!response.ok) {
     const text = await response.text()
     let msg = `HTTP ${response.status}`
+    let code = null
     try {
       const data = JSON.parse(text)
       msg = typeof data.error === 'string' ? data.error : msg
+      // Stable machine-readable identifier for errors the UI branches on
+      // (e.g. 'revision_conflict', 'already_exists') — match on err.code,
+      // never on the message text.
+      if (typeof data.code === 'string') code = data.code
     } catch { /* not JSON */ }
-    throw new Error(msg)
+    const err = new Error(msg)
+    if (code) err.code = code
+    throw err
   }
 
   return response.json()

--- a/dashboard/frontend/src/api.test.js
+++ b/dashboard/frontend/src/api.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchAPI, TOKEN_KEY } from './api'
+
+// Adapter-level transport tests (regression: codex #82 1.3): the component
+// tests manufacture errors that already carry `code`, so without these the
+// JSON→Error.code plumbing could silently break while everything stays green.
+
+beforeEach(() => {
+  localStorage.setItem(TOKEN_KEY, 'test-token')
+})
+
+afterEach(() => {
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(response) {
+  const mock = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+describe('fetchAPI error-code transport', () => {
+  it('attaches the stable code from a coded error body', async () => {
+    stubFetch({
+      ok: false,
+      status: 409,
+      text: async () => JSON.stringify({ error: 'file changed on disk since it was loaded', code: 'revision_conflict' }),
+    })
+    const err = await fetchAPI('/x').catch(e => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toBe('file changed on disk since it was loaded')
+    expect(err.code).toBe('revision_conflict')
+  })
+
+  it('leaves code undefined on an uncoded error body', async () => {
+    stubFetch({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ error: 'bad path' }),
+    })
+    const err = await fetchAPI('/x').catch(e => e)
+    expect(err.message).toBe('bad path')
+    expect(err.code).toBeUndefined()
+  })
+
+  it('survives a non-JSON error body', async () => {
+    stubFetch({ ok: false, status: 502, text: async () => 'gateway exploded' })
+    const err = await fetchAPI('/x').catch(e => e)
+    expect(err.message).toBe('HTTP 502')
+    expect(err.code).toBeUndefined()
+  })
+
+  it('returns the parsed body on success', async () => {
+    stubFetch({ ok: true, status: 200, json: async () => ({ ok: true }) })
+    await expect(fetchAPI('/x')).resolves.toEqual({ ok: true })
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.jsx
@@ -82,8 +82,9 @@ export default function ProjectFileEditor({ projectId, path, isNew = false, onCl
       setDirty(contentRef.current !== submitted)
       onSaved?.()
     } catch (err) {
-      if (err.message.includes('changed on disk') || err.message.includes('already exists')) {
-        setConflict(err.message.includes('already exists')
+      // Branch on the API's stable error code, not the message wording.
+      if (err.code === 'revision_conflict' || err.code === 'already_exists') {
+        setConflict(err.code === 'already_exists'
           ? 'A file with this name already exists on disk.'
           : 'The file changed on disk since it was loaded.')
       } else {

--- a/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectFileEditor.test.jsx
@@ -21,6 +21,10 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+// The real API attaches a stable `code` to conflict errors (see api.js);
+// the editor branches on it, so mocked rejections must carry it too.
+const apiError = (msg, code) => Object.assign(new Error(msg), { code })
+
 async function renderEditor(props = {}) {
   const onClose = vi.fn()
   const onSaved = vi.fn()
@@ -65,7 +69,7 @@ describe('ProjectFileEditor', () => {
 
   it('a 409 shows the conflict bar; Overwrite anyway retries without a base', async () => {
     mockSave
-      .mockRejectedValueOnce(new Error('file changed on disk since it was loaded'))
+      .mockRejectedValueOnce(apiError('file changed on disk since it was loaded', 'revision_conflict'))
       .mockResolvedValueOnce({ path: 'notes.md', revision: 'r102' })
     await renderEditor()
     fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
@@ -78,7 +82,7 @@ describe('ProjectFileEditor', () => {
   })
 
   it('conflict Reload discards local edits and refetches', async () => {
-    mockSave.mockRejectedValueOnce(new Error('file changed on disk since it was loaded'))
+    mockSave.mockRejectedValueOnce(apiError('file changed on disk since it was loaded', 'revision_conflict'))
     await renderEditor()
     fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
     fireEvent.click(screen.getByText('Save'))
@@ -141,7 +145,7 @@ describe('ProjectFileEditor', () => {
   })
 
   it('a create-only 409 shows the already-exists conflict; Reload opens the on-disk file and drops create mode', async () => {
-    mockSave.mockRejectedValueOnce(new Error('file already exists'))
+    mockSave.mockRejectedValueOnce(apiError('file already exists', 'already_exists'))
     await renderEditor({ isNew: true })
     fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })
     fireEvent.click(screen.getByText('Save'))
@@ -159,7 +163,7 @@ describe('ProjectFileEditor', () => {
 
   it('a create-only 409 Overwrite anyway forces a plain save', async () => {
     mockSave
-      .mockRejectedValueOnce(new Error('file already exists'))
+      .mockRejectedValueOnce(apiError('file already exists', 'already_exists'))
       .mockResolvedValueOnce({ path: 'notes.md', revision: 'rf' })
     await renderEditor({ isNew: true })
     fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'mine' } })

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -213,10 +213,10 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
         try {
           await uploadProjectFile(project.id, file, { dir })
         } catch (err) {
-          if (err.message === 'file already exists' &&
+          if (err.code === 'already_exists' &&
               window.confirm(`"${file.name}" already exists. Overwrite?`)) {
             await uploadProjectFile(project.id, file, { dir, overwrite: true })
-          } else if (err.message !== 'file already exists') {
+          } else if (err.code !== 'already_exists') {
             throw err
           }
         }

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -98,7 +98,7 @@ describe('ProjectPage file tree', () => {
 
   it('offers overwrite when the upload conflicts', async () => {
     mockUpload
-      .mockRejectedValueOnce(new Error('file already exists'))
+      .mockRejectedValueOnce(Object.assign(new Error('file already exists'), { code: 'already_exists' }))
       .mockResolvedValueOnce({})
     vi.spyOn(window, 'confirm').mockReturnValue(true)
     await renderPage()

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -83,8 +83,15 @@ export async function uploadProjectFile(projectId, file, { dir = '', overwrite =
   })
   if (!response.ok) {
     let msg = `HTTP ${response.status}`
-    try { msg = (await response.json()).error || msg } catch { /* not JSON */ }
-    throw new Error(msg)
+    let code = null
+    try {
+      const data = await response.json()
+      msg = data.error || msg
+      if (typeof data.code === 'string') code = data.code
+    } catch { /* not JSON */ }
+    const err = new Error(msg)
+    if (code) err.code = code
+    throw err
   }
   return response.json()
 }

--- a/dashboard/frontend/src/services/chat.upload.test.js
+++ b/dashboard/frontend/src/services/chat.upload.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { uploadProjectFile } from './chat'
+import { TOKEN_KEY } from '../api'
+
+// uploadProjectFile bypasses fetchAPI (multipart), so its error-code
+// transport needs its own adapter test (regression: codex #82 1.3).
+
+beforeEach(() => {
+  localStorage.setItem(TOKEN_KEY, 'test-token')
+})
+
+afterEach(() => {
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+describe('uploadProjectFile error-code transport', () => {
+  it('attaches the stable code from a coded 409', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'file already exists', code: 'already_exists' }),
+    }))
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' })
+    const err = await uploadProjectFile('p1', file).catch(e => e)
+    expect(err.message).toBe('file already exists')
+    expect(err.code).toBe('already_exists')
+  })
+
+  it('leaves code undefined on an uncoded error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({ error: 'file too large' }),
+    }))
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' })
+    const err = await uploadProjectFile('p1', file).catch(e => e)
+    expect(err.message).toBe('file too large')
+    expect(err.code).toBeUndefined()
+  })
+
+  it('returns the node on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ path: 'a.txt' }),
+    }))
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' })
+    await expect(uploadProjectFile('p1', file)).resolves.toEqual({ path: 'a.txt' })
+  })
+})

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -746,3 +746,66 @@ def test_project_delete_removes_files_dir(client, tmp_path):
     r = client.delete(f"{PROJECTS_PATH}/{pid}", headers=_auth())
     assert r.status_code == 200
     assert not files_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Stable error codes (codex arch review rec 4)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCodes:
+    """Conditions the frontend branches on carry a stable machine-readable
+    `code` in the error body — clients match on it, never on the message
+    wording, so messages can change freely."""
+
+    def _put(self, client, pid, **body):
+        return client.put(f"{PROJECTS_PATH}/{pid}/files/content",
+                          json=body, headers=_auth())
+
+    def test_revision_conflict(self, client):
+        pid = _mkproject(client)
+        r = self._put(client, pid, path="n.md", content="one", create_only=True)
+        assert r.status_code == 200
+        r = self._put(client, pid, path="n.md", content="two", base_revision="0" * 16)
+        assert r.status_code == 409
+        assert r.get_json()["code"] == "revision_conflict"
+
+    def test_create_only_conflict(self, client):
+        pid = _mkproject(client)
+        assert self._put(client, pid, path="n.md", content="one",
+                         create_only=True).status_code == 200
+        r = self._put(client, pid, path="n.md", content="two", create_only=True)
+        assert r.status_code == 409
+        assert r.get_json()["code"] == "already_exists"
+
+    def test_upload_conflict(self, client):
+        pid = _mkproject(client)
+        assert _upload(client, pid, "a.txt").status_code == 201
+        r = _upload(client, pid, "a.txt")
+        assert r.status_code == 409
+        assert r.get_json()["code"] == "already_exists"
+
+    def test_mkdir_conflict(self, client):
+        pid = _mkproject(client)
+        mk = lambda: client.post(f"{PROJECTS_PATH}/{pid}/files/mkdir",
+                                 json={"path": "d"}, headers=_auth())
+        assert mk().status_code == 201
+        r = mk()
+        assert r.status_code == 409
+        assert r.get_json()["code"] == "already_exists"
+
+    def test_move_conflict(self, client):
+        pid = _mkproject(client)
+        _upload(client, pid, "a.txt")
+        _upload(client, pid, "b.txt")
+        r = client.post(f"{PROJECTS_PATH}/{pid}/files/move",
+                        json={"path": "a.txt", "new_path": "b.txt"}, headers=_auth())
+        assert r.status_code == 409
+        assert r.get_json()["code"] == "already_exists"
+
+    def test_uncoded_errors_have_no_code_key(self, client):
+        pid = _mkproject(client)
+        r = client.get(f"{PROJECTS_PATH}/{pid}/files/content?path=../x",
+                       headers=_auth())
+        assert r.status_code == 400
+        assert "code" not in r.get_json()

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -359,12 +359,62 @@ class TestRuntimeAutoEnable:
         runner._build_stream(_conv(project_id="p1"), mgr)
         assert mgr.calls == []
 
-    def test_run_passes_the_snapshot_through(self):
-        # ChatTurnRequest.effective_project_id is what reaches _build_stream.
+class TestSnapshotThreading:
+    """The snapshot must actually travel start() → executor → _execute →
+    ChatTurnRequest → run() → _build_stream, not merely exist as a field
+    (regression: codex #82 1.2)."""
+
+    def test_run_manager_threads_snapshot_into_the_request(self):
+        import threading as _threading
+        from types import SimpleNamespace
+        from chat.db import ChatDB
+        from chat.event_bus import EventBus
+        from chat.run_manager import ChatRunManager
+
+        manager = ChatRunManager(ChatDB(":memory:"), EventBus())
+        captured = {}
+        done = _threading.Event()
+
+        class SpyRunner:
+            def run(self, run, request, cancel_check=None):
+                captured["request"] = request
+                done.set()
+                return None
+
+        manager.runner = SpyRunner()
+        conv = _conv(project_id="p1")
+        try:
+            manager.start(conv, SimpleNamespace(id="r1"), mcp_manager=None,
+                          effective_project_id="p9")
+            assert done.wait(timeout=5)
+        finally:
+            manager.shutdown()
+        assert captured["request"].effective_project_id == "p9"
+        assert captured["request"].conversation is conv
+
+    def test_dbless_run_consumes_the_snapshot(self):
+        # The ephemeral-caller contract (the Ghost Chat #57 shape): no db
+        # wired, the run-creation site passes the snapshot explicitly, and
+        # it reaches _build_stream through run() itself — resolution stays
+        # with the caller, never the runner (codex #82 1.1).
+        from types import SimpleNamespace
+        from chat.persistence import NullPersistencePolicy
         from chat.runtime import ChatTurnRequest
-        req = ChatTurnRequest(conversation=_conv(), mcp_manager=FakeManager(),
-                              effective_project_id="p9")
-        assert req.effective_project_id == "p9"
+
+        captured = {}
+
+        class CapturingRunner(ChatRunner):
+            def _build_stream(self, conv, mcp_manager, effective_project_id=None):
+                captured["project_id"] = effective_project_id
+                yield ("done", {"content": "ok", "reasoning_content": None})
+
+        runner = CapturingRunner(db=None, persistence=NullPersistencePolicy())
+        conv = _conv(project_id="p1")
+        msg = runner.run(SimpleNamespace(id="r1"),
+                         ChatTurnRequest(conversation=conv, mcp_manager=None,
+                                         effective_project_id="p1"))
+        assert captured["project_id"] == "p1"
+        assert msg is not None and msg.content == "ok"
 
 
 class TestRoutesHelper:

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -322,17 +322,21 @@ class FakePersistence:
 
 
 class TestRuntimeAutoEnable:
+    """_build_stream consumes the effective project snapshotted at run
+    creation (ChatTurnRequest.effective_project_id) — it never re-resolves,
+    so the runner is exercised with the id passed explicitly."""
+
     def test_project_conversation_gets_project_files_tools_and_hint(self):
         runner = ChatRunner(persistence=FakePersistence())
         mgr = FakeManager()
         conv = _conv(project_id="p1", mcp_servers_json=json.dumps(["sympy-math"]))
-        runner._build_stream(conv, mgr)
+        runner._build_stream(conv, mgr, "p1")
         assert ("get_all_tools", ["sympy-math", SERVER_ID]) in mgr.calls
 
     def test_project_conversation_with_no_toggles_still_gets_tools(self):
         runner = ChatRunner(persistence=FakePersistence())
         mgr = FakeManager()
-        runner._build_stream(_conv(project_id="p1"), mgr)
+        runner._build_stream(_conv(project_id="p1"), mgr, "p1")
         assert ("get_all_tools", [SERVER_ID]) in mgr.calls
 
     def test_hint_lands_in_system_prompt(self):
@@ -346,6 +350,22 @@ class TestRuntimeAutoEnable:
         runner._build_stream(_conv(), mgr)
         assert mgr.calls == []  # no enabled servers -> no tool discovery
 
+    def test_runner_does_not_resolve_on_its_own(self):
+        # The row carries a project, but no snapshot was passed: the runner
+        # must NOT fall back to conv.project_id — resolution has exactly one
+        # owner (routes._effective_project_id at run creation).
+        runner = ChatRunner(persistence=FakePersistence())
+        mgr = FakeManager()
+        runner._build_stream(_conv(project_id="p1"), mgr)
+        assert mgr.calls == []
+
+    def test_run_passes_the_snapshot_through(self):
+        # ChatTurnRequest.effective_project_id is what reaches _build_stream.
+        from chat.runtime import ChatTurnRequest
+        req = ChatTurnRequest(conversation=_conv(), mcp_manager=FakeManager(),
+                              effective_project_id="p9")
+        assert req.effective_project_id == "p9"
+
 
 class TestRoutesHelper:
     @pytest.fixture
@@ -358,12 +378,12 @@ class TestRoutesHelper:
     def test_none_without_servers_or_project(self, app):
         from chat.routes import _mcp_for_conversation
         with app.app_context():
-            assert _mcp_for_conversation(_conv(), []) is None
+            assert _mcp_for_conversation(_conv(), [], None) is None
 
     def test_plain_manager_for_toggled_non_project_conversation(self, app):
         from chat.routes import _mcp_for_conversation
         with app.app_context():
-            mgr = _mcp_for_conversation(_conv(), ["sympy-math"])
+            mgr = _mcp_for_conversation(_conv(), ["sympy-math"], None)
         assert mgr is app.config["MCP_MANAGER"]
 
     def test_scoped_manager_for_project_conversation(self, app, tmp_path):
@@ -375,7 +395,7 @@ class TestRoutesHelper:
         from chat.routes import _mcp_for_conversation
         from chat.project_files_mcp import ProjectScopedMCPManager as CurrentScoped
         with app.app_context():
-            mgr = _mcp_for_conversation(_conv(project_id="p1"), [])
+            mgr = _mcp_for_conversation(_conv(project_id="p1"), [], "p1")
         assert isinstance(mgr, CurrentScoped)
         mgr.call_tool(SERVER_ID, "list_files", {})
         call = app.config["MCP_MANAGER"].calls[-1]
@@ -419,8 +439,18 @@ class TestSpinoffInheritance:
             db._close_conn(conn)
         assert db.resolve_project_id("child") is None
 
+    def test_effective_project_id_resolves_through_the_chain(self, db):
+        from chat.routes import _effective_project_id
+        app = Flask(__name__)
+        app.config["CHAT_DB"] = db
+        with app.app_context():
+            assert _effective_project_id(db.get_conversation("root")) == "p1"
+            assert _effective_project_id(db.get_conversation("child")) == "p1"
+            assert _effective_project_id(db.get_conversation("grand")) == "p1"
+            assert _effective_project_id(db.get_conversation("loner")) is None
+
     def test_routes_scope_spinoff_to_root_project(self, db, tmp_path):
-        from chat.routes import _mcp_for_conversation
+        from chat.routes import _effective_project_id, _mcp_for_conversation
         app = Flask(__name__)
         app.config["MCP_MANAGER"] = FakeManager()
         app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
@@ -428,24 +458,48 @@ class TestSpinoffInheritance:
         child = db.get_conversation("child")
         assert child.project_id is None  # root-only membership held
         with app.app_context():
-            mgr = _mcp_for_conversation(child, [])
+            project_id = _effective_project_id(child)
+            mgr = _mcp_for_conversation(child, [], project_id)
         assert mgr is not None
         mgr.call_tool(SERVER_ID, "list_files", {})
         call = app.config["MCP_MANAGER"].calls[-1]
         assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
 
-    def test_runtime_auto_enables_for_spinoff(self, db):
+    def test_runtime_auto_enables_for_spinoff_snapshot(self, db):
+        # The runner gets the resolved project as a snapshot, the same value
+        # routes bound the manager with — spin-off rows carry NULL themselves.
         runner = ChatRunner(db=db, persistence=FakePersistence())
         mgr = FakeManager()
-        runner._build_stream(db.get_conversation("grand"), mgr)
+        grand = db.get_conversation("grand")
+        assert grand.project_id is None
+        runner._build_stream(grand, mgr, db.resolve_project_id("grand"))
         assert ("get_all_tools", [SERVER_ID]) in mgr.calls
 
-    def test_runtime_without_db_still_works_for_direct_membership(self, db):
-        # Ghost-chat shape: no db wired. Direct project_id still enables.
-        runner = ChatRunner(db=None, persistence=FakePersistence())
-        mgr = FakeManager()
-        runner._build_stream(db.get_conversation("root"), mgr)
-        assert ("get_all_tools", [SERVER_ID]) in mgr.calls
+    def test_spinoff_cannot_carry_project_directly(self, db):
+        # DB-level enforcement of root-only membership (codex arch rec 2):
+        # neither inserting a spin-off with a project nor attaching a
+        # project to an existing spin-off can slip past the triggers.
+        import sqlite3
+        with pytest.raises(sqlite3.IntegrityError):
+            db.create_conversation(
+                _conv2("bad", parent_conversation_id="root", project_id="p1"))
+        conn = db._get_conn()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "UPDATE conversations SET project_id = 'p1' WHERE id = 'child'")
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "UPDATE conversations SET parent_conversation_id = 'loner' WHERE id = 'root'")
+        finally:
+            db._close_conn(conn)
+        # detach-on-delete stays allowed: setting NULL never trips the trigger
+        conn = db._get_conn()
+        try:
+            conn.execute("UPDATE conversations SET project_id = NULL WHERE id = 'root'")
+            conn.commit()
+        finally:
+            db._close_conn(conn)
 
 
 class TestRunAsyncTimeout:


### PR DESCRIPTION
Implements recommendations 1, 2 and 4 from the codex architecture review of the projects feature (follow-up to #77/#78/#79/#81).

## Rec 1 — resolve effective project context once per run

Routes and the runtime each resolved a conversation's project independently — two owners of one policy, with a theoretical divergence window (root moved between the two resolutions → MCP manager scoped to one project, tools auto-enabled for another).

Now `routes._effective_project_id()` is the **single owner**: called once at run creation, snapshotted into `ChatTurnRequest.effective_project_id`, threaded through `run_manager.start()/_execute()`, and consumed verbatim by `ChatRunner._build_stream()` — which no longer resolves anything itself (including no fallback to `conv.project_id`, so the single-owner property is real, and there's a regression test asserting the runner does not resolve on its own). This also makes the snapshot semantics explicit: membership is fixed when the run is created.

## Rec 2 — DB-level enforcement of root-only membership

Two new triggers reject any conversation row carrying both `parent_conversation_id` and `project_id` (insert, and update of either column). The HTTP routes already rejected this; now the invariant that `resolve_project_id()` and the sidebar rely on is self-defending against any future write path. `SET project_id = NULL` (detach-on-project-delete) is unaffected.

## Rec 4 — stable machine-readable error codes

`ProjectFilesError` grew a `code` field, surfaced as `{"error": msg, "code": ...}` by the blueprint error handler. Coded conditions are the ones the UI branches on: `revision_conflict` (editor conflict bar) and `already_exists` (create-only conflict, upload overwrite prompt, mkdir/move conflicts). `fetchAPI` and the raw-fetch upload helper attach `err.code` to thrown errors; `ProjectFileEditor` and `ProjectPage` now branch on `err.code` instead of matching human-readable message text, so wording can change freely.

## Tests

- `test_spinoff_cannot_carry_project_directly` — trigger enforcement (insert + both update directions + detach still allowed)
- `test_effective_project_id_resolves_through_the_chain`, `test_runtime_auto_enables_for_spinoff_snapshot`, `test_runner_does_not_resolve_on_its_own`, `test_run_passes_the_snapshot_through` — snapshot threading
- `TestErrorCodes` (6 tests) — every coded 409 on the HTTP surface, plus uncoded errors carrying no `code` key
- Frontend mocks updated to carry codes like the real API

Backend: 540 passed. Frontend: 199 passed.