### PR TITLE
feat(chat): project-files MCP write tools — create, write, edit, insert

### DIFF
--- a/dashboard/chat/mcp_registry.py
+++ b/dashboard/chat/mcp_registry.py
@@ -128,10 +128,10 @@ The diagram will be rendered automatically as an artifact.""",
     },
     "project-files": {
         "name": "Project Files",
-        "description": "Read this conversation's project files — list, read, search. Auto-enabled for conversations inside a project; does nothing outside one.",
+        "description": "Read and edit this conversation's project files — list, read, search, create, write. Auto-enabled for conversations inside a project; does nothing outside one.",
         "command": [sys.executable, os.path.join(_SERVERS_DIR, "project_files_server.py")],
         "icon": "fa-folder-tree",
-        "tool_hint": "This conversation belongs to a project with a file area (documents, notes, data the user keeps alongside the project's conversations). You have read-only access to it: list_files shows the file tree, read_file returns a text file's content, search_files finds a substring across file names and contents. Paths are relative to the project root, e.g. 'docs/plan.md' — use them exactly as list_files prints them. When the user refers to project files or material \"in the project\", consult these tools instead of guessing.",
+        "tool_hint": "This conversation belongs to a project with a file area (documents, notes, data the user keeps alongside the project's conversations). Reading: list_files shows the file tree, read_file returns a text file's content, search_files finds a substring across file names and contents. Writing: create_file makes a new text file (parent folders are created automatically; it refuses to overwrite), write_file replaces an existing file's entire content, edit_file swaps one exact snippet for another (copy the snippet verbatim from read_file — for small changes prefer this over write_file), insert_text adds lines after a given line number. All files are UTF-8 text up to 2 MB; paths are relative to the project root, e.g. 'docs/plan.md' — use them exactly as list_files prints them. When the user refers to project files or material \"in the project\", consult these tools instead of guessing, and when they ask you to save or update something in the project, actually write the file rather than only replying in chat.",
     },
     "render-html": {
         "name": "Render HTML",

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -1,10 +1,18 @@
-"""Project Files MCP server — read-only view of one project's file area.
+"""Project Files MCP server — read/write access to one project's file area.
 
 Spawned per tool call by MCPClientManager like the other built-ins, but
 scoped: the dashboard injects LLM_DOCK_PROJECT_ROOT (the absolute
 directory of the conversation's project) into the subprocess environment
 at spawn time (see chat/project_files_mcp.py). Without it, every tool
 answers with a clear error instead of guessing a directory.
+
+Read tools: list_files, read_file, search_files. Write tools:
+create_file, write_file (full replace), edit_file (exact-snippet
+replace), insert_text (line-based insert). Writes go through
+chat.project_files.write_text — atomic temp-file publication, UTF-8/NUL
+validation, the 2 MB text cap, and (for the read-modify-write tools) the
+content-revision guard, so a concurrent editor save turns into a clear
+error instead of a silent overwrite.
 
 All path handling is delegated to chat.project_files — the same layer the
 HTTP file routes use — so `..` traversal, absolute paths and symlink
@@ -194,6 +202,146 @@ def search_files(query: str, path: str = "") -> str:
             f"scan budget reached — narrow the search with a subdirectory path)"
         )
     return result
+
+
+def _ensure_parent(root: str, path: str):
+    """Create the missing parent folders of `path` (resolve-safe).
+
+    Raises ProjectFilesError for invalid paths or when a parent component
+    exists but is not a directory.
+    """
+    parts = pf.split_rel_path(path)
+    if not parts:
+        raise pf.ProjectFilesError("path is required")
+    parent = "/".join(parts[:-1])
+    if not parent:
+        return
+    abs_parent = pf.resolve(root, parent)
+    if os.path.isdir(abs_parent):
+        return
+    if os.path.lexists(abs_parent):
+        raise pf.ProjectFilesError("parent path exists and is not a directory")
+    pf.mkdir(root, parent)
+
+
+@mcp.tool()
+def create_file(path: str, content: str = "") -> str:
+    """Create a new text file in the project (UTF-8, up to 2 MB).
+
+    path is relative to the project root, e.g. 'docs/plan.md'; missing
+    parent folders are created automatically. Fails if the file already
+    exists — use write_file to replace an existing file's content, or
+    edit_file / insert_text for targeted changes.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not isinstance(content, str):
+        return "Error: content must be a string"
+    try:
+        # The project directory itself is created lazily by the first
+        # mutation, mirroring the HTTP upload/write routes.
+        os.makedirs(root, exist_ok=True)
+        _ensure_parent(root, path)
+        node = pf.write_text(root, path, content, create_only=True)
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+    return f"Created {node['path']} ({node['size']} bytes)"
+
+
+@mcp.tool()
+def write_file(path: str, content: str) -> str:
+    """Replace an existing project text file's ENTIRE content (UTF-8, up to 2 MB).
+
+    Fails if the file does not exist — use create_file for new files.
+    For small changes prefer edit_file or insert_text, which modify only
+    part of the file and guard against concurrent edits.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not isinstance(content, str):
+        return "Error: content must be a string"
+    if not os.path.isdir(root):
+        return "Error: file not found (the project has no files yet) — use create_file"
+    try:
+        pf.stat_file(root, path)  # must already exist as a regular file
+        node = pf.write_text(root, path, content)
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+    return f"Wrote {node['path']} ({node['size']} bytes)"
+
+
+@mcp.tool()
+def edit_file(path: str, old_text: str, new_text: str, replace_all: bool = False) -> str:
+    """Replace an exact text snippet inside a project text file.
+
+    old_text must match the file's content exactly — same whitespace,
+    same line breaks — so call read_file first and copy the text
+    verbatim. Unless replace_all is true, old_text must occur exactly
+    once; include a few surrounding lines to make it unique. new_text
+    may be empty to delete the snippet.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not isinstance(old_text, str) or old_text == "":
+        return "Error: old_text must be a non-empty string"
+    if not isinstance(new_text, str):
+        return "Error: new_text must be a string"
+    if not os.path.isdir(root):
+        return "Error: file not found (the project has no files yet)"
+    try:
+        doc = pf.read_text(root, path)
+        count = doc["content"].count(old_text)
+        if count == 0:
+            return ("Error: old_text was not found in the file — call read_file "
+                    "and copy the exact text, including whitespace and line breaks")
+        if count > 1 and not replace_all:
+            return (f"Error: old_text occurs {count} times — include more "
+                    f"surrounding context to make it unique, or pass replace_all=true")
+        updated = doc["content"].replace(old_text, new_text)
+        # base_revision: if the file changed on disk between our read and
+        # this write (e.g. the user saved the in-browser editor), fail
+        # loudly instead of silently reverting their edit.
+        node = pf.write_text(root, path, updated, base_revision=doc["revision"])
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+    return f"Replaced {count} occurrence{'s' if count != 1 else ''} in {node['path']} ({node['size']} bytes)"
+
+
+@mcp.tool()
+def insert_text(path: str, line: int, text: str) -> str:
+    """Insert text into a project text file after a given line.
+
+    line is 1-based and refers to the line the text is inserted AFTER;
+    pass 0 to insert at the very top of the file. text is inserted as
+    whole lines (a trailing newline is added if missing). Use read_file
+    to find the right line number first.
+    """
+    root = _project_root()
+    if root is None:
+        return NO_PROJECT_ERROR
+    if not isinstance(line, int) or isinstance(line, bool) or line < 0:
+        return "Error: line must be a non-negative integer (0 inserts at the top)"
+    if not isinstance(text, str) or text == "":
+        return "Error: text must be a non-empty string"
+    if not os.path.isdir(root):
+        return "Error: file not found (the project has no files yet)"
+    try:
+        doc = pf.read_text(root, path)
+        lines = doc["content"].splitlines(keepends=True)
+        if line > len(lines):
+            return f"Error: line {line} is past the end of the file ({len(lines)} lines)"
+        # Appending after a final line that lacks its newline must not
+        # glue the two lines together.
+        if line == len(lines) and lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.insert(line, text if text.endswith("\n") else text + "\n")
+        node = pf.write_text(root, path, "".join(lines), base_revision=doc["revision"])
+    except pf.ProjectFilesError as e:
+        return f"Error: {e}"
+    return f"Inserted after line {line} of {node['path']} ({node['size']} bytes)"
 
 
 if __name__ == "__main__":

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -265,8 +265,10 @@ def write_file(path: str, content: str) -> str:
     if not os.path.isdir(root):
         return "Error: file not found (the project has no files yet) — use create_file"
     try:
