### PR TITLE
feat(projects): explorer-style file view with drag-and-drop and context menu

### DIFF
--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -457,6 +457,86 @@ def move(root: str, rel_src: str, rel_dst: str) -> dict:
     return _node(abs_dst, "/".join(dst_parts))
 
 
+def _precheck_copy_tree(abs_src: str, dst_depth: int):
+    """Pre-scan a directory before copytree: reject special files (opening
+    a FIFO to copy it would block the worker forever) and enforce the path
+    depth cap at the DESTINATION — the source obeys it relative to its own
+    location, but copying deep subtree into an already-deep folder could
+    mint paths build_tree/rmtree would then have to recurse past."""
+    for dirpath, dirnames, filenames in os.walk(abs_src):
+        rel_depth = 0 if dirpath == abs_src else len(os.path.relpath(dirpath, abs_src).split(os.sep))
+        child_depth = dst_depth + rel_depth + 1
+        if child_depth > MAX_PATH_DEPTH and (dirnames or filenames):
+            raise ProjectFilesError("copy would exceed maximum path depth")
+        for name in filenames:
+            st = os.lstat(os.path.join(dirpath, name))
+            if not (stat_mod.S_ISREG(st.st_mode) or stat_mod.S_ISLNK(st.st_mode)):
+                raise ProjectFilesError("directory contains a special file that cannot be copied")
+
+
+def copy_path(root: str, rel_src: str, rel_dst: str) -> dict:
+    """Copy a file, symlink, or directory tree to a new relative path.
+    Same contract as move: the destination's parent must exist and the
+    destination itself must not. Symlinks are copied as links, never
+    followed (matching the tree/delete contract — a link pointing outside
+    the root must not smuggle its target's content into the project)."""
+    src_parts = split_rel_path(rel_src)
+    dst_parts = split_rel_path(rel_dst)
+    if not src_parts:
+        raise ProjectFilesError("cannot copy project root")
+    if not dst_parts:
+        raise ProjectFilesError("destination is required")
+    abs_src = resolve(root, rel_src)
+    abs_dst = resolve(root, rel_dst)
+    if not os.path.lexists(abs_src):
+        raise ProjectFilesError("source not found", status=404)
+    if os.path.lexists(abs_dst):
+        raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+    if dst_parts[:len(src_parts)] == src_parts:
+        raise ProjectFilesError("cannot copy a directory into itself")
+    abs_dst_dir = os.path.dirname(abs_dst)
+    if not os.path.isdir(abs_dst_dir):
+        raise ProjectFilesError("destination directory not found", status=404)
+
+    src_st = os.lstat(abs_src)
+    with _fs_errors():
+        if stat_mod.S_ISDIR(src_st.st_mode):
+            _precheck_copy_tree(abs_src, len(dst_parts))
+            try:
+                shutil.copytree(abs_src, abs_dst, symlinks=True)
+            except FileExistsError:
+                raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+            except Exception:
+                # A partial tree is worse than no tree: the client will
+                # retry the whole copy, and a half-populated destination
+                # would then 409 as already_exists.
+                shutil.rmtree(abs_dst, ignore_errors=True)
+                raise
+        elif stat_mod.S_ISLNK(src_st.st_mode):
+            try:
+                os.symlink(os.readlink(abs_src), abs_dst)
+            except FileExistsError:
+                raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+        elif stat_mod.S_ISREG(src_st.st_mode):
+            # Stage in the destination directory, then publish with an
+            # atomic no-replace link — same 409 contract as save_stream
+            # even against a concurrent claim of the destination name.
+            fd, tmp_path = tempfile.mkstemp(prefix=".copy-", suffix=".tmp", dir=abs_dst_dir)
+            try:
+                os.close(fd)
+                shutil.copy2(abs_src, tmp_path)  # preserves mode
+                try:
+                    os.link(tmp_path, abs_dst)
+                except FileExistsError:
+                    raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+        else:
+            raise ProjectFilesError("not a copyable file type")
+    return _node(abs_dst, "/".join(dst_parts))
+
+
 def delete(root: str, rel_path: str):
     parts = split_rel_path(rel_path)
     if not parts:

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -501,6 +501,16 @@ def copy_path(root: str, rel_src: str, rel_dst: str) -> dict:
     src_st = os.lstat(abs_src)
     with _fs_errors():
         if stat_mod.S_ISDIR(src_st.st_mode):
+            # The component-prefix check above only sees CLIENT paths; an
+            # in-root symlink alias (alias -> d) would let "d" ->
+            # "alias/copy" physically target d/copy and send copytree
+            # into its own output. Compare physical paths: the real
+            # destination is its existing parent's realpath plus the
+            # final component.
+            real_src = os.path.realpath(abs_src)
+            real_dst = os.path.join(os.path.realpath(abs_dst_dir), os.path.basename(abs_dst))
+            if real_dst == real_src or real_dst.startswith(real_src + os.sep):
+                raise ProjectFilesError("cannot copy a directory into itself")
             _precheck_copy_tree(abs_src, len(dst_parts))
             try:
                 shutil.copytree(abs_src, abs_dst, symlinks=True)

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -499,19 +499,23 @@ def copy_path(root: str, rel_src: str, rel_dst: str) -> dict:
         raise ProjectFilesError("destination directory not found", status=404)
 
     src_st = os.lstat(abs_src)
+    # The component checks above only see CLIENT paths; an in-root symlink
+    # alias can spell a destination whose PHYSICAL location differs — both
+    # deeper than the client path suggests and inside the source itself.
+    # Judge depth and self-containment on realpaths: the real destination
+    # is its existing parent's realpath plus the final component. Copying
+    # past the depth cap would mint entries build_tree returns but every
+    # other route rejects as "path too deep".
+    real_dst = os.path.join(os.path.realpath(abs_dst_dir), os.path.basename(abs_dst))
+    phys_dst_depth = len(os.path.relpath(real_dst, os.path.realpath(root)).split(os.sep))
+    if phys_dst_depth > MAX_PATH_DEPTH:
+        raise ProjectFilesError("path too deep")
     with _fs_errors():
         if stat_mod.S_ISDIR(src_st.st_mode):
-            # The component-prefix check above only sees CLIENT paths; an
-            # in-root symlink alias (alias -> d) would let "d" ->
-            # "alias/copy" physically target d/copy and send copytree
-            # into its own output. Compare physical paths: the real
-            # destination is its existing parent's realpath plus the
-            # final component.
             real_src = os.path.realpath(abs_src)
-            real_dst = os.path.join(os.path.realpath(abs_dst_dir), os.path.basename(abs_dst))
             if real_dst == real_src or real_dst.startswith(real_src + os.sep):
                 raise ProjectFilesError("cannot copy a directory into itself")
-            _precheck_copy_tree(abs_src, len(dst_parts))
+            _precheck_copy_tree(abs_src, phys_dst_depth)
             try:
                 shutil.copytree(abs_src, abs_dst, symlinks=True)
             except FileExistsError:

--- a/dashboard/chat/project_files_routes.py
+++ b/dashboard/chat/project_files_routes.py
@@ -189,6 +189,22 @@ def project_files_move(project_id):
     return jsonify(node)
 
 
+@chat_bp.route("/api/chat/projects/<project_id>/files/copy", methods=["POST"])
+@require_auth
+def project_files_copy(project_id):
+    root, err = _project_root_or_404(project_id, create=True)
+    if err:
+        return err
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "body must be {path, new_path}"}), 400
+    node = pf.copy_path(root, data.get("path"), data.get("new_path"))
+    stale = _revalidate_or_cleanup(project_id)
+    if stale:
+        return stale
+    return jsonify(node), 201
+
+
 @chat_bp.route("/api/chat/projects/<project_id>/files", methods=["DELETE"])
 @require_auth
 def project_files_delete(project_id):