-        pf.stat_file(root, path)  # must already exist as a regular file
-        node = pf.write_text(root, path, content)
+        # must_exist: the replace-only precondition is evaluated inside
+        # write_text's locked critical section — a caller-side existence
+        # check could be invalidated by a concurrent delete/move.
+        node = pf.write_text(root, path, content, must_exist=True)
     except pf.ProjectFilesError as e:
         return f"Error: {e}"
     return f"Wrote {node['path']} ({node['size']} bytes)"

--- a/dashboard/chat/mcp_servers/project_files_server.py
+++ b/dashboard/chat/mcp_servers/project_files_server.py
@@ -68,7 +68,15 @@ def list_files(path: str = "") -> str:
     Optionally pass a directory path (relative to the project root) to
     list only that subtree. Returns one entry per line: directories end
     with '/', files show their size. Use the printed paths verbatim with
-    read_file / search_files.
+    the other project-files tools.
+
+    Examples:
+    - list_files() → the whole tree:
+        docs/
+        docs/plan.md (1204 bytes)
+        notes.md (88 bytes)
+    - list_files(path="docs") → only the entries under docs/
+    - list_files(path="docs/notes") → a nested subfolder
     """
     root = _project_root()
     if root is None:
@@ -101,11 +109,18 @@ def list_files(path: str = "") -> str:
 def read_file(path: str, offset: int = 0) -> str:
     """Read a text file from the project (UTF-8, up to 2 MB).
 
-    path is relative to the project root, e.g. 'docs/plan.md'. At most
-    ~64k characters are returned per call; a longer file ends with a
-    notice giving the offset to pass to read the next chunk. Binary
-    files and files over the size cap are rejected — use list_files to
-    check sizes first.
+    path is relative to the project root. At most ~64k characters are
+    returned per call; a longer file ends with a notice giving the
+    offset to pass to read the next chunk. Binary files and files over
+    the size cap are rejected — use list_files to check sizes first.
+
+    Examples:
+    - read_file(path="docs/plan.md") → the file's full text
+    - read_file(path="notes.md") → "hello project\\n..."
+    - A long file ends with:
+        (truncated: showing characters 0–65536 of 180000 — call
+        read_file again with offset=65536 to continue)
+      then read_file(path="logs/big.txt", offset=65536) → the next chunk
     """
     root = _project_root()
     if root is None:
@@ -138,6 +153,15 @@ def search_files(query: str, path: str = "") -> str:
     oversized files are skipped). Optionally restrict the search to a
     subdirectory via path. Content matches are returned as
     'path:line_number: line text'.
+
+    Examples:
+    - search_files(query="deadline") →
+        docs/plan.md:12: the deadline is Friday
+        notes.md:3: moved the DEADLINE to next week
+    - search_files(query="config") → also matches file NAMES:
+        src/config.yaml (name match)
+    - search_files(query="TODO", path="src") → content/name matches
+      under src/ only
     """
     root = _project_root()
     if root is None:
@@ -228,10 +252,20 @@ def _ensure_parent(root: str, path: str):
 def create_file(path: str, content: str = "") -> str:
     """Create a new text file in the project (UTF-8, up to 2 MB).
 
-    path is relative to the project root, e.g. 'docs/plan.md'; missing
-    parent folders are created automatically. Fails if the file already
-    exists — use write_file to replace an existing file's content, or
-    edit_file / insert_text for targeted changes.
+    path is relative to the project root; missing parent folders are
+    created automatically. Fails if the file already exists — use
+    write_file to replace an existing file's content, or edit_file /
+    insert_text for targeted changes.
+
+    Examples:
+    - create_file(path="notes/todo.md", content="- buy milk\\n")
+      → "Created notes/todo.md (11 bytes)" (the notes/ folder is
+      created automatically if missing)
+    - create_file(path="empty.txt") → creates an empty file
+    - create_file(path="report.md", content="# Report\\n\\n## Findings\\n")
+      → a new multi-line markdown file
+    - create_file on a path that already exists
+      → "Error: file already exists" — switch to write_file or edit_file
     """
     root = _project_root()
     if root is None:
@@ -256,6 +290,14 @@ def write_file(path: str, content: str) -> str:
     Fails if the file does not exist — use create_file for new files.
     For small changes prefer edit_file or insert_text, which modify only
     part of the file and guard against concurrent edits.
+
+    Examples:
+    - write_file(path="config.yaml", content="port: 8080\\nlog: info\\n")
+      → "Wrote config.yaml (20 bytes)" — the previous content is gone
+    - write_file(path="docs/summary.md", content="# Summary\\n...full new text...")
+      → full rewrite of an existing document
+    - write_file(path="does-not-exist.md", content="x")
+      → "Error: file not found" — use create_file instead
     """
     root = _project_root()
     if root is None:
@@ -283,6 +325,23 @@ def edit_file(path: str, old_text: str, new_text: str, replace_all: bool = False
     verbatim. Unless replace_all is true, old_text must occur exactly
     once; include a few surrounding lines to make it unique. new_text
     may be empty to delete the snippet.
+
+    Examples:
+    - edit_file(path="todo.md", old_text="- buy milk",
+                new_text="- buy milk (done)")
+      → "Replaced 1 occurrence in todo.md (64 bytes)"
+    - Delete a line (include its newline):
+      edit_file(path="todo.md", old_text="- obsolete task\\n", new_text="")
+    - Multi-line replacement:
+      edit_file(path="plan.md",
+                old_text="## Phase 2\\nTBD\\n",
+                new_text="## Phase 2\\nShip the explorer.\\n")
+    - If old_text is ambiguous you get
+      "Error: old_text occurs 3 times" — either add surrounding lines,
+      e.g. old_text="## Shopping\\n- buy milk", or pass replace_all=true
+      to change every occurrence:
+      edit_file(path="report.md", old_text="colour", new_text="color",
+                replace_all=true) → "Replaced 3 occurrences in report.md"
     """
     root = _project_root()
     if root is None:
@@ -320,6 +379,19 @@ def insert_text(path: str, line: int, text: str) -> str:
     pass 0 to insert at the very top of the file. text is inserted as
     whole lines (a trailing newline is added if missing). Use read_file
     to find the right line number first.
+
+    Examples (file todo.md contains "# TODO\\n- first\\n- second\\n"):
+    - insert_text(path="todo.md", line=0, text="<!-- draft -->")
+      → new first line, everything else shifts down
+    - insert_text(path="todo.md", line=1, text="- urgent")
+      → inserted between "# TODO" and "- first"
+    - insert_text(path="todo.md", line=3, text="- third")
+      → appended after the last line
+    - Multi-line insert:
+      insert_text(path="todo.md", line=1, text="- a\\n- b")
+      → two new lines after line 1
+    - insert_text(path="todo.md", line=99, text="x")
+      → "Error: line 99 is past the end of the file (3 lines)"
     """
     root = _project_root()
     if root is None:

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -253,23 +253,20 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
         raise ProjectFilesError("target directory not found", status=404)
     rel_target = f"{dir_rel.strip('/')}/{filename}" if dir_rel.strip("/") else filename
     abs_target = resolve(root, rel_target)
+    # Fast-fail prechecks; re-checked under the project lock before
+    # publication (the body may take arbitrarily long to stream).
     if os.path.isdir(abs_target):
         raise ProjectFilesError("a directory with that name exists", status=409)
     if os.path.exists(abs_target) and not overwrite:
         raise ProjectFilesError("file already exists", status=409, code="already_exists")
-    # Same permission fidelity as write_text: mkstemp stages at 0600, so an
-    # overwriting upload must keep the target's mode and a fresh one gets
-    # a normal default instead of 0600.
-    publish_mode = 0o644
-    if overwrite and os.path.lexists(abs_target):
-        target_st = os.lstat(abs_target)
-        if stat_mod.S_ISREG(target_st.st_mode):
-            publish_mode = stat_mod.S_IMODE(target_st.st_mode)
 
     # Stage in a UNIQUE, exclusively-created temp file in the destination
     # directory (same filesystem → atomic publication). A deterministic
     # "<target>.uploading" name would collide with a legitimate user file
     # of that name and with a concurrent upload of the same target.
+    # Streaming happens OUTSIDE the project lock — an upload must not
+    # hold up other writers for the duration of its body — only the
+    # publication step synchronizes.
     written = 0
     with _fs_errors():
         fd, tmp_path = tempfile.mkstemp(prefix=".upload-", suffix=".tmp", dir=abs_dir)
@@ -283,17 +280,28 @@ def save_stream(root: str, dir_rel: str, filename: str, stream, overwrite: bool 
                     if written > MAX_UPLOAD_BYTES:
                         raise ProjectFilesError("file too large", status=413)
                     f.write(chunk)
-            os.chmod(tmp_path, publish_mode)
-            if overwrite:
-                os.replace(tmp_path, abs_target)
-            else:
-                # Atomic no-replace publication: link() fails with EEXIST if the
-                # target appeared since the pre-check, upholding the 409 contract
-                # even against a concurrent upload of the same name.
-                try:
-                    os.link(tmp_path, abs_target)
-                except FileExistsError:
-                    raise ProjectFilesError("file already exists", status=409, code="already_exists")
+            with _write_lock(root):
+                if os.path.isdir(abs_target) and not os.path.islink(abs_target):
+                    raise ProjectFilesError("a directory with that name exists", status=409)
+                # Same permission fidelity as write_text: mkstemp stages at
+                # 0600, so an overwriting upload must keep the target's mode
+                # and a fresh one gets a normal default instead of 0600.
+                publish_mode = 0o644
+                if overwrite and os.path.lexists(abs_target):
+                    target_st = os.lstat(abs_target)
+                    if stat_mod.S_ISREG(target_st.st_mode):
+                        publish_mode = stat_mod.S_IMODE(target_st.st_mode)
+                os.chmod(tmp_path, publish_mode)
+                if overwrite:
+                    os.replace(tmp_path, abs_target)
+                else:
+                    # Atomic no-replace publication: link() fails with EEXIST if the
+                    # target appeared since the pre-check, upholding the 409 contract
+                    # even against a concurrent upload of the same name.
+                    try:
+                        os.link(tmp_path, abs_target)
+                    except FileExistsError:
+                        raise ProjectFilesError("file already exists", status=409, code="already_exists")
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -335,17 +343,22 @@ def read_text(root: str, rel_path: str) -> dict:
 
 @contextmanager
 def _write_lock(root: str):
-    """Serialize write_text's compare-and-publish across processes.
+    """Serialize a project's file mutations across processes.
 
-    An exclusive flock on the project root directory: the base_revision
-    comparison and the os.replace that publishes the new content must be
-    one atomic unit, or a writer landing between them (the Flask editor
-    and a spawned MCP tool process are genuinely concurrent) would be
-    silently overwritten despite the revision guard. flock contends
-    between separate opens even within one process, so two threads of the
-    same server are covered too. Per-project granularity is coarse but
-    contention is a single user's editor vs. their chat turn — never a
-    throughput concern.
+    An exclusive flock on the project root directory, taken by EVERY
+    mutator (write_text, save_stream's publication, mkdir, move, copy,
+    delete): write_text's base_revision comparison and the os.replace
+    that publishes the new content must be one atomic unit with respect
+    to anything that could change the checked path — the Flask routes
+    and a spawned MCP tool process are genuinely concurrent — or the
+    interleaved mutation would be silently undone despite the revision
+    guard. flock contends between separate opens even within one
+    process, so two threads of the same server are covered too.
+    Per-project granularity is coarse but contention is a single user's
+    UI action vs. their chat turn — never a throughput concern. Slow
+    work stays outside the lock (uploads stream to their temp file
+    before acquiring it); the held section is checks plus a rename,
+    rmtree, or copy.
     """
     fd = os.open(root, os.O_RDONLY)
     try:
@@ -359,7 +372,8 @@ def _write_lock(root: str):
 
 
 def write_text(root: str, rel_path: str, content: str,
-               base_revision: str = None, create_only: bool = False) -> dict:
+               base_revision: str = None, create_only: bool = False,
+               must_exist: bool = False) -> dict:
     """Write UTF-8 text to a file (create or overwrite), atomically via a
     temp file in the same directory. The target's parent must exist and
     the target itself must be absent or a regular file — symlinks and
@@ -374,10 +388,17 @@ def write_text(root: str, rel_path: str, content: str,
     with 409 if the path already exists (the client believed it was
     creating a file, but its tree snapshot was stale). Publication is an
     atomic no-replace link, mirroring save_stream's upload contract.
+
+    must_exist=True is the replace-only precondition: the save is
+    rejected with 404 if the path does NOT exist. Evaluated inside the
+    locked critical section, so a caller-side existence precheck can't
+    be invalidated by a concurrent delete/move before the write lands.
     """
     parts = split_rel_path(rel_path)
     if not parts:
         raise ProjectFilesError("path is required")
+    if create_only and must_exist:
+        raise ProjectFilesError("create_only and must_exist are mutually exclusive")
     if not isinstance(content, str):
         raise ProjectFilesError("content must be a string")
     if "\x00" in content:
@@ -418,9 +439,12 @@ def write_text(root: str, rel_path: str, content: str,
                     current = f.read()
                 if _content_revision(current) != base_revision:
                     raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
-        elif base_revision is not None:
-            # Client edited a file that has since been deleted/renamed.
-            raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
+        else:
+            if must_exist:
+                raise ProjectFilesError("file not found", status=404)
+            if base_revision is not None:
+                # Client edited a file that has since been deleted/renamed.
+                raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
 
         with _fs_errors():
             fd, tmp_path = tempfile.mkstemp(prefix=".edit-", suffix=".tmp", dir=abs_dir)
@@ -449,13 +473,14 @@ def mkdir(root: str, rel_path: str) -> dict:
     if not parts:
         raise ProjectFilesError("path is required")
     abs_path = resolve(root, rel_path)
-    # lexists: a dangling symlink is an ordinary entry in the tree (listed
-    # by build_tree) and must count as occupying its name — exists() would
-    # follow the link and report the slot free.
-    if os.path.lexists(abs_path):
-        raise ProjectFilesError("path already exists", status=409, code="already_exists")
-    with _fs_errors():
-        os.makedirs(abs_path)
+    with _write_lock(root):
+        # lexists: a dangling symlink is an ordinary entry in the tree (listed
+        # by build_tree) and must count as occupying its name — exists() would
+        # follow the link and report the slot free.
+        if os.path.lexists(abs_path):
+            raise ProjectFilesError("path already exists", status=409, code="already_exists")
+        with _fs_errors():
+            os.makedirs(abs_path)
     rel = "/".join(parts)
     return _node(abs_path, rel)
 
@@ -471,19 +496,20 @@ def move(root: str, rel_src: str, rel_dst: str) -> dict:
         raise ProjectFilesError("destination is required")
     abs_src = resolve(root, rel_src)
     abs_dst = resolve(root, rel_dst)
-    # lexists on both sides: a dangling symlink is movable (the operation
-    # applies to the link itself, as delete already does) and occupies its
-    # destination name.
-    if not os.path.lexists(abs_src):
-        raise ProjectFilesError("source not found", status=404)
-    if os.path.lexists(abs_dst):
-        raise ProjectFilesError("destination already exists", status=409, code="already_exists")
     if dst_parts[:len(src_parts)] == src_parts:
         raise ProjectFilesError("cannot move a directory into itself")
-    if not os.path.isdir(os.path.dirname(abs_dst)):
-        raise ProjectFilesError("destination directory not found", status=404)
-    with _fs_errors():
-        shutil.move(abs_src, abs_dst)
+    with _write_lock(root):
+        # lexists on both sides: a dangling symlink is movable (the operation
+        # applies to the link itself, as delete already does) and occupies its
+        # destination name.
+        if not os.path.lexists(abs_src):
+            raise ProjectFilesError("source not found", status=404)
+        if os.path.lexists(abs_dst):
+            raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+        if not os.path.isdir(os.path.dirname(abs_dst)):
+            raise ProjectFilesError("destination directory not found", status=404)
+        with _fs_errors():
+            shutil.move(abs_src, abs_dst)
     return _node(abs_dst, "/".join(dst_parts))
 
 
@@ -518,66 +544,67 @@ def copy_path(root: str, rel_src: str, rel_dst: str) -> dict:
         raise ProjectFilesError("destination is required")
     abs_src = resolve(root, rel_src)
     abs_dst = resolve(root, rel_dst)
-    if not os.path.lexists(abs_src):
-        raise ProjectFilesError("source not found", status=404)
-    if os.path.lexists(abs_dst):
-        raise ProjectFilesError("destination already exists", status=409, code="already_exists")
     if dst_parts[:len(src_parts)] == src_parts:
         raise ProjectFilesError("cannot copy a directory into itself")
-    abs_dst_dir = os.path.dirname(abs_dst)
-    if not os.path.isdir(abs_dst_dir):
-        raise ProjectFilesError("destination directory not found", status=404)
+    with _write_lock(root):
+        if not os.path.lexists(abs_src):
+            raise ProjectFilesError("source not found", status=404)
+        if os.path.lexists(abs_dst):
+            raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+        abs_dst_dir = os.path.dirname(abs_dst)
+        if not os.path.isdir(abs_dst_dir):
+            raise ProjectFilesError("destination directory not found", status=404)
 
-    src_st = os.lstat(abs_src)
-    # The component checks above only see CLIENT paths; an in-root symlink
-    # alias can spell a destination whose PHYSICAL location differs — both
-    # deeper than the client path suggests and inside the source itself.
-    # Judge depth and self-containment on realpaths: the real destination
-    # is its existing parent's realpath plus the final component. Copying
-    # past the depth cap would mint entries build_tree returns but every
-    # other route rejects as "path too deep".
-    real_dst = os.path.join(os.path.realpath(abs_dst_dir), os.path.basename(abs_dst))
-    phys_dst_depth = len(os.path.relpath(real_dst, os.path.realpath(root)).split(os.sep))
-    if phys_dst_depth > MAX_PATH_DEPTH:
-        raise ProjectFilesError("path too deep")
-    with _fs_errors():
-        if stat_mod.S_ISDIR(src_st.st_mode):
-            real_src = os.path.realpath(abs_src)
-            if real_dst == real_src or real_dst.startswith(real_src + os.sep):
-                raise ProjectFilesError("cannot copy a directory into itself")
-            _precheck_copy_tree(abs_src, phys_dst_depth)
-            try:
-                shutil.copytree(abs_src, abs_dst, symlinks=True)
-            except FileExistsError:
-                raise ProjectFilesError("destination already exists", status=409, code="already_exists")
-            except Exception:
-                # A partial tree is worse than no tree: the client will
-                # retry the whole copy, and a half-populated destination
-                # would then 409 as already_exists.
-                shutil.rmtree(abs_dst, ignore_errors=True)
-                raise
-        elif stat_mod.S_ISLNK(src_st.st_mode):
-            try:
-                os.symlink(os.readlink(abs_src), abs_dst)
-            except FileExistsError:
-                raise ProjectFilesError("destination already exists", status=409, code="already_exists")
-        elif stat_mod.S_ISREG(src_st.st_mode):
-            # Stage in the destination directory, then publish with an
-            # atomic no-replace link — same 409 contract as save_stream
-            # even against a concurrent claim of the destination name.
-            fd, tmp_path = tempfile.mkstemp(prefix=".copy-", suffix=".tmp", dir=abs_dst_dir)
-            try:
-                os.close(fd)
-                shutil.copy2(abs_src, tmp_path)  # preserves mode
+        src_st = os.lstat(abs_src)
+        # The component checks above only see CLIENT paths; an in-root symlink
+        # alias can spell a destination whose PHYSICAL location differs — both
+        # deeper than the client path suggests and inside the source itself.
+        # Judge depth and self-containment on realpaths: the real destination
+        # is its existing parent's realpath plus the final component. Copying
+        # past the depth cap would mint entries build_tree returns but every
+        # other route rejects as "path too deep".
+        real_dst = os.path.join(os.path.realpath(abs_dst_dir), os.path.basename(abs_dst))
+        phys_dst_depth = len(os.path.relpath(real_dst, os.path.realpath(root)).split(os.sep))
+        if phys_dst_depth > MAX_PATH_DEPTH:
+            raise ProjectFilesError("path too deep")
+        with _fs_errors():
+            if stat_mod.S_ISDIR(src_st.st_mode):
+                real_src = os.path.realpath(abs_src)
+                if real_dst == real_src or real_dst.startswith(real_src + os.sep):
+                    raise ProjectFilesError("cannot copy a directory into itself")
+                _precheck_copy_tree(abs_src, phys_dst_depth)
                 try:
-                    os.link(tmp_path, abs_dst)
+                    shutil.copytree(abs_src, abs_dst, symlinks=True)
                 except FileExistsError:
                     raise ProjectFilesError("destination already exists", status=409, code="already_exists")
-            finally:
-                if os.path.exists(tmp_path):
-                    os.unlink(tmp_path)
-        else:
-            raise ProjectFilesError("not a copyable file type")
+                except Exception:
+                    # A partial tree is worse than no tree: the client will
+                    # retry the whole copy, and a half-populated destination
+                    # would then 409 as already_exists.
+                    shutil.rmtree(abs_dst, ignore_errors=True)
+                    raise
+            elif stat_mod.S_ISLNK(src_st.st_mode):
+                try:
+                    os.symlink(os.readlink(abs_src), abs_dst)
+                except FileExistsError:
+                    raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+            elif stat_mod.S_ISREG(src_st.st_mode):
+                # Stage in the destination directory, then publish with an
+                # atomic no-replace link — same 409 contract as save_stream
+                # even against a concurrent claim of the destination name.
+                fd, tmp_path = tempfile.mkstemp(prefix=".copy-", suffix=".tmp", dir=abs_dst_dir)
+                try:
+                    os.close(fd)
+                    shutil.copy2(abs_src, tmp_path)  # preserves mode
+                    try:
+                        os.link(tmp_path, abs_dst)
+                    except FileExistsError:
+                        raise ProjectFilesError("destination already exists", status=409, code="already_exists")
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+            else:
+                raise ProjectFilesError("not a copyable file type")
     return _node(abs_dst, "/".join(dst_parts))
 
 
@@ -586,9 +613,10 @@ def delete(root: str, rel_path: str):
     if not parts:
         raise ProjectFilesError("cannot delete project root")
     abs_path = resolve(root, rel_path)
-    if not os.path.exists(abs_path) and not os.path.islink(abs_path):
-        raise ProjectFilesError("path not found", status=404)
-    if os.path.isdir(abs_path) and not os.path.islink(abs_path):
-        shutil.rmtree(abs_path)
-    else:
-        os.unlink(abs_path)
+    with _write_lock(root):
+        if not os.path.exists(abs_path) and not os.path.islink(abs_path):
+            raise ProjectFilesError("path not found", status=404)
+        if os.path.isdir(abs_path) and not os.path.islink(abs_path):
+            shutil.rmtree(abs_path)
+        else:
+            os.unlink(abs_path)

--- a/dashboard/chat/project_files.py
+++ b/dashboard/chat/project_files.py
@@ -12,6 +12,7 @@ component validation plus a realpath containment check, so neither
 project root.
 """
 import errno
+import fcntl
 import hashlib
 import os
 import stat as stat_mod
@@ -332,6 +333,31 @@ def read_text(root: str, rel_path: str) -> dict:
     }
 
 
+@contextmanager
+def _write_lock(root: str):
+    """Serialize write_text's compare-and-publish across processes.
+
+    An exclusive flock on the project root directory: the base_revision
+    comparison and the os.replace that publishes the new content must be
+    one atomic unit, or a writer landing between them (the Flask editor
+    and a spawned MCP tool process are genuinely concurrent) would be
+    silently overwritten despite the revision guard. flock contends
+    between separate opens even within one process, so two threads of the
+    same server are covered too. Per-project granularity is coarse but
+    contention is a single user's editor vs. their chat turn — never a
+    throughput concern.
+    """
+    fd = os.open(root, os.O_RDONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        # Closing the fd releases the lock; the explicit unlock just makes
+        # the intent visible.
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def write_text(root: str, rel_path: str, content: str,
                base_revision: str = None, create_only: bool = False) -> dict:
     """Write UTF-8 text to a file (create or overwrite), atomically via a
@@ -369,46 +395,50 @@ def write_text(root: str, rel_path: str, content: str,
     abs_dir = os.path.dirname(abs_path)
     if not os.path.isdir(abs_dir):
         raise ProjectFilesError("parent directory not found", status=404)
-    # mkstemp stages at 0600; without this an edit would silently strip the
-    # target's permission bits (e.g. a 0755 script losing its exec bit).
-    publish_mode = 0o644
-    if os.path.lexists(abs_path):
-        if create_only:
-            raise ProjectFilesError("file already exists", status=409, code="already_exists")
-        st = os.lstat(abs_path)
-        if not stat_mod.S_ISREG(st.st_mode):
-            raise ProjectFilesError("not a regular file", status=409)
-        publish_mode = stat_mod.S_IMODE(st.st_mode)
-        if base_revision is not None:
-            # A file too large for read_text can't be what the client
-            # loaded — it definitely changed. Otherwise compare content.
-            if st.st_size > MAX_TEXT_EDIT_BYTES:
-                raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
-            with open(abs_path, "rb") as f:
-                current = f.read()
-            if _content_revision(current) != base_revision:
-                raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
-    elif base_revision is not None:
-        # Client edited a file that has since been deleted/renamed.
-        raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
-
-    with _fs_errors():
-        fd, tmp_path = tempfile.mkstemp(prefix=".edit-", suffix=".tmp", dir=abs_dir)
-        try:
-            with os.fdopen(fd, "wb") as f:
-                f.write(encoded)
-            os.chmod(tmp_path, publish_mode)
+    # The precondition checks and the publication are one critical
+    # section: without the lock a concurrent writer could land between
+    # the base_revision comparison and os.replace and be silently lost.
+    with _write_lock(root):
+        # mkstemp stages at 0600; without this an edit would silently strip the
+        # target's permission bits (e.g. a 0755 script losing its exec bit).
+        publish_mode = 0o644
+        if os.path.lexists(abs_path):
             if create_only:
-                # Atomic no-replace publication, same as upload's contract.
-                try:
-                    os.link(tmp_path, abs_path)
-                except FileExistsError:
-                    raise ProjectFilesError("file already exists", status=409, code="already_exists")
-            else:
-                os.replace(tmp_path, abs_path)
-        finally:
-            if os.path.exists(tmp_path):
-                os.unlink(tmp_path)
+                raise ProjectFilesError("file already exists", status=409, code="already_exists")
+            st = os.lstat(abs_path)
+            if not stat_mod.S_ISREG(st.st_mode):
+                raise ProjectFilesError("not a regular file", status=409)
+            publish_mode = stat_mod.S_IMODE(st.st_mode)
+            if base_revision is not None:
+                # A file too large for read_text can't be what the client
+                # loaded — it definitely changed. Otherwise compare content.
+                if st.st_size > MAX_TEXT_EDIT_BYTES:
+                    raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
+                with open(abs_path, "rb") as f:
+                    current = f.read()
+                if _content_revision(current) != base_revision:
+                    raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
+        elif base_revision is not None:
+            # Client edited a file that has since been deleted/renamed.
+            raise ProjectFilesError("file changed on disk since it was loaded", status=409, code="revision_conflict")
+
+        with _fs_errors():
+            fd, tmp_path = tempfile.mkstemp(prefix=".edit-", suffix=".tmp", dir=abs_dir)
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(encoded)
+                os.chmod(tmp_path, publish_mode)
+                if create_only:
+                    # Atomic no-replace publication, same as upload's contract.
+                    try:
+                        os.link(tmp_path, abs_path)
+                    except FileExistsError:
+                        raise ProjectFilesError("file already exists", status=409, code="already_exists")
+                else:
+                    os.replace(tmp_path, abs_path)
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
     node = _node(abs_path, "/".join(parts))
     node["revision"] = _content_revision(encoded)
     return node

--- a/dashboard/chat/project_files_mcp.py
+++ b/dashboard/chat/project_files_mcp.py
@@ -37,9 +37,18 @@ class ProjectScopedMCPManager:
     only the spawn environment differs.
     """
 
-    def __init__(self, inner, project_root: str):
+    def __init__(self, inner, project_root: str, revalidate=None):
         self._inner = inner
         self._project_root = project_root
+        # Commit-point revalidation, mirroring the HTTP mutation routes'
+        # _revalidate_or_cleanup: the run snapshots its project at start,
+        # so a tool call can outlive a project deletion — a write tool
+        # would then recreate the project directory as an orphan the UI
+        # can never show. The callback (built where the DB is known)
+        # checks the project row after each project-files call and sweeps
+        # the directory if the row is gone; whichever side acts last
+        # cleans up, so no orphan survives either interleaving.
+        self._revalidate = revalidate
 
     def get_tools(self, server_id: str) -> list:
         return self._inner.get_tools(server_id)
@@ -48,7 +57,13 @@ class ProjectScopedMCPManager:
         return self._inner.get_all_tools(server_ids)
 
     def call_tool(self, server_id: str, tool_name: str, arguments: dict) -> tuple:
-        extra_env = None
-        if server_id == SERVER_ID:
-            extra_env = {PROJECT_ROOT_ENV: self._project_root}
-        return self._inner.call_tool(server_id, tool_name, arguments, extra_env=extra_env)
+        if server_id != SERVER_ID:
+            return self._inner.call_tool(server_id, tool_name, arguments)
+        extra_env = {PROJECT_ROOT_ENV: self._project_root}
+        try:
+            return self._inner.call_tool(server_id, tool_name, arguments, extra_env=extra_env)
+        finally:
+            # Also on error/timeout paths: the subprocess may have written
+            # before dying.
+            if self._revalidate is not None:
+                self._revalidate()

--- a/dashboard/chat/routes.py
+++ b/dashboard/chat/routes.py
@@ -102,7 +102,20 @@ def _mcp_for_conversation(conv, enabled_servers, project_id):
     manager = _get_mcp()
     if project_id:
         storage_root = current_app.config.get("PROJECT_FILES_DIR") or pf.default_storage_root()
-        manager = ProjectScopedMCPManager(manager, pf.project_root(storage_root, project_id))
+        db = _get_db()
+
+        def _revalidate():
+            # Commit point for MCP writes, mirroring _revalidate_or_cleanup:
+            # the run snapshotted its project at start, so a write tool can
+            # land after the user deletes the project — its directory would
+            # be recreated as an orphan the UI can never show. Runs on the
+            # runner thread after every project-files call (values captured
+            # here; no app context there).
+            if db.get_project(project_id) is None:
+                pf.delete_project_root(storage_root, project_id)
+
+        manager = ProjectScopedMCPManager(
+            manager, pf.project_root(storage_root, project_id), revalidate=_revalidate)
     return manager
 
 

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -811,6 +811,77 @@ class TestErrorCodes:
         assert "code" not in r.get_json()
 
 
+class TestWriteTextCAS:
+    """write_text's base_revision comparison and its os.replace are one
+    atomic unit under a cross-process lock (regression: codex PR84 1.1).
+    A writer landing between another writer's check and publish must
+    block, then observe the published content and conflict — never be
+    silently overwritten. flock contends between separate opens even in
+    one process, so threads model the Flask-process vs MCP-subprocess
+    pair faithfully."""
+
+    def test_concurrent_writer_blocks_then_conflicts(self, made_root, monkeypatch):
+        import threading
+
+        with open(os.path.join(made_root, "f.md"), "wb") as fh:
+            fh.write(b"base")
+        rev = pf.read_text(made_root, "f.md")["revision"]
+
+        inside = threading.Event()   # A is past its revision check, lock held
+        resume = threading.Event()   # allow A to publish
+        paused_once = threading.Event()
+        real_mkstemp = pf.tempfile.mkstemp
+
+        def pausing_mkstemp(*a, **kw):
+            # Pause only the FIRST writer, exactly between its check
+            # (already done) and its publication (about to happen).
+            if not paused_once.is_set():
+                paused_once.set()
+                inside.set()
+                assert resume.wait(timeout=10)
+            return real_mkstemp(*a, **kw)
+
+        monkeypatch.setattr(pf.tempfile, "mkstemp", pausing_mkstemp)
+
+        a_errors, b_outcome = [], {}
+
+        def writer_a():
+            try:
+                pf.write_text(made_root, "f.md", "A version", base_revision=rev)
+            except Exception as e:  # noqa: BLE001 — surfaced via assert below
+                a_errors.append(e)
+
+        def writer_b():
+            try:
+                pf.write_text(made_root, "f.md", "B version", base_revision=rev)
+                b_outcome["won"] = True
+            except pf.ProjectFilesError as e:
+                b_outcome["error"] = e
+
+        ta = threading.Thread(target=writer_a)
+        ta.start()
+        assert inside.wait(timeout=10)
+
+        tb = threading.Thread(target=writer_b)
+        tb.start()
+        tb.join(timeout=0.3)
+        # The race window is CLOSED: B cannot slip its write in while A
+        # sits between check and publish.
+        assert tb.is_alive(), "second writer entered the critical section concurrently"
+
+        resume.set()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+        assert not ta.is_alive() and not tb.is_alive()
+        assert not a_errors
+
+        # A published; B then saw A's content and conflicted.
+        assert "won" not in b_outcome
+        assert b_outcome["error"].code == "revision_conflict"
+        with open(os.path.join(made_root, "f.md"), "rb") as fh:
+            assert fh.read() == b"A version"
+
+
 # ---------------------------------------------------------------------------
 # copy_path (file-explorer copy/paste)
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/test_project_files.py
+++ b/dashboard/tests/test_project_files.py
@@ -881,6 +881,115 @@ class TestWriteTextCAS:
         with open(os.path.join(made_root, "f.md"), "rb") as fh:
             assert fh.read() == b"A version"
 
+    def _paused_cas_writer(self, made_root, monkeypatch):
+        """Start a CAS write of f.md and pause it INSIDE the critical
+        section (between its revision check and its publication).
+        Returns (thread, resume_event, errors)."""
+        import threading
+
+        with open(os.path.join(made_root, "f.md"), "wb") as fh:
+            fh.write(b"base")
+        rev = pf.read_text(made_root, "f.md")["revision"]
+
+        inside, resume, paused_once = threading.Event(), threading.Event(), threading.Event()
+        real_mkstemp = pf.tempfile.mkstemp
+
+        def pausing_mkstemp(*a, **kw):
+            if not paused_once.is_set():
+                paused_once.set()
+                inside.set()
+                assert resume.wait(timeout=10)
+            return real_mkstemp(*a, **kw)
+
+        monkeypatch.setattr(pf.tempfile, "mkstemp", pausing_mkstemp)
+
+        errors = []
+
+        def writer():
+            try:
+                pf.write_text(made_root, "f.md", "A version", base_revision=rev)
+            except Exception as e:  # noqa: BLE001 — surfaced via assert
+                errors.append(e)
+
+        t = threading.Thread(target=writer)
+        t.start()
+        assert inside.wait(timeout=10)
+        return t, resume, errors
+
+    def test_overwrite_upload_blocks_during_cas(self, made_root, monkeypatch):
+        # Regression: codex PR84 2.1 — the OTHER mutators must take the
+        # same lock, or an explorer upload landing inside the CAS window
+        # would be silently replaced by the paused writer's publication.
+        import threading
+
+        ta, resume, a_errors = self._paused_cas_writer(made_root, monkeypatch)
+
+        def uploader():
+            pf.save_stream(made_root, "", "f.md", io.BytesIO(b"upload version"), overwrite=True)
+
+        tc = threading.Thread(target=uploader)
+        tc.start()
+        tc.join(timeout=0.3)
+        assert tc.is_alive(), "upload published inside the CAS critical section"
+
+        resume.set()
+        ta.join(timeout=10)
+        tc.join(timeout=10)
+        assert not ta.is_alive() and not tc.is_alive()
+        assert not a_errors
+        # Serialized order: CAS write first, upload after — the upload
+        # (the later operation) wins and is NOT lost.
+        with open(os.path.join(made_root, "f.md"), "rb") as fh:
+            assert fh.read() == b"upload version"
+
+    def test_delete_blocks_during_cas(self, made_root, monkeypatch):
+        import threading
+
+        ta, resume, a_errors = self._paused_cas_writer(made_root, monkeypatch)
+
+        deleted = threading.Event()
+
+        def deleter():
+            pf.delete(made_root, "f.md")
+            deleted.set()
+
+        tc = threading.Thread(target=deleter)
+        tc.start()
+        tc.join(timeout=0.3)
+        assert tc.is_alive(), "delete ran inside the CAS critical section"
+
+        resume.set()
+        ta.join(timeout=10)
+        tc.join(timeout=10)
+        assert not a_errors
+        assert deleted.is_set()
+        # The delete was the later operation — the file stays gone
+        # instead of being resurrected by the paused writer.
+        assert not os.path.exists(os.path.join(made_root, "f.md"))
+
+
+class TestWriteTextMustExist:
+    """must_exist: the replace-only precondition (regression: codex
+    PR84 2.2 — evaluated inside the lock, not pre-checked by callers)."""
+
+    def test_missing_file_404(self, made_root):
+        with pytest.raises(pf.ProjectFilesError) as e:
+            pf.write_text(made_root, "nope.md", "x", must_exist=True)
+        assert e.value.status == 404
+        assert not os.path.exists(os.path.join(made_root, "nope.md"))
+
+    def test_existing_file_is_replaced(self, made_root):
+        with open(os.path.join(made_root, "f.md"), "w") as fh:
+            fh.write("old")
+        node = pf.write_text(made_root, "f.md", "new", must_exist=True)
+        assert node["size"] == 3
+        with open(os.path.join(made_root, "f.md")) as fh:
+            assert fh.read() == "new"
+
+    def test_mutually_exclusive_with_create_only(self, made_root):
+        with pytest.raises(pf.ProjectFilesError):
+            pf.write_text(made_root, "f.md", "x", create_only=True, must_exist=True)
+
 
 # ---------------------------------------------------------------------------
 # copy_path (file-explorer copy/paste)

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -599,9 +599,13 @@ class TestSnapshotThreading:
 class TestRoutesHelper:
     @pytest.fixture
     def app(self, tmp_path):
+        from chat.db import ChatDB
         app = Flask(__name__)
         app.config["MCP_MANAGER"] = FakeManager()
         app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
+        # _mcp_for_conversation builds the deleted-project revalidation
+        # closure over the DB.
+        app.config["CHAT_DB"] = ChatDB(":memory:")
         return app
 
     def test_none_without_servers_or_project(self, app):
@@ -629,6 +633,97 @@ class TestRoutesHelper:
         mgr.call_tool(SERVER_ID, "list_files", {})
         call = app.config["MCP_MANAGER"].calls[-1]
         assert call[4] == {PROJECT_ROOT_ENV: str(tmp_path / "storage" / "p1")}
+
+
+class TestDeletedProjectSweep:
+    """Regression: codex PR84 3.1 — a write-tool call landing after the
+    user deletes the project must not leave an orphan project directory.
+    The scoped manager revalidates at its commit point (after every
+    project-files call, success or failure) and sweeps the directory when
+    the project row is gone — the same whoever-acts-last-cleans-up
+    contract as the HTTP mutation routes."""
+
+    @pytest.fixture
+    def app(self, tmp_path):
+        from chat.db import ChatDB
+        app = Flask(__name__)
+        app.config["MCP_MANAGER"] = FakeManager()
+        app.config["PROJECT_FILES_DIR"] = str(tmp_path / "storage")
+        app.config["CHAT_DB"] = ChatDB(":memory:")
+        return app
+
+    def _make_project(self, app):
+        from chat.models import Project
+        import uuid
+        return app.config["CHAT_DB"].create_project(
+            Project(id=str(uuid.uuid4()), name="P")).id
+
+    def _scoped_manager(self, app, pid):
+        from chat.routes import _mcp_for_conversation
+        with app.app_context():
+            return _mcp_for_conversation(_conv(project_id=pid), [], pid)
+
+    class _WritingInner:
+        """Stands in for the real subprocess spawn: the call itself
+        recreates the project root, exactly like a late create_file."""
+
+        def __init__(self, root, raise_after_write=False):
+            self.root = root
+            self.raise_after_write = raise_after_write
+
+        def call_tool(self, server_id, tool_name, arguments, extra_env=None):
+            os.makedirs(self.root, exist_ok=True)
+            with open(os.path.join(self.root, "late.md"), "w") as fh:
+                fh.write("resurrected")
+            if self.raise_after_write:
+                raise RuntimeError("tool call timed out")
+            return ("Created late.md (11 bytes)", [])
+
+    def test_late_write_after_project_delete_is_swept(self, app, tmp_path):
+        pid = self._make_project(app)
+        mgr = self._scoped_manager(app, pid)
+        root = str(tmp_path / "storage" / pid)
+        mgr._inner = self._WritingInner(root)
+
+        # The user deletes the project: directory pass + row + sweep,
+        # like the delete route.
+        pf.delete_project_root(str(tmp_path / "storage"), pid)
+        app.config["CHAT_DB"].delete_project(pid)
+        pf.delete_project_root(str(tmp_path / "storage"), pid)
+
+        text, _ = mgr.call_tool(SERVER_ID, "create_file", {"path": "late.md", "content": "x"})
+        assert text.startswith("Created")  # the tool itself succeeded...
+        assert not os.path.exists(root)    # ...but no orphan survives
+
+    def test_live_project_write_is_kept(self, app, tmp_path):
+        pid = self._make_project(app)
+        mgr = self._scoped_manager(app, pid)
+        root = str(tmp_path / "storage" / pid)
+        mgr._inner = self._WritingInner(root)
+        mgr.call_tool(SERVER_ID, "create_file", {"path": "late.md", "content": "x"})
+        assert os.path.exists(os.path.join(root, "late.md"))
+
+    def test_sweep_runs_even_when_the_call_raises(self, app, tmp_path):
+        # A timed-out subprocess may have written before dying — the
+        # revalidation is in a finally, not only on success.
+        pid = self._make_project(app)
+        mgr = self._scoped_manager(app, pid)
+        root = str(tmp_path / "storage" / pid)
+        mgr._inner = self._WritingInner(root, raise_after_write=True)
+        app.config["CHAT_DB"].delete_project(pid)
+        with pytest.raises(RuntimeError):
+            mgr.call_tool(SERVER_ID, "create_file", {"path": "late.md", "content": "x"})
+        assert not os.path.exists(root)
+
+    def test_other_servers_do_not_revalidate(self, app):
+        pid = self._make_project(app)
+        mgr = self._scoped_manager(app, pid)
+        calls = []
+        mgr._revalidate = lambda: calls.append(1)
+        mgr.call_tool("sympy-math", "solve", {})
+        assert calls == []
+        mgr.call_tool(SERVER_ID, "list_files", {})
+        assert calls == [1]
 
 
 class TestSpinoffInheritance:

--- a/dashboard/tests/test_project_files_mcp.py
+++ b/dashboard/tests/test_project_files_mcp.py
@@ -68,6 +68,18 @@ class TestUnscoped:
     def test_search_files(self):
         assert "not part of a project" in srv.search_files("x")
 
+    def test_create_file(self):
+        assert "not part of a project" in srv.create_file("a.md", "x")
+
+    def test_write_file(self):
+        assert "not part of a project" in srv.write_file("a.md", "x")
+
+    def test_edit_file(self):
+        assert "not part of a project" in srv.edit_file("a.md", "a", "b")
+
+    def test_insert_text(self):
+        assert "not part of a project" in srv.insert_text("a.md", 0, "x")
+
 
 class TestListFiles:
     def test_lists_tree_with_relative_paths(self, proj_root):
@@ -255,6 +267,173 @@ class TestSearchFiles:
         out = srv.search_files("needle")
         assert "bbb.txt:1: needle" in out
         assert "scan budget" not in out
+
+
+class TestCreateFile:
+    def test_creates_a_file(self, proj_root):
+        out = srv.create_file("new.md", "hello\n")
+        assert out.startswith("Created new.md")
+        assert (proj_root / "new.md").read_text() == "hello\n"
+
+    def test_creates_missing_parent_folders(self, proj_root):
+        out = srv.create_file("a/b/c.md", "deep\n")
+        assert out.startswith("Created a/b/c.md")
+        assert (proj_root / "a" / "b" / "c.md").read_text() == "deep\n"
+
+    def test_empty_content_by_default(self, proj_root):
+        srv.create_file("empty.md")
+        assert (proj_root / "empty.md").read_text() == ""
+
+    def test_refuses_to_overwrite(self, proj_root):
+        out = srv.create_file("notes.md", "clobber")
+        assert out.startswith("Error:")
+        assert "exists" in out
+        assert (proj_root / "notes.md").read_text().startswith("hello project")
+
+    def test_lazily_creates_the_project_root(self, tmp_path, monkeypatch):
+        root = tmp_path / "never-created"
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(root))
+        out = srv.create_file("first.md", "x")
+        assert out.startswith("Created first.md")
+        assert (root / "first.md").read_text() == "x"
+
+    def test_traversal_rejected(self, proj_root, tmp_path):
+        assert srv.create_file("../outside.md", "x").startswith("Error:")
+        assert not (tmp_path / "outside.md").exists()
+
+    def test_parent_that_is_a_file_rejected(self, proj_root):
+        out = srv.create_file("notes.md/sub.md", "x")
+        assert out.startswith("Error:")
+
+    def test_nul_content_rejected(self, proj_root):
+        assert srv.create_file("bin.md", "a\x00b").startswith("Error:")
+
+
+class TestWriteFile:
+    def test_replaces_entire_content(self, proj_root):
+        out = srv.write_file("notes.md", "rewritten\n")
+        assert out.startswith("Wrote notes.md")
+        assert (proj_root / "notes.md").read_text() == "rewritten\n"
+
+    def test_missing_file_points_to_create_file(self, proj_root):
+        out = srv.write_file("nope.md", "x")
+        assert out.startswith("Error:")
+        assert not (proj_root / "nope.md").exists()
+
+    def test_directory_rejected(self, proj_root):
+        assert srv.write_file("docs", "x").startswith("Error:")
+
+    def test_missing_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(tmp_path / "never-created"))
+        out = srv.write_file("a.md", "x")
+        assert out.startswith("Error:")
+        assert "create_file" in out
+
+    def test_size_cap_enforced(self, proj_root, monkeypatch):
+        monkeypatch.setattr(pf, "MAX_TEXT_EDIT_BYTES", 10)
+        out = srv.write_file("notes.md", "x" * 11)
+        assert out.startswith("Error:")
+
+
+class TestEditFile:
+    def test_replaces_unique_snippet(self, proj_root):
+        out = srv.edit_file("notes.md", "hello project", "hi there")
+        assert out == f"Replaced 1 occurrence in notes.md ({(proj_root / 'notes.md').stat().st_size} bytes)"
+        assert (proj_root / "notes.md").read_text().startswith("hi there\n")
+
+    def test_multiline_snippet(self, proj_root):
+        (proj_root / "multi.md").write_text("one\ntwo\nthree\n")
+        out = srv.edit_file("multi.md", "one\ntwo\n", "uno\n")
+        assert out.startswith("Replaced 1 occurrence")
+        assert (proj_root / "multi.md").read_text() == "uno\nthree\n"
+
+    def test_not_found_is_a_clear_error(self, proj_root):
+        out = srv.edit_file("notes.md", "no such text", "x")
+        assert out.startswith("Error:")
+        assert "not found" in out
+
+    def test_ambiguous_snippet_reports_the_count(self, proj_root):
+        (proj_root / "dup.md").write_text("aaa\nbbb\naaa\n")
+        out = srv.edit_file("dup.md", "aaa", "ccc")
+        assert out.startswith("Error:")
+        assert "2 times" in out
+        assert (proj_root / "dup.md").read_text() == "aaa\nbbb\naaa\n"  # untouched
+
+    def test_replace_all(self, proj_root):
+        (proj_root / "dup.md").write_text("aaa\nbbb\naaa\n")
+        out = srv.edit_file("dup.md", "aaa", "ccc", replace_all=True)
+        assert out.startswith("Replaced 2 occurrences")
+        assert (proj_root / "dup.md").read_text() == "ccc\nbbb\nccc\n"
+
+    def test_empty_new_text_deletes_the_snippet(self, proj_root):
+        (proj_root / "del.md").write_text("keep DROPME keep\n")
+        srv.edit_file("del.md", " DROPME", "")
+        assert (proj_root / "del.md").read_text() == "keep keep\n"
+
+    def test_empty_old_text_rejected(self, proj_root):
+        assert srv.edit_file("notes.md", "", "x").startswith("Error:")
+
+    def test_missing_file(self, proj_root):
+        assert srv.edit_file("nope.md", "a", "b").startswith("Error:")
+
+    def test_concurrent_change_fails_loudly(self, proj_root, monkeypatch):
+        # Simulate the file changing between the tool's read and its
+        # write: hand edit_file a stale revision for the real content.
+        real_read = pf.read_text
+
+        def stale_read(root, path):
+            doc = real_read(root, path)
+            return {**doc, "revision": "0" * 16}
+
+        monkeypatch.setattr(pf, "read_text", stale_read)
+        out = srv.edit_file("notes.md", "hello project", "hi")
+        assert out.startswith("Error:")
+        assert "changed on disk" in out
+        assert (proj_root / "notes.md").read_text().startswith("hello project")
+
+
+class TestInsertText:
+    def test_insert_at_top(self, proj_root):
+        (proj_root / "ins.md").write_text("second\n")
+        out = srv.insert_text("ins.md", 0, "first")
+        assert out.startswith("Inserted after line 0")
+        assert (proj_root / "ins.md").read_text() == "first\nsecond\n"
+
+    def test_insert_after_line(self, proj_root):
+        (proj_root / "ins.md").write_text("one\nthree\n")
+        srv.insert_text("ins.md", 1, "two")
+        assert (proj_root / "ins.md").read_text() == "one\ntwo\nthree\n"
+
+    def test_append_at_end(self, proj_root):
+        (proj_root / "ins.md").write_text("one\n")
+        srv.insert_text("ins.md", 1, "two")
+        assert (proj_root / "ins.md").read_text() == "one\ntwo\n"
+
+    def test_append_after_unterminated_last_line_does_not_glue(self, proj_root):
+        (proj_root / "ins.md").write_text("one")  # no trailing newline
+        srv.insert_text("ins.md", 1, "two")
+        assert (proj_root / "ins.md").read_text() == "one\ntwo\n"
+
+    def test_multiline_insert(self, proj_root):
+        (proj_root / "ins.md").write_text("top\n")
+        srv.insert_text("ins.md", 1, "a\nb")
+        assert (proj_root / "ins.md").read_text() == "top\na\nb\n"
+
+    def test_line_past_end_rejected(self, proj_root):
+        (proj_root / "ins.md").write_text("one\n")
+        out = srv.insert_text("ins.md", 5, "x")
+        assert out.startswith("Error:")
+        assert "past the end" in out
+
+    def test_invalid_line_values(self, proj_root):
+        assert srv.insert_text("notes.md", -1, "x").startswith("Error:")
+        assert srv.insert_text("notes.md", True, "x").startswith("Error:")
+
+    def test_empty_text_rejected(self, proj_root):
+        assert srv.insert_text("notes.md", 0, "").startswith("Error:")
+
+    def test_missing_file(self, proj_root):
+        assert srv.insert_text("nope.md", 0, "x").startswith("Error:")
 
 
 # ---------------------------------------------------------------------------
@@ -603,6 +782,30 @@ class TestEndToEnd:
         text, _ = scoped.call_tool(SERVER_ID, "search_files", {"query": "NEEDLE"})
         assert "hello.txt:1: end to end needle" in text
 
+    def test_write_round_trip_through_subprocess(self, tmp_path):
+        from chat.mcp_client import MCPClientManager
+
+        root = tmp_path / "p-e2e-write"
+        root.mkdir()
+
+        manager = MCPClientManager()
+        scoped = ProjectScopedMCPManager(manager, str(root))
+
+        text, _ = scoped.call_tool(SERVER_ID, "create_file",
+                                   {"path": "notes/todo.md", "content": "- first\n"})
+        assert text.startswith("Created notes/todo.md")
+
+        text, _ = scoped.call_tool(SERVER_ID, "edit_file",
+                                   {"path": "notes/todo.md",
+                                    "old_text": "- first", "new_text": "- first (done)"})
+        assert text.startswith("Replaced 1 occurrence")
+
+        text, _ = scoped.call_tool(SERVER_ID, "insert_text",
+                                   {"path": "notes/todo.md", "line": 1, "text": "- second"})
+        assert text.startswith("Inserted after line 1")
+
+        assert (root / "notes" / "todo.md").read_text() == "- first (done)\n- second\n"
+
     def test_unscoped_call_reports_no_project(self):
         from chat.mcp_client import MCPClientManager
 
@@ -610,7 +813,7 @@ class TestEndToEnd:
         text, _ = manager.call_tool(SERVER_ID, "list_files", {})
         assert "not part of a project" in text
 
-    def test_tool_discovery_lists_all_three(self):
+    def test_tool_discovery_lists_all_seven(self):
         from chat.mcp_client import MCPClientManager
 
         manager = MCPClientManager()
@@ -620,4 +823,8 @@ class TestEndToEnd:
             f"{SERVER_ID}__list_files",
             f"{SERVER_ID}__read_file",
             f"{SERVER_ID}__search_files",
+            f"{SERVER_ID}__create_file",
+            f"{SERVER_ID}__write_file",
+            f"{SERVER_ID}__edit_file",
+            f"{SERVER_ID}__insert_text",
         }


### PR DESCRIPTION
Extends the `project-files` MCP server from read-only (list/read/search) to read-write, so the chat LLM can create project files and modify them — including inserts and partial replacements.

## New tools
- **create_file(path, content="")** — strictly create; refuses to overwrite (same `already_exists` contract as the HTTP routes); auto-creates missing parent folders and the lazily-created project root.
- **write_file(path, content)** — replaces an existing regular file's entire content; a missing file is an error that points the model at create_file.
- **edit_file(path, old_text, new_text, replace_all=false)** — exact-snippet replacement. Zero matches → clear error telling the model to read_file and copy verbatim; multiple matches without replace_all → error reporting the count. The write carries the read's content revision, so a concurrent save from the in-browser editor fails loudly ("changed on disk") instead of silently reverting the user's edit.
- **insert_text(path, line, text)** — inserts whole lines after a 1-based line number (0 = top of file); appending after an unterminated final line adds the missing newline instead of gluing lines together.

## Plumbing
- Everything funnels through `chat.project_files.write_text`: path traversal/symlink-escape rejection, atomic temp-file publication, UTF-8 + NUL validation, and the 2 MB text cap all apply identically to the LLM and the UI.
- Scoping unchanged: tools act only under `LLM_DOCK_PROJECT_ROOT` injected per call; unscoped conversations get the explicit refusal.
- Registry `tool_hint` rewritten to describe the write surface and steer the model toward edit_file for small changes and actually persisting files when asked to.

## Tests
- 599 backend passing (+35: per-tool direct coverage incl. traversal/NUL/size-cap/ambiguity/revision-conflict/glue edge cases, unscoped refusals for all four, an end-to-end create→edit→insert round trip through the real spawned subprocess, and tool discovery asserting all seven tools).