--- a/dashboard/frontend/src/components/chat/ContextMenu.jsx
+++ b/dashboard/frontend/src/components/chat/ContextMenu.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+
+// Generic right-click menu. `items` is a list of
+// {label, icon, onClick, disabled?, danger?} entries or the string 'sep'.
+// The caller owns positioning (x/y from the contextmenu event) and closes
+// the menu via onClose — this component only handles dismissal (click
+// away, Escape, window blur) and viewport clamping.
+export default function ContextMenu({ x, y, items, onClose }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const away = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) onClose()
+    }
+    const esc = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('mousedown', away)
+    window.addEventListener('contextmenu', away)
+    window.addEventListener('keydown', esc)
+    window.addEventListener('blur', onClose)
+    return () => {
+      window.removeEventListener('mousedown', away)
+      window.removeEventListener('contextmenu', away)
+      window.removeEventListener('keydown', esc)
+      window.removeEventListener('blur', onClose)
+    }
+  }, [onClose])
+
+  // Rough clamp so the menu never opens half off-screen. Row height ~32px.
+  const width = 200
+  const height = items.length * 32 + 12
+  const left = Math.max(0, Math.min(x, (window.innerWidth || 10000) - width))
+  const top = Math.max(0, Math.min(y, (window.innerHeight || 10000) - height))
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 min-w-[190px] bg-surface border border-border rounded-lg shadow-xl py-1"
+      style={{ left, top }}
+      data-testid="context-menu"
+      role="menu"
+    >
+      {items.map((item, i) =>
+        item === 'sep' ? (
+          <div key={i} className="my-1 border-t border-border-subtle" />
+        ) : (
+          <button
+            key={i}
+            role="menuitem"
+            disabled={item.disabled}
+            onClick={() => { onClose(); item.onClick() }}
+            className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-left text-sm cursor-pointer disabled:opacity-40 disabled:cursor-default ${
+              item.danger
+                ? 'text-danger-fg hover:bg-danger-subtle'
+                : 'text-fg hover:bg-surface-muted'
+            } disabled:hover:bg-transparent`}
+          >
+            <i className={`fa-solid ${item.icon} w-4 text-xs text-fg-subtle`}></i>
+            <span className="flex-1">{item.label}</span>
+            {item.hint && <span className="text-[10px] text-fg-faint">{item.hint}</span>}
+          </button>
+        )
+      )}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -1,9 +1,15 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import {
   getProjectFilesTree, uploadProjectFile, mkdirProjectPath,
-  moveProjectPath, deleteProjectPath, downloadProjectFile,
+  moveProjectPath, copyProjectPath, deleteProjectPath, downloadProjectFile,
 } from '../../services/chat'
 import ProjectFileEditor from './ProjectFileEditor'
+import ContextMenu from './ContextMenu'
+
+// The DataTransfer type carrying the dragged entry's project-relative
+// path. A custom type keeps foreign drags (text, files from the OS) from
+// being mistaken for an internal move.
+const DND_TYPE = 'application/x-llmdock-path'
 
 function findNode(nodes, path) {
   for (const n of nodes) {
@@ -16,6 +22,51 @@ function findNode(nodes, path) {
   return null
 }
 
+// Children of a directory path ('' = project root).
+function listDir(tree, dirPath) {
+  if (!dirPath) return tree
+  const node = findNode(tree, dirPath)
+  return node && node.type === 'dir' ? (node.children || []) : null
+}
+
+function parentDir(path) {
+  const i = path.lastIndexOf('/')
+  return i === -1 ? '' : path.slice(0, i)
+}
+
+function baseName(path) {
+  return path.split('/').pop()
+}
+
+function isSelfOrDescendant(dirPath, ofPath) {
+  return dirPath === ofPath || dirPath.startsWith(ofPath + '/')
+}
+
+// All ancestor dir paths of a path, root ('') excluded:
+// 'a/b/c' -> ['a', 'a/b'].
+function ancestorsOf(path) {
+  const out = []
+  const parts = path.split('/')
+  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join('/'))
+  return out
+}
+
+// First name that doesn't collide inside dirPath: "a.txt" -> "a (copy).txt"
+// -> "a (copy 2).txt". Works off the client tree snapshot; a stale snapshot
+// just means the backend's already_exists 409 surfaces as an error.
+function uniqueChildName(tree, dirPath, name) {
+  const siblings = new Set((listDir(tree, dirPath) || []).map(n => n.name))
+  if (!siblings.has(name)) return name
+  const dot = name.lastIndexOf('.')
+  const stem = dot > 0 ? name.slice(0, dot) : name
+  const ext = dot > 0 ? name.slice(dot) : ''
+  for (let i = 1; i < 100; i++) {
+    const candidate = i === 1 ? `${stem} (copy)${ext}` : `${stem} (copy ${i})${ext}`
+    if (!siblings.has(candidate)) return candidate
+  }
+  return name // give up; the backend 409 will surface
+}
+
 function formatSize(bytes) {
   if (bytes == null) return ''
   if (bytes < 1024) return `${bytes} B`
@@ -23,84 +74,56 @@ function formatSize(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, onNewFile, onRename, onDelete, onDownload, onOpenFile }) {
-  const isDir = node.type === 'dir'
+// One folder row in the left tree pane (recursive over subdirectories).
+function TreeDir({ node, depth, expanded, selectedDir, dropTarget, cutPath,
+                   onToggle, onSelect, onMenu, onDragStart, onDragOver, onDragLeave, onDrop }) {
+  const subdirs = (node.children || []).filter(c => c.type === 'dir')
+  const isExpanded = expanded.has(node.path)
   return (
     <>
       <div
-        onClick={isDir ? () => onToggle(node.path) : () => onOpenFile(node)}
-        className={`group flex items-center gap-2 py-1.5 pr-3 border-b border-border-subtle text-sm cursor-pointer ${
-          isDir ? 'text-fg' : 'text-fg-muted'
-        } hover:bg-surface-muted`}
-        style={{ paddingLeft: `${12 + depth * 18}px` }}
-        data-testid={`file-row-${node.path}`}
+        draggable
+        onClick={() => onSelect(node.path)}
+        onContextMenu={e => onMenu(e, node)}
+        onDragStart={e => onDragStart(e, node)}
+        onDragOver={e => onDragOver(e, node.path)}
+        onDragLeave={() => onDragLeave(node.path)}
+        onDrop={e => onDrop(e, node.path)}
+        className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
+          selectedDir === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
+        } ${dropTarget === node.path ? 'ring-1 ring-accent-strong bg-accent-subtle' : ''} ${
+          cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''
+        }`}
+        style={{ paddingLeft: `${8 + depth * 14}px` }}
+        data-testid={`tree-node-${node.path}`}
       >
-        {isDir ? (
-          <>
-            <i className={`fa-solid fa-chevron-${expanded.has(node.path) ? 'down' : 'right'} text-[9px] w-3 text-fg-faint flex-shrink-0`}></i>
-            <i className="fa-solid fa-folder text-xs text-amber-500/80 flex-shrink-0"></i>
-          </>
-        ) : (
-          <>
-            <span className="w-3 flex-shrink-0"></span>
-            <i className="fa-regular fa-file text-xs text-fg-faint flex-shrink-0"></i>
-          </>
-        )}
+        <button
+          onClick={e => { e.stopPropagation(); onToggle(node.path) }}
+          className={`w-4 flex-shrink-0 text-fg-faint cursor-pointer ${subdirs.length ? '' : 'invisible'}`}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${node.path}`}
+          tabIndex={-1}
+        >
+          <i className={`fa-solid fa-chevron-${isExpanded ? 'down' : 'right'} text-[9px]`}></i>
+        </button>
+        <i className={`fa-solid fa-folder${selectedDir === node.path ? '-open' : ''} text-xs text-amber-500/80 flex-shrink-0`}></i>
         <span className="flex-1 min-w-0 truncate">{node.name}</span>
-        {!isDir && <span className="text-[10px] text-fg-faint flex-shrink-0">{formatSize(node.size)}</span>}
-        <span className="flex items-center gap-0.5 flex-shrink-0">
-          {isDir && (
-            <>
-              <button
-                onClick={e => { e.stopPropagation(); onUploadInto(node.path) }}
-                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
-                title="Upload into folder" aria-label={`Upload into ${node.path}`}
-              ><i className="fa-solid fa-file-arrow-up text-xs"></i></button>
-              <button
-                onClick={e => { e.stopPropagation(); onNewFile(node.path) }}
-                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
-                title="New file" aria-label={`New file in ${node.path}`}
-              ><i className="fa-solid fa-file-circle-plus text-xs"></i></button>
-              <button
-                onClick={e => { e.stopPropagation(); onNewFolder(node.path) }}
-                className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
-                title="New subfolder" aria-label={`New subfolder in ${node.path}`}
-              ><i className="fa-solid fa-folder-plus text-xs"></i></button>
-            </>
-          )}
-          {!isDir && (
-            <button
-              onClick={e => { e.stopPropagation(); onDownload(node) }}
-              className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
-              title="Download" aria-label={`Download ${node.path}`}
-            ><i className="fa-solid fa-download text-xs"></i></button>
-          )}
-          <button
-            onClick={e => { e.stopPropagation(); onRename(node) }}
-            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
-            title="Rename / move" aria-label={`Rename ${node.path}`}
-          ><i className="fa-solid fa-pen text-xs"></i></button>
-          <button
-            onClick={e => { e.stopPropagation(); onDelete(node) }}
-            className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-danger-fg p-1 cursor-pointer"
-            title="Delete" aria-label={`Delete ${node.path}`}
-          ><i className="fa-solid fa-trash text-xs"></i></button>
-        </span>
       </div>
-      {isDir && expanded.has(node.path) && (node.children || []).map(child => (
-        <NodeRow
+      {isExpanded && subdirs.map(child => (
+        <TreeDir
           key={child.path}
           node={child}
           depth={depth + 1}
           expanded={expanded}
+          selectedDir={selectedDir}
+          dropTarget={dropTarget}
+          cutPath={cutPath}
           onToggle={onToggle}
-          onUploadInto={onUploadInto}
-          onNewFolder={onNewFolder}
-          onNewFile={onNewFile}
-          onRename={onRename}
-          onDelete={onDelete}
-          onDownload={onDownload}
-          onOpenFile={onOpenFile}
+          onSelect={onSelect}
+          onMenu={onMenu}
+          onDragStart={onDragStart}
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
         />
       ))}
     </>
@@ -109,10 +132,19 @@ function NodeRow({ node, depth, expanded, onToggle, onUploadInto, onNewFolder, o
 
 export default function ProjectPage({ project, onEditorDirtyChange }) {
   const [tree, setTree] = useState([])
+  // Tree-pane expansion state (dir paths). Root is always rendered.
   const [expanded, setExpanded] = useState(() => new Set())
+  // Directory whose contents fill the right pane ('' = project root).
+  const [selectedDir, setSelectedDir] = useState('')
+  // {op: 'copy'|'cut', path, name} — armed by the context menu.
+  const [clipboard, setClipboard] = useState(null)
+  // {x, y, node} — node null means the right pane's background.
+  const [menu, setMenu] = useState(null)
+  // Dir path currently highlighted as a drag-and-drop target.
+  const [dropTarget, setDropTarget] = useState(null)
   const [error, setError] = useState(null)
   const [busy, setBusy] = useState(false)
-  // {path, isNew} when the editor is open; replaces the tree area.
+  // {path, isNew} when the editor is open; replaces the right pane.
   const [editing, setEditing] = useState(null)
   // Local mirror of the editor's dirty state: the toolbar stays visible
   // while the editor is open, and starting another New file would remount
@@ -166,12 +198,32 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
   useEffect(() => {
     setTree([])
     setExpanded(new Set())
+    setSelectedDir('')
+    setClipboard(null)
+    setMenu(null)
+    setDropTarget(null)
     setError(null)
     setBusy(false)
     setEditing(null)
     refresh()
   }, [refresh])
 
+  // If the selected directory vanished (deleted, renamed, moved away),
+  // fall back to its nearest surviving ancestor.
+  useEffect(() => {
+    if (!selectedDir) return
+    let p = selectedDir
+    while (p) {
+      const node = findNode(tree, p)
+      if (node && node.type === 'dir') break
+      p = parentDir(p)
+    }
+    if (p !== selectedDir) setSelectedDir(p)
+  }, [tree, selectedDir])
+
+  // Returns true when the mutation succeeded — callers use it to gate
+  // follow-up state changes (selection remaps, clipboard clears) that
+  // must not happen when the backend rejected the operation.
   const run = useCallback(async (fn) => {
     // Same binding as refresh: a slow mutation for the previous project
     // must not flip busy/error state on the project now displayed (its
@@ -182,8 +234,10 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     try {
       await fn()
       await refresh()
+      return true
     } catch (err) {
       if (projectIdRef.current === pid) setError(err.message)
+      return false
     } finally {
       if (projectIdRef.current === pid) setBusy(false)
     }
@@ -197,6 +251,25 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       return next
     })
   }, [])
+
+  const expandTo = useCallback((dirPath) => {
+    if (!dirPath) return
+    setExpanded(prev => {
+      const next = new Set(prev)
+      for (const a of ancestorsOf(dirPath)) next.add(a)
+      next.add(dirPath)
+      return next
+    })
+  }, [])
+
+  const selectDir = useCallback((dirPath) => {
+    if (editing) {
+      if (!confirmDiscardEdits()) return
+      setEditing(null)
+    }
+    setSelectedDir(dirPath)
+    expandTo(dirPath)
+  }, [editing, confirmDiscardEdits, expandTo])
 
   const pickUpload = useCallback((dir) => {
     uploadDirRef.current = dir
@@ -222,38 +295,40 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
         }
       }
     })
-    if (dir) setExpanded(prev => new Set(prev).add(dir))
   }, [project?.id, run])
 
-  const handleNewFolder = useCallback(async (parentDir) => {
+  const handleNewFolder = useCallback(async (parentPath) => {
     const name = window.prompt('Folder name')
     if (!name || !name.trim()) return
-    const path = parentDir ? `${parentDir}/${name.trim()}` : name.trim()
+    const path = parentPath ? `${parentPath}/${name.trim()}` : name.trim()
     await run(() => mkdirProjectPath(project.id, path))
-    if (parentDir) setExpanded(prev => new Set(prev).add(parentDir))
-  }, [project?.id, run])
+    expandTo(parentPath)
+  }, [project?.id, run, expandTo])
 
   const handleRename = useCallback(async (node) => {
     const newPath = window.prompt('New path (relative to project root)', node.path)
     if (!newPath || !newPath.trim() || newPath.trim() === node.path) return
-    await run(() => moveProjectPath(project.id, node.path, newPath.trim()))
+    const ok = await run(() => moveProjectPath(project.id, node.path, newPath.trim()))
+    if (ok) setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
   }, [project?.id, run])
 
   const handleDelete = useCallback(async (node) => {
     const label = node.type === 'dir' ? `folder "${node.path}" and everything in it` : `"${node.path}"`
     if (!window.confirm(`Delete ${label}?`)) return
-    await run(() => deleteProjectPath(project.id, node.path))
+    const ok = await run(() => deleteProjectPath(project.id, node.path))
+    if (ok) setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
   }, [project?.id, run])
 
   const handleOpenFile = useCallback((node) => {
+    if (!confirmDiscardEdits()) return
     setEditing({ path: node.path, isNew: false })
-  }, [])
+  }, [confirmDiscardEdits])
 
-  const handleNewFile = useCallback((parentDir) => {
+  const handleNewFile = useCallback((parentPath) => {
     if (!confirmDiscardEdits()) return
     const name = window.prompt('File name')
     if (!name || !name.trim()) return
-    const path = parentDir ? `${parentDir}/${name.trim()}` : name.trim()
+    const path = parentPath ? `${parentPath}/${name.trim()}` : name.trim()
     // If it already exists, open it instead of silently overwriting on save.
     const existing = findNode(tree, path)
     setEditing({ path, isNew: !existing })
@@ -273,6 +348,126 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       setError(err.message)
     }
   }, [project?.id])
+
+  // -- Move (drag-and-drop and cut-paste share this) --
+
+  const moveInto = useCallback(async (srcPath, dstDir) => {
+    if (parentDir(srcPath) === dstDir) return // already there
+    if (isSelfOrDescendant(dstDir, srcPath)) {
+      setError('cannot move a folder into itself')
+      return
+    }
+    const dstPath = dstDir ? `${dstDir}/${baseName(srcPath)}` : baseName(srcPath)
+    const ok = await run(() => moveProjectPath(project.id, srcPath, dstPath))
+    if (!ok) return
+    // Keep the selection meaningful when the selected dir itself moved.
+    setSelectedDir(prev => {
+      if (prev && isSelfOrDescendant(prev, srcPath)) {
+        return dstPath + prev.slice(srcPath.length)
+      }
+      return prev
+    })
+    setClipboard(prev => (prev && isSelfOrDescendant(prev.path, srcPath) ? null : prev))
+    expandTo(dstDir)
+  }, [project?.id, run, expandTo])
+
+  // -- Clipboard --
+
+  const armClipboard = useCallback((op, node) => {
+    setClipboard({ op, path: node.path, name: node.name })
+  }, [])
+
+  const handlePaste = useCallback(async (dstDir) => {
+    if (!clipboard) return
+    const { op, path, name } = clipboard
+    if (op === 'cut') {
+      await moveInto(path, dstDir)
+    } else {
+      const dstName = uniqueChildName(tree, dstDir, name)
+      const dstPath = dstDir ? `${dstDir}/${dstName}` : dstName
+      if (isSelfOrDescendant(dstDir, path)) {
+        setError('cannot copy a folder into itself')
+        return
+      }
+      const ok = await run(() => copyProjectPath(project.id, path, dstPath))
+      if (ok) expandTo(dstDir)
+    }
+  }, [clipboard, tree, moveInto, run, project?.id, expandTo])
+
+  // -- Drag and drop --
+
+  const handleDragStart = useCallback((e, node) => {
+    e.dataTransfer.setData(DND_TYPE, node.path)
+    e.dataTransfer.effectAllowed = 'move'
+  }, [])
+
+  const handleDragOver = useCallback((e, dirPath) => {
+    if (!e.dataTransfer.types.includes(DND_TYPE)) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
+    setDropTarget(dirPath)
+  }, [])
+
+  const handleDragLeave = useCallback((dirPath) => {
+    setDropTarget(prev => (prev === dirPath ? null : prev))
+  }, [])
+
+  const handleDrop = useCallback((e, dirPath) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDropTarget(null)
+    const srcPath = e.dataTransfer.getData(DND_TYPE)
+    if (srcPath) moveInto(srcPath, dirPath)
+  }, [moveInto])
+
+  // -- Context menu --
+
+  const openMenu = useCallback((e, node) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setMenu({ x: e.clientX, y: e.clientY, node })
+  }, [])
+
+  const closeMenu = useCallback(() => setMenu(null), [])
+
+  const menuItems = useMemo(() => {
+    if (!menu) return []
+    const node = menu.node
+    if (!node || node.isRoot) {
+      // Background of the right pane acts on the selected directory; the
+      // root tree node acts on the project root.
+      const dir = node?.isRoot ? '' : selectedDir
+      return [
+        { label: 'New file', icon: 'fa-file-circle-plus', onClick: () => handleNewFile(dir) },
+        { label: 'New folder', icon: 'fa-folder-plus', onClick: () => handleNewFolder(dir) },
+        { label: 'Upload files', icon: 'fa-file-arrow-up', onClick: () => pickUpload(dir) },
+        'sep',
+        { label: 'Paste', icon: 'fa-paste', disabled: !clipboard, onClick: () => handlePaste(dir) },
+      ]
+    }
+    const isDir = node.type === 'dir'
+    const items = []
+    if (isDir) {
+      items.push({ label: 'Open', icon: 'fa-folder-open', onClick: () => selectDir(node.path) })
+      items.push({ label: 'Paste into', icon: 'fa-paste', disabled: !clipboard, onClick: () => handlePaste(node.path) })
+    } else {
+      items.push({ label: 'Open', icon: 'fa-pen-to-square', onClick: () => handleOpenFile(node) })
+      items.push({ label: 'Download', icon: 'fa-download', onClick: () => handleDownload(node) })
+    }
+    items.push('sep')
+    items.push({ label: 'Cut', icon: 'fa-scissors', onClick: () => armClipboard('cut', node) })
+    items.push({ label: 'Copy', icon: 'fa-copy', onClick: () => armClipboard('copy', node) })
+    items.push({ label: 'Rename', icon: 'fa-pen', onClick: () => handleRename(node) })
+    items.push('sep')
+    items.push({ label: 'Delete', icon: 'fa-trash', danger: true, onClick: () => handleDelete(node) })
+    return items
+  }, [menu, clipboard, selectedDir, handleNewFile, handleNewFolder, pickUpload, handlePaste,
+      selectDir, handleOpenFile, handleDownload, armClipboard, handleRename, handleDelete])
+
+  const entries = listDir(tree, selectedDir) || []
+  const crumbs = selectedDir ? selectedDir.split('/') : []
+  const cutPath = clipboard?.op === 'cut' ? clipboard.path : null
 
   if (!project) {
     return (
@@ -306,7 +501,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       {/* Toolbar */}
       <div className="px-6 py-2 border-b border-border flex items-center gap-2">
         <button
-          onClick={() => pickUpload('')}
+          onClick={() => pickUpload(selectedDir)}
           disabled={busy}
           className="px-3 py-1.5 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-xs font-medium transition-colors flex items-center gap-2 disabled:opacity-50"
         >
@@ -314,7 +509,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
           Upload files
         </button>
         <button
-          onClick={() => handleNewFile('')}
+          onClick={() => handleNewFile(selectedDir)}
           disabled={busy}
           className="px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center gap-2 disabled:opacity-50"
         >
@@ -322,13 +517,24 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
           New file
         </button>
         <button
-          onClick={() => handleNewFolder('')}
+          onClick={() => handleNewFolder(selectedDir)}
           disabled={busy}
           className="px-3 py-1.5 bg-surface hover:bg-surface-muted border border-border rounded-lg text-xs text-fg-muted transition-colors flex items-center gap-2 disabled:opacity-50"
         >
           <i className="fa-solid fa-folder-plus"></i>
           New folder
         </button>
+        {clipboard && (
+          <span className="flex items-center gap-1.5 px-2 py-1 bg-surface border border-border rounded-lg text-[11px] text-fg-subtle" data-testid="clipboard-chip">
+            <i className={`fa-solid ${clipboard.op === 'cut' ? 'fa-scissors' : 'fa-copy'} text-[10px]`}></i>
+            <span className="max-w-[160px] truncate">{clipboard.name}</span>
+            <button
+              onClick={() => setClipboard(null)}
+              className="text-fg-faint hover:text-fg cursor-pointer"
+              aria-label="Clear clipboard"
+            ><i className="fa-solid fa-xmark text-[10px]"></i></button>
+          </span>
+        )}
         <button
           onClick={refresh}
           disabled={busy}
@@ -345,47 +551,146 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
         </div>
       )}
 
-      {/* Editor takes over the content area while a file is open */}
-      {editing ? (
-        <ProjectFileEditor
-          key={`${project.id}:${editing.path}`}
-          projectId={project.id}
-          path={editing.path}
-          isNew={editing.isNew}
-          onDirtyChange={handleEditorDirtyChange}
-          onClose={() => setEditing(null)}
-          onSaved={() => {
-            // A saved new file now exists on disk; drop the isNew flag so
-            // later saves carry the conflict guard, and refresh the tree.
-            setEditing(prev => (prev ? { ...prev, isNew: false } : prev))
-            refresh()
-          }}
-        />
-      ) : (
-      <div className="flex-1 overflow-auto py-1">
-        {tree.length === 0 && !error && (
-          <div className="p-8 text-center text-xs text-fg-subtle">
-            No files yet. Upload files or create a folder to get started.
+      <div className="flex-1 flex overflow-hidden">
+        {/* Left: folder tree */}
+        <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto py-2 px-1.5 select-none">
+          <div
+            onClick={() => selectDir('')}
+            onContextMenu={e => openMenu(e, { isRoot: true })}
+            onDragOver={e => handleDragOver(e, '')}
+            onDragLeave={() => handleDragLeave('')}
+            onDrop={e => handleDrop(e, '')}
+            className={`flex items-center gap-1.5 py-1 pl-2 pr-2 text-sm cursor-pointer rounded ${
+              selectedDir === '' ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
+            } ${dropTarget === '' ? 'ring-1 ring-accent-strong bg-accent-subtle' : ''}`}
+            data-testid="tree-node-root"
+          >
+            <i className="fa-solid fa-house text-xs text-fg-subtle flex-shrink-0"></i>
+            <span className="flex-1 min-w-0 truncate font-medium">{project.name}</span>
           </div>
-        )}
-        {tree.map(node => (
-          <NodeRow
-            key={node.path}
-            node={node}
-            depth={0}
-            expanded={expanded}
-            onToggle={toggle}
-            onUploadInto={pickUpload}
-            onNewFolder={handleNewFolder}
-            onNewFile={handleNewFile}
-            onRename={handleRename}
-            onDelete={handleDelete}
-            onDownload={handleDownload}
-            onOpenFile={handleOpenFile}
+          {tree.filter(n => n.type === 'dir').map(node => (
+            <TreeDir
+              key={node.path}
+              node={node}
+              depth={1}
+              expanded={expanded}
+              selectedDir={selectedDir}
+              dropTarget={dropTarget}
+              cutPath={cutPath}
+              onToggle={toggle}
+              onSelect={selectDir}
+              onMenu={openMenu}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            />
+          ))}
+        </div>
+
+        {/* Right: editor, or the selected directory's contents */}
+        {editing ? (
+          <ProjectFileEditor
+            key={`${project.id}:${editing.path}`}
+            projectId={project.id}
+            path={editing.path}
+            isNew={editing.isNew}
+            onDirtyChange={handleEditorDirtyChange}
+            onClose={() => setEditing(null)}
+            onSaved={() => {
+              // A saved new file now exists on disk; drop the isNew flag so
+              // later saves carry the conflict guard, and refresh the tree.
+              setEditing(prev => (prev ? { ...prev, isNew: false } : prev))
+              refresh()
+            }}
           />
-        ))}
+        ) : (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Breadcrumb */}
+          <div className="px-4 py-1.5 border-b border-border-subtle flex items-center gap-1 text-xs text-fg-subtle flex-wrap">
+            <button
+              onClick={() => selectDir('')}
+              className="hover:text-fg cursor-pointer"
+              aria-label="Go to project root"
+            ><i className="fa-solid fa-house"></i></button>
+            {crumbs.map((seg, i) => {
+              const path = crumbs.slice(0, i + 1).join('/')
+              return (
+                <span key={path} className="flex items-center gap-1">
+                  <i className="fa-solid fa-chevron-right text-[8px] text-fg-faint"></i>
+                  <button
+                    onClick={() => selectDir(path)}
+                    className={`hover:text-fg cursor-pointer ${i === crumbs.length - 1 ? 'text-fg font-medium' : ''}`}
+                    data-testid={`crumb-${path}`}
+                  >{seg}</button>
+                </span>
+              )
+            })}
+          </div>
+
+          <div
+            className={`flex-1 overflow-auto py-1 ${dropTarget === `bg:${selectedDir}` ? 'ring-1 ring-inset ring-accent-strong' : ''}`}
+            onContextMenu={e => openMenu(e, null)}
+            onDragOver={e => handleDragOver(e, `bg:${selectedDir}`)}
+            onDragLeave={() => handleDragLeave(`bg:${selectedDir}`)}
+            onDrop={e => handleDrop(e, selectedDir)}
+            data-testid="dir-contents"
+          >
+            {entries.length === 0 && !error && (
+              <div className="p-8 text-center text-xs text-fg-subtle">
+                {selectedDir ? 'This folder is empty.' : 'No files yet. Upload files or create a folder to get started.'}
+              </div>
+            )}
+            {entries.map(node => {
+              const isDir = node.type === 'dir'
+              return (
+                <div
+                  key={node.path}
+                  draggable
+                  onClick={isDir ? () => selectDir(node.path) : () => handleOpenFile(node)}
+                  onContextMenu={e => openMenu(e, node)}
+                  onDragStart={e => handleDragStart(e, node)}
+                  onDragOver={isDir ? e => handleDragOver(e, node.path) : undefined}
+                  onDragLeave={isDir ? () => handleDragLeave(node.path) : undefined}
+                  onDrop={isDir ? e => handleDrop(e, node.path) : undefined}
+                  className={`group flex items-center gap-2 py-1.5 px-4 border-b border-border-subtle text-sm cursor-pointer ${
+                    isDir ? 'text-fg' : 'text-fg-muted'
+                  } hover:bg-surface-muted ${dropTarget === node.path ? 'ring-1 ring-accent-strong bg-accent-subtle' : ''} ${
+                    cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''
+                  }`}
+                  data-testid={`file-row-${node.path}`}
+                >
+                  <i className={`${isDir ? 'fa-solid fa-folder text-amber-500/80' : 'fa-regular fa-file text-fg-faint'} text-xs flex-shrink-0 w-4`}></i>
+                  <span className="flex-1 min-w-0 truncate">{node.name}</span>
+                  {!isDir && <span className="text-[10px] text-fg-faint flex-shrink-0">{formatSize(node.size)}</span>}
+                  <span className="flex items-center gap-0.5 flex-shrink-0">
+                    {!isDir && (
+                      <button
+                        onClick={e => { e.stopPropagation(); handleDownload(node) }}
+                        className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+                        title="Download" aria-label={`Download ${node.path}`}
+                      ><i className="fa-solid fa-download text-xs"></i></button>
+                    )}
+                    <button
+                      onClick={e => { e.stopPropagation(); handleRename(node) }}
+                      className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-fg p-1 cursor-pointer"
+                      title="Rename / move" aria-label={`Rename ${node.path}`}
+                    ><i className="fa-solid fa-pen text-xs"></i></button>
+                    <button
+                      onClick={e => { e.stopPropagation(); handleDelete(node) }}
+                      className="opacity-0 group-hover:opacity-100 text-fg-subtle hover:text-danger-fg p-1 cursor-pointer"
+                      title="Delete" aria-label={`Delete ${node.path}`}
+                    ><i className="fa-solid fa-trash text-xs"></i></button>
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+        )}
       </div>
-      )}
+
+      {menu && <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={closeMenu} />}
     </div>
   )
 }

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -169,14 +169,12 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     if (!editorDirtyRef.current) return true
     return window.confirm('Discard unsaved changes?')
   }, [editingUnder])
-  // After a successful rename/move of the open file or an ancestor, carry
-  // the editor to the new path (the keyed remount reloads from there — a
-  // dirty buffer was already discard-confirmed by guardEditedPath).
-  const remapEditing = useCallback((srcPath, dstPath) => {
-    setEditing(prev => (prev && isSelfOrDescendant(prev.path, srcPath)
-      ? { ...prev, path: dstPath + prev.path.slice(srcPath.length) }
-      : prev))
-  }, [])
+  // The guard samples the buffer BEFORE the request, but the editor would
+  // stay writable during the await — anything typed in that window would
+  // be silently discarded by the post-success remount/close. So affected
+  // mutations close the editor for the duration of the request (nothing
+  // to type into) and reopen it afterwards: at the remapped path on
+  // success, at the original path on failure.
   // Expansion state follows too: entries under the source move to the
   // destination (a remapped selection must not end up inside a collapsed
   // branch, and stale entries must not pre-expand a folder later
@@ -348,9 +346,19 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     const dst = input.trim().replace(/^\/+|\/+$/g, '')
     if (!dst || dst === node.path) return
     if (!guardEditedPath(node.path)) return
+    const pid = project?.id
+    const affectedEditing = editingUnder(node.path) ? editing : null
+    if (affectedEditing) setEditing(null)
     const ok = await run(() => moveProjectPath(project.id, node.path, dst))
-    if (!ok) return
-    remapEditing(node.path, dst)
+    if (!ok) {
+      // Restore only when still on the same project — a mid-flight switch
+      // already reset the editor state for the new project.
+      if (affectedEditing && projectIdRef.current === pid) setEditing(affectedEditing)
+      return
+    }
+    if (affectedEditing) {
+      setEditing({ ...affectedEditing, path: dst + affectedEditing.path.slice(node.path.length) })
+    }
     remapExpanded(node.path, dst)
     // Same remap as moveInto: a rename of the selected dir or one of its
     // ancestors must carry the selection to the new path, not strand it
@@ -359,17 +367,22 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       ? dst + prev.slice(node.path.length)
       : prev))
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
-  }, [project?.id, run, guardEditedPath, remapEditing, remapExpanded])
+  }, [project?.id, run, guardEditedPath, editingUnder, editing, remapExpanded])
 
   const handleDelete = useCallback(async (node) => {
     if (!guardEditedPath(node.path)) return
     const label = node.type === 'dir' ? `folder "${node.path}" and everything in it` : `"${node.path}"`
     if (!window.confirm(`Delete ${label}?`)) return
+    const pid = project?.id
+    const affectedEditing = editingUnder(node.path) ? editing : null
+    if (affectedEditing) setEditing(null) // closed before flight; stays closed on success
     const ok = await run(() => deleteProjectPath(project.id, node.path))
-    if (!ok) return
-    setEditing(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
+    if (!ok) {
+      if (affectedEditing && projectIdRef.current === pid) setEditing(affectedEditing)
+      return
+    }
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
-  }, [project?.id, run, guardEditedPath])
+  }, [project?.id, run, guardEditedPath, editingUnder, editing])
 
   const handleOpenFile = useCallback((node) => {
     if (!confirmDiscardEdits()) return
@@ -411,9 +424,17 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     }
     const dstPath = dstDir ? `${dstDir}/${baseName(srcPath)}` : baseName(srcPath)
     if (!guardEditedPath(srcPath)) return
+    const pid = project?.id
+    const affectedEditing = editingUnder(srcPath) ? editing : null
+    if (affectedEditing) setEditing(null)
     const ok = await run(() => moveProjectPath(project.id, srcPath, dstPath))
-    if (!ok) return
-    remapEditing(srcPath, dstPath)
+    if (!ok) {
+      if (affectedEditing && projectIdRef.current === pid) setEditing(affectedEditing)
+      return
+    }
+    if (affectedEditing) {
+      setEditing({ ...affectedEditing, path: dstPath + affectedEditing.path.slice(srcPath.length) })
+    }
     remapExpanded(srcPath, dstPath)
     // Keep the selection meaningful when the selected dir itself moved.
     setSelectedDir(prev => {
@@ -424,7 +445,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     })
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, srcPath) ? null : prev))
     expandTo(dstDir)
-  }, [project?.id, run, expandTo, guardEditedPath, remapEditing, remapExpanded])
+  }, [project?.id, run, expandTo, guardEditedPath, editingUnder, editing, remapExpanded])
 
   // -- Clipboard --
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -306,10 +306,21 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
   }, [project?.id, run, expandTo])
 
   const handleRename = useCallback(async (node) => {
-    const newPath = window.prompt('New path (relative to project root)', node.path)
-    if (!newPath || !newPath.trim() || newPath.trim() === node.path) return
-    const ok = await run(() => moveProjectPath(project.id, node.path, newPath.trim()))
-    if (ok) setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
+    const input = window.prompt('New path (relative to project root)', node.path)
+    if (!input || !input.trim()) return
+    // Normalize like the backend (split_rel_path strips slashes) so the
+    // selection remap below works with the path the tree will report.
+    const dst = input.trim().replace(/^\/+|\/+$/g, '')
+    if (!dst || dst === node.path) return
+    const ok = await run(() => moveProjectPath(project.id, node.path, dst))
+    if (!ok) return
+    // Same remap as moveInto: a rename of the selected dir or one of its
+    // ancestors must carry the selection to the new path, not strand it
+    // on a path the refreshed tree no longer contains.
+    setSelectedDir(prev => (prev && isSelfOrDescendant(prev, node.path)
+      ? dst + prev.slice(node.path.length)
+      : prev))
+    setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
   }, [project?.id, run])
 
   const handleDelete = useCallback(async (node) => {

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -159,6 +159,24 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     if (!editing || !editorDirtyRef.current) return true
     return window.confirm('Discard unsaved changes?')
   }, [editing])
+  // Mutations that touch the OPEN file or one of its ancestors (the tree
+  // stays actionable while the editor is mounted) must not proceed behind
+  // a dirty buffer's back: ask first, and let cancel abort the mutation.
+  const editingUnder = useCallback((path) =>
+    editing != null && isSelfOrDescendant(editing.path, path), [editing])
+  const guardEditedPath = useCallback((srcPath) => {
+    if (!editingUnder(srcPath)) return true
+    if (!editorDirtyRef.current) return true
+    return window.confirm('Discard unsaved changes?')
+  }, [editingUnder])
+  // After a successful rename/move of the open file or an ancestor, carry
+  // the editor to the new path (the keyed remount reloads from there — a
+  // dirty buffer was already discard-confirmed by guardEditedPath).
+  const remapEditing = useCallback((srcPath, dstPath) => {
+    setEditing(prev => (prev && isSelfOrDescendant(prev.path, srcPath)
+      ? { ...prev, path: dstPath + prev.path.slice(srcPath.length) }
+      : prev))
+  }, [])
   const fileInputRef = useRef(null)
   // Directory the next file-picker selection uploads into.
   const uploadDirRef = useRef('')
@@ -312,8 +330,10 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     // selection remap below works with the path the tree will report.
     const dst = input.trim().replace(/^\/+|\/+$/g, '')
     if (!dst || dst === node.path) return
+    if (!guardEditedPath(node.path)) return
     const ok = await run(() => moveProjectPath(project.id, node.path, dst))
     if (!ok) return
+    remapEditing(node.path, dst)
     // Same remap as moveInto: a rename of the selected dir or one of its
     // ancestors must carry the selection to the new path, not strand it
     // on a path the refreshed tree no longer contains.
@@ -321,14 +341,17 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       ? dst + prev.slice(node.path.length)
       : prev))
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
-  }, [project?.id, run])
+  }, [project?.id, run, guardEditedPath, remapEditing])
 
   const handleDelete = useCallback(async (node) => {
+    if (!guardEditedPath(node.path)) return
     const label = node.type === 'dir' ? `folder "${node.path}" and everything in it` : `"${node.path}"`
     if (!window.confirm(`Delete ${label}?`)) return
     const ok = await run(() => deleteProjectPath(project.id, node.path))
-    if (ok) setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
-  }, [project?.id, run])
+    if (!ok) return
+    setEditing(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
+    setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
+  }, [project?.id, run, guardEditedPath])
 
   const handleOpenFile = useCallback((node) => {
     if (!confirmDiscardEdits()) return
@@ -369,8 +392,10 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       return
     }
     const dstPath = dstDir ? `${dstDir}/${baseName(srcPath)}` : baseName(srcPath)
+    if (!guardEditedPath(srcPath)) return
     const ok = await run(() => moveProjectPath(project.id, srcPath, dstPath))
     if (!ok) return
+    remapEditing(srcPath, dstPath)
     // Keep the selection meaningful when the selected dir itself moved.
     setSelectedDir(prev => {
       if (prev && isSelfOrDescendant(prev, srcPath)) {
@@ -380,7 +405,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     })
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, srcPath) ? null : prev))
     expandTo(dstDir)
-  }, [project?.id, run, expandTo])
+  }, [project?.id, run, expandTo, guardEditedPath, remapEditing])
 
   // -- Clipboard --
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -254,9 +254,11 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     if (p !== selectedDir) setSelectedDir(p)
   }, [tree, selectedDir])
 
-  // Returns true when the mutation succeeded — callers use it to gate
-  // follow-up state changes (selection remaps, clipboard clears) that
-  // must not happen when the backend rejected the operation.
+  // Returns true only when the mutation succeeded AND the component still
+  // shows the project it ran against — callers use it to gate follow-up
+  // state changes (selection/editor/expansion remaps, clipboard clears)
+  // that must not happen when the backend rejected the operation, nor be
+  // applied to a DIFFERENT project the user switched to mid-flight.
   const run = useCallback(async (fn) => {
     // Same binding as refresh: a slow mutation for the previous project
     // must not flip busy/error state on the project now displayed (its
@@ -267,7 +269,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     try {
       await fn()
       await refresh()
-      return true
+      return projectIdRef.current === pid
     } catch (err) {
       if (projectIdRef.current === pid) setError(err.message)
       return false
@@ -334,8 +336,8 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     const name = window.prompt('Folder name')
     if (!name || !name.trim()) return
     const path = parentPath ? `${parentPath}/${name.trim()}` : name.trim()
-    await run(() => mkdirProjectPath(project.id, path))
-    expandTo(parentPath)
+    const ok = await run(() => mkdirProjectPath(project.id, path))
+    if (ok) expandTo(parentPath)
   }, [project?.id, run, expandTo])
 
   const handleRename = useCallback(async (node) => {

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -177,6 +177,21 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       ? { ...prev, path: dstPath + prev.path.slice(srcPath.length) }
       : prev))
   }, [])
+  // Expansion state follows too: entries under the source move to the
+  // destination (a remapped selection must not end up inside a collapsed
+  // branch, and stale entries must not pre-expand a folder later
+  // recreated at the old path), and the destination's ancestors open up
+  // so the moved/renamed node is actually visible.
+  const remapExpanded = useCallback((srcPath, dstPath) => {
+    setExpanded(prev => {
+      const next = new Set()
+      for (const p of prev) {
+        next.add(isSelfOrDescendant(p, srcPath) ? dstPath + p.slice(srcPath.length) : p)
+      }
+      for (const a of ancestorsOf(dstPath)) next.add(a)
+      return next
+    })
+  }, [])
   const fileInputRef = useRef(null)
   // Directory the next file-picker selection uploads into.
   const uploadDirRef = useRef('')
@@ -334,6 +349,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     const ok = await run(() => moveProjectPath(project.id, node.path, dst))
     if (!ok) return
     remapEditing(node.path, dst)
+    remapExpanded(node.path, dst)
     // Same remap as moveInto: a rename of the selected dir or one of its
     // ancestors must carry the selection to the new path, not strand it
     // on a path the refreshed tree no longer contains.
@@ -341,7 +357,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
       ? dst + prev.slice(node.path.length)
       : prev))
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, node.path) ? null : prev))
-  }, [project?.id, run, guardEditedPath, remapEditing])
+  }, [project?.id, run, guardEditedPath, remapEditing, remapExpanded])
 
   const handleDelete = useCallback(async (node) => {
     if (!guardEditedPath(node.path)) return
@@ -396,6 +412,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     const ok = await run(() => moveProjectPath(project.id, srcPath, dstPath))
     if (!ok) return
     remapEditing(srcPath, dstPath)
+    remapExpanded(srcPath, dstPath)
     // Keep the selection meaningful when the selected dir itself moved.
     setSelectedDir(prev => {
       if (prev && isSelfOrDescendant(prev, srcPath)) {
@@ -405,7 +422,7 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
     })
     setClipboard(prev => (prev && isSelfOrDescendant(prev.path, srcPath) ? null : prev))
     expandTo(dstDir)
-  }, [project?.id, run, expandTo, guardEditedPath, remapEditing])
+  }, [project?.id, run, expandTo, guardEditedPath, remapEditing, remapExpanded])
 
   // -- Clipboard --
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -724,6 +724,43 @@ describe('ProjectPage stale-mutation guard', () => {
   })
 })
 
+describe('ProjectPage stale-mutation success remap guard (regression: codex 4.2)', () => {
+  it('a move finishing after a project switch cannot remap the new project\'s selection', async () => {
+    // Start moving docs → archive in project A, switch to project B (which
+    // has its own docs/inner), select B's docs/inner, THEN let A's move
+    // resolve. run()'s success must be project-bound, or the stale
+    // handler's remap would drag B's selection to A's destination.
+    const treeB = [
+      { name: 'docs', path: 'docs', type: 'dir', modified_at: 1, children: [
+        { name: 'inner', path: 'docs/inner', type: 'dir', modified_at: 1, children: [] },
+      ] },
+    ]
+    mockTree.mockImplementation((pid) =>
+      Promise.resolve({ tree: pid === 'pb' ? treeB : TREE }))
+    let resolveMove
+    mockMove.mockImplementation(() => new Promise(res => { resolveMove = res }))
+
+    const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
+    await screen.findByTestId('file-row-readme.md')
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('pa', 'docs', 'archive/docs'))
+
+    rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
+    await screen.findByTestId('tree-node-docs')
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    fireEvent.click(screen.getByTestId('tree-node-docs/inner'))
+    expect(screen.getByTestId('crumb-docs/inner')).toBeTruthy()
+
+    resolveMove({}) // A's moveInto resumes against B's rendered state
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+    // B's selection is untouched — not remapped to A's destination, not
+    // knocked back to the root by the missing-path fallback.
+    expect(screen.getByTestId('crumb-docs/inner')).toBeTruthy()
+    expect(screen.queryByTestId('crumb-archive/docs/inner')).toBeNull()
+  })
+})
+
 describe('ProjectPage stale-refresh generation theft', () => {
   it('a stale mutation follow-up cannot invalidate the pending fetch of the current project', async () => {
     // Ordering: A's mutation pending → switch to B (B's tree fetch stays

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -476,6 +476,32 @@ describe('ProjectPage rename selection follow (regression: codex 1.1)', () => {
     await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'notes'))
     // Selection followed docs/inner → notes/inner instead of falling back.
     await waitFor(() => expect(screen.getByTestId('crumb-notes/inner')).toBeTruthy())
+    // And the expansion set followed too: the selected tree row is
+    // actually visible, not hidden inside a collapsed "notes" branch
+    // (regression: codex 3.1).
+    expect(screen.getByTestId('tree-node-notes/inner')).toBeTruthy()
+  })
+
+  it('moving an ancestor of the selected folder keeps the selected tree row visible (regression: codex 3.1)', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    fireEvent.click(screen.getByTestId('tree-node-docs/inner'))
+    const movedTree = [
+      { name: 'archive', path: 'archive', type: 'dir', modified_at: 1, children: [
+        { name: 'docs', path: 'archive/docs', type: 'dir', modified_at: 1, children: [
+          { name: 'inner', path: 'archive/docs/inner', type: 'dir', modified_at: 1, children: [] },
+          { name: 'a.txt', path: 'archive/docs/a.txt', type: 'file', size: 5, modified_at: 1 },
+        ] },
+      ] },
+      { name: 'readme.md', path: 'readme.md', type: 'file', size: 12, modified_at: 1 },
+    ]
+    mockTree.mockResolvedValue({ tree: movedTree })
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'archive/docs'))
+    // Selection followed to archive/docs/inner AND its whole branch is
+    // expanded, so the selected tree row is on screen.
+    await waitFor(() => expect(screen.getByTestId('crumb-archive/docs/inner')).toBeTruthy())
+    expect(screen.getByTestId('tree-node-archive/docs/inner')).toBeTruthy()
   })
 
   it('renaming the selected folder itself follows to the new path', async () => {

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -27,6 +27,7 @@ vi.mock('../../services/chat', () => ({
 const project = { id: 'p1', name: 'Research', description: 'notes & data' }
 
 const TREE = [
+  { name: 'archive', path: 'archive', type: 'dir', modified_at: 1, children: [] },
   {
     name: 'docs', path: 'docs', type: 'dir', modified_at: 1, children: [
       { name: 'inner', path: 'docs/inner', type: 'dir', modified_at: 1, children: [] },
@@ -209,7 +210,7 @@ describe('ProjectPage explorer layout', () => {
     await renderPage()
     fireEvent.click(screen.getByTestId('tree-node-docs'))
     expect(screen.getByTestId('file-row-docs/a.txt')).toBeTruthy()
-    mockTree.mockResolvedValue({ tree: [TREE[1]] }) // docs gone after refresh
+    mockTree.mockResolvedValue({ tree: TREE.filter(n => n.path !== 'docs') }) // docs gone after refresh
     vi.spyOn(window, 'confirm').mockReturnValue(true)
     fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
     fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Delete'))
@@ -378,6 +379,80 @@ describe('ProjectPage drag and drop', () => {
     await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs/inner', 'inner'))
     // Right pane follows the moved folder (still selected, at its new path).
     await waitFor(() => expect(screen.getByTestId('crumb-inner')).toBeTruthy())
+  })
+})
+
+describe('ProjectPage open-editor mutation guard (regression: codex 2.1)', () => {
+  // The tree stays actionable while the editor is mounted, so mutating
+  // the open file's folder must consult the dirty buffer first, and a
+  // successful rename/move must carry the editor to the new path.
+  async function openDocsFile({ dirty }) {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    fireEvent.click(screen.getByTestId('file-row-docs/a.txt'))
+    const ta = await screen.findByTestId('editor-textarea')
+    if (dirty) fireEvent.change(ta, { target: { value: 'unsaved work' } })
+    return ta
+  }
+
+  it('dragging the open file\'s folder with a dirty buffer asks; cancel aborts the move', async () => {
+    await openDocsFile({ dirty: true })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    expect(confirmSpy).toHaveBeenCalled()
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockMove).not.toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
+  })
+
+  it('confirming the discard moves the folder and remaps the editor path', async () => {
+    await openDocsFile({ dirty: true })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'archive/docs'))
+    // The keyed remount reloads the buffer from the file's new location.
+    await waitFor(() => expect(mockGetContent).toHaveBeenLastCalledWith('p1', 'archive/docs/a.txt'))
+    expect(screen.getByTestId('file-editor')).toBeTruthy()
+  })
+
+  it('renaming the open file\'s folder with a clean buffer remaps without asking', async () => {
+    await openDocsFile({ dirty: false })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    vi.spyOn(window, 'prompt').mockReturnValue('notes')
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Rename'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'notes'))
+    expect(confirmSpy).not.toHaveBeenCalled()
+    await waitFor(() => expect(mockGetContent).toHaveBeenLastCalledWith('p1', 'notes/a.txt'))
+  })
+
+  it('deleting the open file\'s folder closes the editor', async () => {
+    await openDocsFile({ dirty: true })
+    vi.spyOn(window, 'confirm').mockReturnValue(true) // discard + delete confirms
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Delete'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('p1', 'docs'))
+    await waitFor(() => expect(screen.queryByTestId('file-editor')).toBeNull())
+  })
+
+  it('cancelling the discard aborts the delete entirely', async () => {
+    await openDocsFile({ dirty: true })
+    vi.spyOn(window, 'confirm').mockReturnValueOnce(false) // discard prompt
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Delete'))
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockDelete).not.toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
+  })
+
+  it('cut-pasting the open file itself carries the editor to the destination', async () => {
+    await openDocsFile({ dirty: false })
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    fireEvent.contextMenu(screen.getByTestId('tree-node-archive'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Paste into'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'archive/docs'))
+    await waitFor(() => expect(mockGetContent).toHaveBeenLastCalledWith('p1', 'archive/docs/a.txt'))
   })
 })
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -445,6 +445,46 @@ describe('ProjectPage open-editor mutation guard (regression: codex 2.1)', () =>
     expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
   })
 
+  it('the editor is unmounted while an affecting move is in flight, so nothing can be typed into a doomed buffer (regression: codex 6.1)', async () => {
+    await openDocsFile({ dirty: false })
+    let resolveMove
+    mockMove.mockImplementation(() => new Promise(res => { resolveMove = res }))
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'archive/docs'))
+    // In flight: no writable textarea exists — the iteration-2 guard's
+    // pre-await dirty sample can't be raced by typing.
+    expect(screen.queryByTestId('editor-textarea')).toBeNull()
+
+    resolveMove({})
+    // Reopened at the new path, freshly loaded from disk.
+    await waitFor(() => expect(mockGetContent).toHaveBeenLastCalledWith('p1', 'archive/docs/a.txt'))
+    expect(await screen.findByTestId('file-editor')).toBeTruthy()
+  })
+
+  it('a failed affecting move reopens the editor at its original path', async () => {
+    await openDocsFile({ dirty: false })
+    mockGetContent.mockClear()
+    mockMove.mockRejectedValue(new Error('destination already exists'))
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-archive'))
+    expect(await screen.findByText('destination already exists')).toBeTruthy()
+    await waitFor(() => expect(mockGetContent).toHaveBeenLastCalledWith('p1', 'docs/a.txt'))
+    expect(screen.getByTestId('file-editor')).toBeTruthy()
+  })
+
+  it('the editor closes before an affecting delete resolves and stays closed', async () => {
+    await openDocsFile({ dirty: false })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    let resolveDelete
+    mockDelete.mockImplementation(() => new Promise(res => { resolveDelete = res }))
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Delete'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('p1', 'docs'))
+    expect(screen.queryByTestId('editor-textarea')).toBeNull()
+    resolveDelete({ ok: true })
+    await new Promise(r => setTimeout(r, 0))
+    expect(screen.queryByTestId('file-editor')).toBeNull()
+  })
+
   it('cut-pasting the open file itself carries the editor to the destination', async () => {
     await openDocsFile({ dirty: false })
     fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -381,6 +381,53 @@ describe('ProjectPage drag and drop', () => {
   })
 })
 
+describe('ProjectPage rename selection follow (regression: codex 1.1)', () => {
+  const renamedTree = [
+    { name: 'notes', path: 'notes', type: 'dir', modified_at: 1, children: [
+      { name: 'inner', path: 'notes/inner', type: 'dir', modified_at: 1, children: [] },
+      { name: 'a.txt', path: 'notes/a.txt', type: 'file', size: 5, modified_at: 1 },
+    ] },
+    { name: 'readme.md', path: 'readme.md', type: 'file', size: 12, modified_at: 1 },
+  ]
+
+  it('renaming an ancestor of the selected folder carries the selection along', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    fireEvent.click(screen.getByTestId('tree-node-docs/inner'))
+    mockTree.mockResolvedValue({ tree: renamedTree })
+    vi.spyOn(window, 'prompt').mockReturnValue('notes')
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Rename'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'notes'))
+    // Selection followed docs/inner → notes/inner instead of falling back.
+    await waitFor(() => expect(screen.getByTestId('crumb-notes/inner')).toBeTruthy())
+  })
+
+  it('renaming the selected folder itself follows to the new path', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    mockTree.mockResolvedValue({ tree: renamedTree })
+    // Slashes are normalized away, matching the backend's path handling.
+    vi.spyOn(window, 'prompt').mockReturnValue('/notes/')
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Rename'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs', 'notes'))
+    await waitFor(() => expect(screen.getByTestId('crumb-notes')).toBeTruthy())
+    expect(screen.getByTestId('file-row-notes/a.txt')).toBeTruthy()
+  })
+
+  it('a failed rename leaves the selection where it was', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    mockMove.mockRejectedValue(new Error('destination already exists'))
+    vi.spyOn(window, 'prompt').mockReturnValue('notes')
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Rename'))
+    expect(await screen.findByText('destination already exists')).toBeTruthy()
+    expect(screen.getByTestId('crumb-docs')).toBeTruthy()
+  })
+})
+
 describe('ProjectPage editor integration', () => {
   it('clicking a file row opens the editor with its content; closing returns to the listing', async () => {
     await renderPage()

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react'
 import ProjectPage from './ProjectPage'
 
-const { mockTree, mockUpload, mockMkdir, mockMove, mockDelete, mockGetContent, mockSaveContent } = vi.hoisted(() => ({
+const { mockTree, mockUpload, mockMkdir, mockMove, mockCopy, mockDelete, mockGetContent, mockSaveContent } = vi.hoisted(() => ({
   mockTree: vi.fn(),
   mockUpload: vi.fn(),
   mockMkdir: vi.fn(),
   mockMove: vi.fn(),
+  mockCopy: vi.fn(),
   mockDelete: vi.fn(),
   mockGetContent: vi.fn(),
   mockSaveContent: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock('../../services/chat', () => ({
   uploadProjectFile: (...a) => mockUpload(...a),
   mkdirProjectPath: (...a) => mockMkdir(...a),
   moveProjectPath: (...a) => mockMove(...a),
+  copyProjectPath: (...a) => mockCopy(...a),
   deleteProjectPath: (...a) => mockDelete(...a),
   downloadProjectFile: vi.fn(),
   getProjectFileContent: (...a) => mockGetContent(...a),
@@ -27,6 +29,7 @@ const project = { id: 'p1', name: 'Research', description: 'notes & data' }
 const TREE = [
   {
     name: 'docs', path: 'docs', type: 'dir', modified_at: 1, children: [
+      { name: 'inner', path: 'docs/inner', type: 'dir', modified_at: 1, children: [] },
       { name: 'a.txt', path: 'docs/a.txt', type: 'file', size: 5, modified_at: 1 },
     ],
   },
@@ -38,6 +41,7 @@ beforeEach(() => {
   mockUpload.mockReset().mockResolvedValue({})
   mockMkdir.mockReset().mockResolvedValue({})
   mockMove.mockReset().mockResolvedValue({})
+  mockCopy.mockReset().mockResolvedValue({})
   mockDelete.mockReset().mockResolvedValue({ ok: true })
   mockGetContent.mockReset().mockResolvedValue({ path: 'readme.md', content: 'doc', revision: 'r1' })
   mockSaveContent.mockReset().mockResolvedValue({ path: 'readme.md', revision: 'r2' })
@@ -51,25 +55,88 @@ afterEach(() => {
 async function renderPage() {
   render(<ProjectPage project={project} />)
   await waitFor(() => expect(mockTree).toHaveBeenCalledWith('p1'))
-  await screen.findByText('readme.md')
+  await screen.findByTestId('file-row-readme.md')
 }
 
-describe('ProjectPage file tree', () => {
-  it('renders header, root entries, and dir contents after expand', async () => {
+// Minimal DataTransfer stand-in — jsdom has no native one.
+function makeDataTransfer() {
+  return {
+    store: {},
+    types: [],
+    effectAllowed: '',
+    dropEffect: '',
+    setData(type, val) {
+      this.store[type] = val
+      if (!this.types.includes(type)) this.types.push(type)
+    },
+    getData(type) { return this.store[type] || '' },
+  }
+}
+
+function dragAndDrop(srcEl, dstEl) {
+  const dataTransfer = makeDataTransfer()
+  fireEvent.dragStart(srcEl, { dataTransfer })
+  fireEvent.dragOver(dstEl, { dataTransfer })
+  fireEvent.drop(dstEl, { dataTransfer })
+}
+
+describe('ProjectPage explorer layout', () => {
+  it('renders header, folder tree, and root contents', async () => {
     await renderPage()
-    expect(screen.getByText('Research')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Research' })).toBeTruthy()
     expect(screen.getByText('notes & data')).toBeTruthy()
-    expect(screen.getByText('docs')).toBeTruthy()
-    // Children hidden until the dir is expanded.
-    expect(screen.queryByText('a.txt')).toBeNull()
+    // Tree pane: root node + dirs only.
+    expect(screen.getByTestId('tree-node-root')).toBeTruthy()
+    expect(screen.getByTestId('tree-node-docs')).toBeTruthy()
+    expect(screen.queryByTestId('tree-node-readme.md')).toBeNull()
+    // Right pane: root entries; children hidden until docs is selected.
+    expect(screen.getByTestId('file-row-docs')).toBeTruthy()
+    expect(screen.queryByTestId('file-row-docs/a.txt')).toBeNull()
+  })
+
+  it('selecting a folder in the tree shows its contents in the right pane', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    expect(screen.getByTestId('file-row-docs/a.txt')).toBeTruthy()
+    expect(screen.getByTestId('file-row-docs/inner')).toBeTruthy()
+    expect(screen.queryByTestId('file-row-readme.md')).toBeNull()
+  })
+
+  it('clicking a folder row in the right pane navigates into it', async () => {
+    await renderPage()
     fireEvent.click(screen.getByTestId('file-row-docs'))
-    expect(screen.getByText('a.txt')).toBeTruthy()
+    expect(screen.getByTestId('file-row-docs/a.txt')).toBeTruthy()
+  })
+
+  it('breadcrumb navigates back to the root', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-docs'))
+    expect(screen.getByTestId('crumb-docs')).toBeTruthy()
+    fireEvent.click(screen.getByLabelText('Go to project root'))
+    expect(screen.getByTestId('file-row-readme.md')).toBeTruthy()
+  })
+
+  it('tree chevron expands subfolders without changing the selection', async () => {
+    await renderPage()
+    expect(screen.queryByTestId('tree-node-docs/inner')).toBeNull()
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    expect(screen.getByTestId('tree-node-docs/inner')).toBeTruthy()
+    // Selection unchanged: right pane still shows the root.
+    expect(screen.getByTestId('file-row-readme.md')).toBeTruthy()
   })
 
   it('renders a "Project not found" state without a project', () => {
     render(<ProjectPage project={null} />)
     expect(screen.getByText('Project not found')).toBeTruthy()
     expect(mockTree).not.toHaveBeenCalled()
+  })
+
+  it('toolbar actions target the selected folder', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    vi.spyOn(window, 'prompt').mockReturnValue('sub')
+    fireEvent.click(screen.getByText('New folder'))
+    await waitFor(() => expect(mockMkdir).toHaveBeenCalledWith('p1', 'docs/sub'))
   })
 
   it('creates a folder at root via prompt and refreshes', async () => {
@@ -80,20 +147,13 @@ describe('ProjectPage file tree', () => {
     expect(mockTree).toHaveBeenCalledTimes(2)
   })
 
-  it('creates a subfolder inside a dir from its hover action', async () => {
+  it('uploads picked files into the selected directory', async () => {
     await renderPage()
-    vi.spyOn(window, 'prompt').mockReturnValue('sub')
-    fireEvent.click(screen.getByLabelText('New subfolder in docs'))
-    await waitFor(() => expect(mockMkdir).toHaveBeenCalledWith('p1', 'docs/sub'))
-  })
-
-  it('uploads picked files into the chosen directory', async () => {
-    await renderPage()
-    fireEvent.click(screen.getByLabelText('Upload into docs'))
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    fireEvent.click(screen.getByText('Upload files'))
     const file = new File(['hello'], 'up.txt', { type: 'text/plain' })
     fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
     await waitFor(() => expect(mockUpload).toHaveBeenCalledWith('p1', file, { dir: 'docs' }))
-    expect(mockTree).toHaveBeenCalledTimes(2)
   })
 
   it('offers overwrite when the upload conflicts', async () => {
@@ -144,10 +204,185 @@ describe('ProjectPage file tree', () => {
     render(<ProjectPage project={project} />)
     expect(await screen.findByText(/No files yet/)).toBeTruthy()
   })
+
+  it('deleting the selected folder falls back to its parent', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    expect(screen.getByTestId('file-row-docs/a.txt')).toBeTruthy()
+    mockTree.mockResolvedValue({ tree: [TREE[1]] }) // docs gone after refresh
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.contextMenu(screen.getByTestId('tree-node-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Delete'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('p1', 'docs'))
+    // Selection fell back to root, which still has readme.md.
+    expect(await screen.findByTestId('file-row-readme.md')).toBeTruthy()
+  })
+})
+
+describe('ProjectPage context menu', () => {
+  it('right-clicking a file offers Open/Download/Cut/Copy/Rename/Delete', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    const menu = screen.getByTestId('context-menu')
+    for (const label of ['Open', 'Download', 'Cut', 'Copy', 'Rename', 'Delete']) {
+      expect(within(menu).getByText(label)).toBeTruthy()
+    }
+  })
+
+  it('closes on Escape without acting', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByTestId('context-menu')).toBeNull()
+    expect(mockMove).not.toHaveBeenCalled()
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('cut then paste into a folder moves it and clears the clipboard', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    expect(screen.getByTestId('clipboard-chip')).toBeTruthy()
+    // Cut source is dimmed while on the clipboard.
+    expect(screen.getByTestId('file-row-readme.md').className).toContain('opacity-50')
+
+    fireEvent.contextMenu(screen.getByTestId('file-row-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Paste into'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'readme.md', 'docs/readme.md'))
+    await waitFor(() => expect(screen.queryByTestId('clipboard-chip')).toBeNull())
+  })
+
+  it('copy then paste keeps the clipboard and copies with a non-colliding name', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Copy'))
+
+    // Paste into the SAME folder → "(copy)" suffix before the extension.
+    fireEvent.contextMenu(screen.getByTestId('dir-contents'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Paste'))
+    await waitFor(() => expect(mockCopy).toHaveBeenCalledWith('p1', 'readme.md', 'readme (copy).md'))
+    // Copy stays on the clipboard for repeated pastes.
+    expect(screen.getByTestId('clipboard-chip')).toBeTruthy()
+  })
+
+  it('pasting a copied file into a folder without a collision keeps its name', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Copy'))
+    fireEvent.contextMenu(screen.getByTestId('file-row-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Paste into'))
+    await waitFor(() => expect(mockCopy).toHaveBeenCalledWith('p1', 'readme.md', 'docs/readme.md'))
+  })
+
+  it('Paste is disabled while the clipboard is empty', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('dir-contents'), { clientX: 5, clientY: 5 })
+    expect(within(screen.getByTestId('context-menu')).getByText('Paste').closest('button').disabled).toBe(true)
+  })
+
+  it('the clipboard chip can be cleared manually', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    fireEvent.click(screen.getByLabelText('Clear clipboard'))
+    expect(screen.queryByTestId('clipboard-chip')).toBeNull()
+  })
+
+  it('deleting the cut source clears the clipboard', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.click(screen.getByLabelText('Delete readme.md'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalled())
+    await waitFor(() => expect(screen.queryByTestId('clipboard-chip')).toBeNull())
+  })
+
+  it('the root tree node menu pastes into the root', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs')) // selection elsewhere
+    fireEvent.contextMenu(screen.getByTestId('file-row-docs/a.txt'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    fireEvent.contextMenu(screen.getByTestId('tree-node-root'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Paste'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs/a.txt', 'a.txt'))
+  })
+
+  it('Open on a folder navigates into it', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('file-row-docs'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Open'))
+    expect(screen.getByTestId('file-row-docs/a.txt')).toBeTruthy()
+  })
+})
+
+describe('ProjectPage drag and drop', () => {
+  it('dropping a file onto a tree folder moves it there', async () => {
+    await renderPage()
+    dragAndDrop(screen.getByTestId('file-row-readme.md'), screen.getByTestId('tree-node-docs'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'readme.md', 'docs/readme.md'))
+  })
+
+  it('dropping a file onto a folder row moves it there', async () => {
+    await renderPage()
+    dragAndDrop(screen.getByTestId('file-row-readme.md'), screen.getByTestId('file-row-docs'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'readme.md', 'docs/readme.md'))
+  })
+
+  it('dropping onto the root tree node moves to the root', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    dragAndDrop(screen.getByTestId('file-row-docs/a.txt'), screen.getByTestId('tree-node-root'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs/a.txt', 'a.txt'))
+  })
+
+  it('dropping into the item\'s own parent is a no-op', async () => {
+    await renderPage()
+    dragAndDrop(screen.getByTestId('file-row-readme.md'), screen.getByTestId('tree-node-root'))
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockMove).not.toHaveBeenCalled()
+  })
+
+  it('dropping a folder into its own subtree is rejected client-side', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    dragAndDrop(screen.getByTestId('tree-node-docs'), screen.getByTestId('tree-node-docs/inner'))
+    expect(await screen.findByText('cannot move a folder into itself')).toBeTruthy()
+    expect(mockMove).not.toHaveBeenCalled()
+  })
+
+  it('foreign drags without the internal payload type are ignored', async () => {
+    await renderPage()
+    const dataTransfer = makeDataTransfer()
+    dataTransfer.setData('text/plain', 'whatever')
+    fireEvent.dragOver(screen.getByTestId('tree-node-docs'), { dataTransfer })
+    fireEvent.drop(screen.getByTestId('tree-node-docs'), { dataTransfer })
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockMove).not.toHaveBeenCalled()
+  })
+
+  it('moving the selected folder keeps the selection on its new path', async () => {
+    await renderPage()
+    // Select docs/inner, then move it into the root.
+    fireEvent.click(screen.getByLabelText('Expand docs'))
+    fireEvent.click(screen.getByTestId('tree-node-docs/inner'))
+    const movedTree = [
+      { name: 'docs', path: 'docs', type: 'dir', modified_at: 1, children: [
+        { name: 'a.txt', path: 'docs/a.txt', type: 'file', size: 5, modified_at: 1 },
+      ] },
+      { name: 'inner', path: 'inner', type: 'dir', modified_at: 1, children: [] },
+      { name: 'readme.md', path: 'readme.md', type: 'file', size: 12, modified_at: 1 },
+    ]
+    mockTree.mockResolvedValue({ tree: movedTree })
+    dragAndDrop(screen.getByTestId('tree-node-docs/inner'), screen.getByTestId('tree-node-root'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs/inner', 'inner'))
+    // Right pane follows the moved folder (still selected, at its new path).
+    await waitFor(() => expect(screen.getByTestId('crumb-inner')).toBeTruthy())
+  })
 })
 
 describe('ProjectPage editor integration', () => {
-  it('clicking a file row opens the editor with its content; closing returns to the tree', async () => {
+  it('clicking a file row opens the editor with its content; closing returns to the listing', async () => {
     await renderPage()
     fireEvent.click(screen.getByTestId('file-row-readme.md'))
     await waitFor(() => expect(mockGetContent).toHaveBeenCalledWith('p1', 'readme.md'))
@@ -156,7 +391,7 @@ describe('ProjectPage editor integration', () => {
 
     fireEvent.click(screen.getByLabelText('Close editor'))
     expect(screen.queryByTestId('file-editor')).toBeNull()
-    expect(screen.getByText('readme.md')).toBeTruthy()
+    expect(screen.getByTestId('file-row-readme.md')).toBeTruthy()
   })
 
   it('New file prompts for a name and opens an empty new-file editor', async () => {
@@ -176,6 +411,17 @@ describe('ProjectPage editor integration', () => {
     await waitFor(() => expect(mockGetContent).toHaveBeenCalledWith('p1', 'readme.md'))
   })
 
+  it('New file in a selected folder creates under that folder', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    vi.spyOn(window, 'prompt').mockReturnValue('notes.md')
+    fireEvent.click(screen.getByText('New file'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'x' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockSaveContent).toHaveBeenCalledWith('p1', 'docs/notes.md', 'x', null, true))
+  })
+
   it('saving a new file refreshes the tree', async () => {
     await renderPage()
     vi.spyOn(window, 'prompt').mockReturnValue('fresh.md')
@@ -185,6 +431,17 @@ describe('ProjectPage editor integration', () => {
     fireEvent.click(screen.getByText('Save'))
     await waitFor(() => expect(mockSaveContent).toHaveBeenCalledWith('p1', 'fresh.md', 'body', null, true))
     await waitFor(() => expect(mockTree).toHaveBeenCalledTimes(2))
+  })
+
+  it('navigating the tree while the editor is dirty asks first; cancel keeps the editor', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('file-row-readme.md'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved work' } })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
   })
 })
 
@@ -350,17 +607,5 @@ describe('ProjectPage stale-refresh generation theft', () => {
     resolveB({ tree: treeB })                                // B resolves LAST
     expect(await screen.findByText('b-only.txt')).toBeTruthy()
     expect(screen.queryByText('a-only.txt')).toBeNull()
-  })
-})
-
-describe('ProjectPage upload row visibility', () => {
-  it('expands the target dir after uploading into it', async () => {
-    await renderPage()
-    fireEvent.click(within(screen.getByTestId('file-row-docs')).getByLabelText('Upload into docs'))
-    const file = new File(['hello'], 'up.txt', { type: 'text/plain' })
-    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
-    await waitFor(() => expect(mockUpload).toHaveBeenCalled())
-    // docs auto-expanded → its child is visible.
-    expect(await screen.findByText('a.txt')).toBeTruthy()
   })
 })

--- a/dashboard/frontend/src/services/chat.js
+++ b/dashboard/frontend/src/services/chat.js
@@ -110,6 +110,13 @@ export async function moveProjectPath(projectId, path, newPath) {
   })
 }
 
+export async function copyProjectPath(projectId, path, newPath) {
+  return fetchAPI(`/chat/projects/${projectId}/files/copy`, {
+    method: 'POST',
+    body: JSON.stringify({ path, new_path: newPath }),
+  })
+}
+
 export async function deleteProjectPath(projectId, path) {
   return fetchAPI(`/chat/projects/${projectId}/files?path=${encodeURIComponent(path)}`, {
     method: 'DELETE',

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -907,6 +907,28 @@ class TestCopy:
         with pytest.raises(pf.ProjectFilesError):
             pf.copy_path(made_root, "d", "d/inner")
 
+    def test_copy_into_self_via_symlink_alias_rejected(self, made_root):
+        # The client-path prefix check can't see that "alias/copy" is
+        # physically d/copy when alias -> d; the physical-path comparison
+        # must catch it (regression: codex PR83 4.1).
+        pf.mkdir(made_root, "d")
+        self._write(made_root, "d/x.txt")
+        os.symlink(os.path.join(made_root, "d"), os.path.join(made_root, "alias"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "d", "alias/copy")
+        assert "into itself" in str(e.value)
+        assert not os.path.exists(os.path.join(made_root, "d", "copy"))
+
+    def test_copy_through_symlink_alias_to_elsewhere_still_works(self, made_root):
+        # An alias that does NOT land inside the source stays usable.
+        pf.mkdir(made_root, "d")
+        pf.mkdir(made_root, "other")
+        self._write(made_root, "d/x.txt")
+        os.symlink(os.path.join(made_root, "other"), os.path.join(made_root, "alias"))
+        node = pf.copy_path(made_root, "d", "alias/d")
+        assert node["type"] == "dir"
+        assert os.path.exists(os.path.join(made_root, "other", "d", "x.txt"))
+
     def test_copy_root_rejected(self, made_root):
         with pytest.raises(pf.ProjectFilesError):
             pf.copy_path(made_root, "", "x")

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -919,6 +919,34 @@ class TestCopy:
         assert "into itself" in str(e.value)
         assert not os.path.exists(os.path.join(made_root, "d", "copy"))
 
+    def test_copy_depth_cap_via_symlink_alias(self, made_root):
+        # A root-level alias to a deep directory spells a 2-component
+        # client path whose PHYSICAL depth is at the cap — the copied
+        # directory's children would land past it (regression: codex
+        # PR83 5.1).
+        deep_parts = ["p"] * (pf.MAX_PATH_DEPTH - 1)
+        deep_abs = os.path.join(made_root, *deep_parts)
+        os.makedirs(deep_abs)
+        os.symlink(deep_abs, os.path.join(made_root, "alias"))
+        self._write(made_root, "d/x.txt")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "d", "alias/c")
+        assert "depth" in str(e.value)
+        assert not os.path.exists(os.path.join(deep_abs, "c"))
+
+    def test_copy_file_past_depth_cap_via_symlink_alias(self, made_root):
+        # Same bypass with a single file: the destination itself sits past
+        # the cap, which would mint an entry no other route can address.
+        deep_parts = ["p"] * pf.MAX_PATH_DEPTH
+        deep_abs = os.path.join(made_root, *deep_parts)
+        os.makedirs(deep_abs)
+        os.symlink(deep_abs, os.path.join(made_root, "alias"))
+        self._write(made_root, "a.txt")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "a.txt", "alias/a.txt")
+        assert "too deep" in str(e.value)
+        assert not os.path.exists(os.path.join(deep_abs, "a.txt"))
+
     def test_copy_through_symlink_alias_to_elsewhere_still_works(self, made_root):
         # An alias that does NOT land inside the source stays usable.
         pf.mkdir(made_root, "d")

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -809,3 +809,172 @@ class TestErrorCodes:
                        headers=_auth())
         assert r.status_code == 400
         assert "code" not in r.get_json()
+
+
+# ---------------------------------------------------------------------------
+# copy_path (file-explorer copy/paste)
+# ---------------------------------------------------------------------------
+
+
+class TestCopy:
+    def _write(self, root, rel, content=b"data", mode=None):
+        abs_path = os.path.join(root, *rel.split("/"))
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        with open(abs_path, "wb") as f:
+            f.write(content)
+        if mode is not None:
+            os.chmod(abs_path, mode)
+        return abs_path
+
+    def test_copy_file(self, made_root):
+        self._write(made_root, "a.txt", b"hello")
+        node = pf.copy_path(made_root, "a.txt", "b.txt")
+        assert node["path"] == "b.txt"
+        assert node["type"] == "file"
+        with open(os.path.join(made_root, "b.txt"), "rb") as f:
+            assert f.read() == b"hello"
+        # Source untouched.
+        assert os.path.exists(os.path.join(made_root, "a.txt"))
+
+    def test_copy_preserves_mode(self, made_root):
+        self._write(made_root, "run.sh", b"#!/bin/sh\n", mode=0o755)
+        pf.copy_path(made_root, "run.sh", "run2.sh")
+        st = os.lstat(os.path.join(made_root, "run2.sh"))
+        assert stat_mod.S_IMODE(st.st_mode) == 0o755
+
+    def test_copy_into_directory(self, made_root):
+        self._write(made_root, "a.txt")
+        pf.mkdir(made_root, "docs")
+        node = pf.copy_path(made_root, "a.txt", "docs/a.txt")
+        assert node["path"] == "docs/a.txt"
+
+    def test_copy_directory_recursive(self, made_root):
+        self._write(made_root, "d/sub/x.txt", b"x")
+        self._write(made_root, "d/y.txt", b"y")
+        node = pf.copy_path(made_root, "d", "d2")
+        assert node["type"] == "dir"
+        with open(os.path.join(made_root, "d2", "sub", "x.txt"), "rb") as f:
+            assert f.read() == b"x"
+        with open(os.path.join(made_root, "d2", "y.txt"), "rb") as f:
+            assert f.read() == b"y"
+        # Original intact.
+        assert os.path.exists(os.path.join(made_root, "d", "sub", "x.txt"))
+
+    def test_copy_dangling_symlink_copies_the_link(self, made_root, tmp_path):
+        # A dangling link is an ordinary tree entry (build_tree lists it,
+        # move/delete operate on the link itself) — copy matches.
+        target = str(tmp_path / "does-not-exist.txt")
+        os.symlink(target, os.path.join(made_root, "link"))
+        pf.copy_path(made_root, "link", "link2")
+        dst = os.path.join(made_root, "link2")
+        assert os.path.islink(dst)
+        assert os.readlink(dst) == target
+
+    def test_copy_of_escaping_symlink_rejected_at_resolve(self, made_root, tmp_path):
+        # A link whose target EXISTS outside the root can't even be
+        # addressed — resolve()'s realpath containment check fires first.
+        # Same contract as move/delete.
+        outside = tmp_path / "outside-secret.txt"
+        outside.write_text("secret")
+        os.symlink(str(outside), os.path.join(made_root, "link"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "link", "link2")
+        assert "escapes" in str(e.value)
+
+    def test_copy_dir_containing_symlink_keeps_it_a_link(self, made_root, tmp_path):
+        outside = tmp_path / "outside-file.txt"
+        outside.write_text("secret")
+        pf.mkdir(made_root, "d")
+        os.symlink(str(outside), os.path.join(made_root, "d", "link"))
+        pf.copy_path(made_root, "d", "d2")
+        assert os.path.islink(os.path.join(made_root, "d2", "link"))
+
+    def test_copy_missing_source_404(self, made_root):
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "nope.txt", "x.txt")
+        assert e.value.status == 404
+
+    def test_copy_onto_existing_409(self, made_root):
+        self._write(made_root, "a.txt")
+        self._write(made_root, "b.txt")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "a.txt", "b.txt")
+        assert e.value.status == 409
+        assert e.value.code == "already_exists"
+
+    def test_copy_dir_into_itself_rejected(self, made_root):
+        pf.mkdir(made_root, "d")
+        with pytest.raises(pf.ProjectFilesError):
+            pf.copy_path(made_root, "d", "d/inner")
+
+    def test_copy_root_rejected(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.copy_path(made_root, "", "x")
+
+    def test_copy_to_missing_parent_404(self, made_root):
+        self._write(made_root, "a.txt")
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "a.txt", "missing-dir/a.txt")
+        assert e.value.status == 404
+
+    def test_copy_depth_cap_at_destination(self, made_root):
+        # Source: shallow dir with one file. Destination sits at the depth
+        # cap, so the copied CHILD would exceed it.
+        self._write(made_root, "d/x.txt")
+        deep = "/".join(["p"] * (pf.MAX_PATH_DEPTH - 1))
+        os.makedirs(os.path.join(made_root, *deep.split("/")))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "d", f"{deep}/d")
+        assert "depth" in str(e.value)
+        # Nothing partially copied.
+        assert not os.path.exists(os.path.join(made_root, *deep.split("/"), "d"))
+
+    def test_copy_dir_with_fifo_rejected_before_copying(self, made_root):
+        pf.mkdir(made_root, "d")
+        self._write(made_root, "d/ok.txt")
+        os.mkfifo(os.path.join(made_root, "d", "pipe"))
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.copy_path(made_root, "d", "d2")
+        assert "special file" in str(e.value)
+        assert not os.path.exists(os.path.join(made_root, "d2"))
+
+    def test_copy_bare_fifo_rejected(self, made_root):
+        os.mkfifo(os.path.join(made_root, "pipe"))
+        with pytest.raises(pf.ProjectFilesError):
+            pf.copy_path(made_root, "pipe", "pipe2")
+
+    def test_copy_traversal_rejected(self, made_root):
+        self._write(made_root, "a.txt")
+        with pytest.raises(pf.ProjectFilesError):
+            pf.copy_path(made_root, "a.txt", "../escape.txt")
+        with pytest.raises(pf.ProjectFilesError):
+            pf.copy_path(made_root, "../outside.txt", "a2.txt")
+
+
+def test_copy_via_http(client):
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt", b"hello")
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/copy",
+                    json={"path": "a.txt", "new_path": "b.txt"}, headers=_auth())
+    assert r.status_code == 201
+    assert r.get_json()["path"] == "b.txt"
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files/download?path=b.txt", headers=_auth())
+    assert r.data == b"hello"
+    # Source still present.
+    r = client.get(f"{PROJECTS_PATH}/{pid}/files", headers=_auth())
+    assert [n["name"] for n in r.get_json()["tree"]] == ["a.txt", "b.txt"]
+
+
+def test_copy_via_http_conflict_and_bad_body(client):
+    pid = _mkproject(client)
+    _upload(client, pid, "a.txt")
+    _upload(client, pid, "b.txt")
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/copy",
+                    json={"path": "a.txt", "new_path": "b.txt"}, headers=_auth())
+    assert r.status_code == 409
+    assert r.get_json()["code"] == "already_exists"
+    r = client.post(f"{PROJECTS_PATH}/{pid}/files/copy",
+                    data="nope", headers=_auth(), content_type="application/json")
+    assert r.status_code == 400
+    assert client.post(f"{PROJECTS_PATH}/{pid}/files/copy",
+                       json={"path": "a.txt", "new_path": "b.txt"}).status_code == 401


### PR DESCRIPTION
Reworks the project files page into a two-pane explorer and adds the backend copy operation that copy/paste needs.

## Frontend
- **Two-pane layout**: folder tree on the left (expand/collapse independent of selection), the selected folder's contents on the right, with breadcrumb navigation. Selection follows a moved folder to its new path and falls back to the nearest surviving ancestor when the selected folder is deleted.
- **Drag-and-drop move**: rows (files and folders) are draggable; tree folders, folder rows, and the right pane's background are drop targets. A custom DataTransfer type keeps foreign drags inert; dropping into the item's own parent is a no-op; dropping a folder into its own subtree is rejected client-side.
- **Context menu** (new `ContextMenu.jsx`): Open/Download/Cut/Copy/Rename/Delete on entries; New file/New folder/Upload/Paste on folders, the root tree node, and the pane background. A toolbar chip shows the armed clipboard entry (cut sources render dimmed); pasting a copy auto-suffixes `(copy)` / `(copy N)` on name collisions. Cut+paste maps to move; the clipboard clears when its source is moved, renamed, or deleted.
- Toolbar (upload / new file / new folder) now targets the selected folder.
- All existing stale-response/stale-mutation/generation-theft guards and editor regressions preserved and re-covered.

## Backend
- `project_files.copy_path`: copies a regular file (staged + atomic no-replace link, preserving mode), a dangling symlink (as a link, never followed), or a directory tree (`copytree(symlinks=True)` with cleanup of partial copies). Same contracts as `move`: destination parent must exist, `409 already_exists` when the destination is taken, no copy-into-self. A pre-scan rejects special files (a FIFO would block the worker) and enforces `MAX_PATH_DEPTH` at the destination.
- `POST /api/chat/projects/<id>/files/copy` `{path, new_path}` → 201.

## Tests
- Backend: 559 passing (+16 for copy: pure layer incl. symlink/FIFO/depth/traversal cases, HTTP roundtrip, conflict codes, auth).
- Frontend: 229 passing (ProjectPage suite rewritten for the explorer model: tree navigation, breadcrumbs, context menu, clipboard flows, DnD incl. guard cases).