### PR TITLE
feat(explorer): show files in the tree pane

### DIFF
--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -74,10 +74,33 @@ function formatSize(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-// One folder row in the left tree pane (recursive over subdirectories).
-function TreeDir({ node, depth, expanded, selectedDir, dropTarget, cutPath,
-                   onToggle, onSelect, onMenu, onDragStart, onDragOver, onDragLeave, onDrop }) {
-  const subdirs = (node.children || []).filter(c => c.type === 'dir')
+// One file row in the left tree pane. Files aren't drop targets (drops go
+// to folders), but they are drag sources and carry the full context menu.
+function TreeFile({ node, depth, editingPath, cutPath, onOpen, onMenu, onDragStart }) {
+  return (
+    <div
+      draggable
+      onClick={() => onOpen(node)}
+      onContextMenu={e => onMenu(e, node)}
+      onDragStart={e => onDragStart(e, node)}
+      className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
+        editingPath === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
+      } ${cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''}`}
+      style={{ paddingLeft: `${8 + depth * 14}px` }}
+      data-testid={`tree-node-${node.path}`}
+    >
+      <span className="w-4 flex-shrink-0"></span>
+      <i className="fa-regular fa-file text-xs text-fg-faint flex-shrink-0"></i>
+      <span className="flex-1 min-w-0 truncate">{node.name}</span>
+    </div>
+  )
+}
+
+// One folder row in the left tree pane (recursive over children; the
+// backend sorts dirs before files, so children render in tree order).
+function TreeDir({ node, depth, expanded, selectedDir, editingPath, dropTarget, cutPath,
+                   onToggle, onSelect, onOpenFile, onMenu, onDragStart, onDragOver, onDragLeave, onDrop }) {
+  const children = node.children || []
   const isExpanded = expanded.has(node.path)
   return (
     <>
@@ -99,7 +122,7 @@ function TreeDir({ node, depth, expanded, selectedDir, dropTarget, cutPath,
       >
         <button
           onClick={e => { e.stopPropagation(); onToggle(node.path) }}
-          className={`w-4 flex-shrink-0 text-fg-faint cursor-pointer ${subdirs.length ? '' : 'invisible'}`}
+          className={`w-4 flex-shrink-0 text-fg-faint cursor-pointer ${children.length ? '' : 'invisible'}`}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${node.path}`}
           tabIndex={-1}
         >
@@ -108,23 +131,38 @@ function TreeDir({ node, depth, expanded, selectedDir, dropTarget, cutPath,
         <i className={`fa-solid fa-folder${selectedDir === node.path ? '-open' : ''} text-xs text-amber-500/80 flex-shrink-0`}></i>
         <span className="flex-1 min-w-0 truncate">{node.name}</span>
       </div>
-      {isExpanded && subdirs.map(child => (
-        <TreeDir
-          key={child.path}
-          node={child}
-          depth={depth + 1}
-          expanded={expanded}
-          selectedDir={selectedDir}
-          dropTarget={dropTarget}
-          cutPath={cutPath}
-          onToggle={onToggle}
-          onSelect={onSelect}
-          onMenu={onMenu}
-          onDragStart={onDragStart}
-          onDragOver={onDragOver}
-          onDragLeave={onDragLeave}
-          onDrop={onDrop}
-        />
+      {isExpanded && children.map(child => (
+        child.type === 'dir' ? (
+          <TreeDir
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            expanded={expanded}
+            selectedDir={selectedDir}
+            editingPath={editingPath}
+            dropTarget={dropTarget}
+            cutPath={cutPath}
+            onToggle={onToggle}
+            onSelect={onSelect}
+            onOpenFile={onOpenFile}
+            onMenu={onMenu}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+          />
+        ) : (
+          <TreeFile
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            editingPath={editingPath}
+            cutPath={cutPath}
+            onOpen={onOpenFile}
+            onMenu={onMenu}
+            onDragStart={onDragStart}
+          />
+        )
       ))}
     </>
   )
@@ -644,23 +682,38 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
             <i className="fa-solid fa-house text-xs text-fg-subtle flex-shrink-0"></i>
             <span className="flex-1 min-w-0 truncate font-medium">{project.name}</span>
           </div>
-          {tree.filter(n => n.type === 'dir').map(node => (
-            <TreeDir
-              key={node.path}
-              node={node}
-              depth={1}
-              expanded={expanded}
-              selectedDir={selectedDir}
-              dropTarget={dropTarget}
-              cutPath={cutPath}
-              onToggle={toggle}
-              onSelect={selectDir}
-              onMenu={openMenu}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onDrop={handleDrop}
-            />
+          {tree.map(node => (
+            node.type === 'dir' ? (
+              <TreeDir
+                key={node.path}
+                node={node}
+                depth={1}
+                expanded={expanded}
+                selectedDir={selectedDir}
+                editingPath={editing?.path}
+                dropTarget={dropTarget}
+                cutPath={cutPath}
+                onToggle={toggle}
+                onSelect={selectDir}
+                onOpenFile={handleOpenFile}
+                onMenu={openMenu}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+              />
+            ) : (
+              <TreeFile
+                key={node.path}
+                node={node}
+                depth={1}
+                editingPath={editing?.path}
+                cutPath={cutPath}
+                onOpen={handleOpenFile}
+                onMenu={openMenu}
+                onDragStart={handleDragStart}
+              />
+            )
           ))}
         </div>
 

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -423,9 +423,13 @@ export default function ProjectPage({ project, onEditorDirtyChange }) {
   }, [project?.id, run, guardEditedPath, editingUnder, editing])
 
   const handleOpenFile = useCallback((node) => {
+    // Already open (e.g. clicking the highlighted tree row): a no-op.
+    // Prompting would be misleading — confirming installs the same
+    // editor key, so nothing is actually discarded.
+    if (editing?.path === node.path) return
     if (!confirmDiscardEdits()) return
     setEditing({ path: node.path, isNew: false })
-  }, [confirmDiscardEdits])
+  }, [editing?.path, confirmDiscardEdits])
 
   const handleNewFile = useCallback((parentPath) => {
     if (!confirmDiscardEdits()) return

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -413,6 +413,18 @@ describe('ProjectPage tree file rows', () => {
     expect(mockGetContent).toHaveBeenCalledTimes(1) // no second load
   })
 
+  it('clicking the tree row of the already-open file is a no-op — no discard prompt, buffer intact (regression: codex 1.1)', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-readme.md'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved work' } })
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    fireEvent.click(screen.getByTestId('tree-node-readme.md'))
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
+    expect(mockGetContent).toHaveBeenCalledTimes(1) // no reload
+  })
+
   it('right-clicking a tree file offers the file menu and Delete works', async () => {
     await renderPage()
     fireEvent.contextMenu(screen.getByTestId('tree-node-readme.md'), { clientX: 5, clientY: 5 })

--- a/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.test.jsx
@@ -86,10 +86,12 @@ describe('ProjectPage explorer layout', () => {
     await renderPage()
     expect(screen.getByRole('heading', { name: 'Research' })).toBeTruthy()
     expect(screen.getByText('notes & data')).toBeTruthy()
-    // Tree pane: root node + dirs only.
+    // Tree pane: root node, dirs, and root-level files.
     expect(screen.getByTestId('tree-node-root')).toBeTruthy()
     expect(screen.getByTestId('tree-node-docs')).toBeTruthy()
-    expect(screen.queryByTestId('tree-node-readme.md')).toBeNull()
+    expect(screen.getByTestId('tree-node-readme.md')).toBeTruthy()
+    // Files inside collapsed folders stay hidden until expanded.
+    expect(screen.queryByTestId('tree-node-docs/a.txt')).toBeNull()
     // Right pane: root entries; children hidden until docs is selected.
     expect(screen.getByTestId('file-row-docs')).toBeTruthy()
     expect(screen.queryByTestId('file-row-docs/a.txt')).toBeNull()
@@ -117,11 +119,12 @@ describe('ProjectPage explorer layout', () => {
     expect(screen.getByTestId('file-row-readme.md')).toBeTruthy()
   })
 
-  it('tree chevron expands subfolders without changing the selection', async () => {
+  it('tree chevron expands subfolders and files without changing the selection', async () => {
     await renderPage()
     expect(screen.queryByTestId('tree-node-docs/inner')).toBeNull()
     fireEvent.click(screen.getByLabelText('Expand docs'))
     expect(screen.getByTestId('tree-node-docs/inner')).toBeTruthy()
+    expect(screen.getByTestId('tree-node-docs/a.txt')).toBeTruthy()
     // Selection unchanged: right pane still shows the root.
     expect(screen.getByTestId('file-row-readme.md')).toBeTruthy()
   })
@@ -379,6 +382,60 @@ describe('ProjectPage drag and drop', () => {
     await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'docs/inner', 'inner'))
     // Right pane follows the moved folder (still selected, at its new path).
     await waitFor(() => expect(screen.getByTestId('crumb-inner')).toBeTruthy())
+  })
+})
+
+describe('ProjectPage tree file rows', () => {
+  it('clicking a file in the tree opens it in the editor', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-readme.md'))
+    await waitFor(() => expect(mockGetContent).toHaveBeenCalledWith('p1', 'readme.md'))
+    expect(await screen.findByTestId('file-editor')).toBeTruthy()
+  })
+
+  it('the file open in the editor is highlighted in the tree', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-readme.md'))
+    await screen.findByTestId('file-editor')
+    expect(screen.getByTestId('tree-node-readme.md').className).toContain('bg-accent-subtle')
+  })
+
+  it('clicking a tree file with a dirty editor asks first; cancel keeps the buffer', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    fireEvent.click(screen.getByTestId('file-row-docs/a.txt'))
+    const ta = await screen.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved work' } })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getByTestId('tree-node-readme.md'))
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
+    expect(mockGetContent).toHaveBeenCalledTimes(1) // no second load
+  })
+
+  it('right-clicking a tree file offers the file menu and Delete works', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('tree-node-readme.md'), { clientX: 5, clientY: 5 })
+    const menu = screen.getByTestId('context-menu')
+    for (const label of ['Open', 'Download', 'Cut', 'Copy', 'Rename', 'Delete']) {
+      expect(within(menu).getByText(label)).toBeTruthy()
+    }
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fireEvent.click(within(menu).getByText('Delete'))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('p1', 'readme.md'))
+  })
+
+  it('dragging a tree file onto a tree folder moves it there', async () => {
+    await renderPage()
+    dragAndDrop(screen.getByTestId('tree-node-readme.md'), screen.getByTestId('tree-node-docs'))
+    await waitFor(() => expect(mockMove).toHaveBeenCalledWith('p1', 'readme.md', 'docs/readme.md'))
+  })
+
+  it('a cut tree file is dimmed while on the clipboard', async () => {
+    await renderPage()
+    fireEvent.contextMenu(screen.getByTestId('tree-node-readme.md'), { clientX: 5, clientY: 5 })
+    fireEvent.click(within(screen.getByTestId('context-menu')).getByText('Cut'))
+    expect(screen.getByTestId('tree-node-readme.md').className).toContain('opacity-50')
   })
 })
 
@@ -647,7 +704,8 @@ describe('ProjectPage in-page editor replacement guard (regression: codex 5.1)',
     // Cancelled: same editor, text intact, no name prompt shown.
     expect(promptSpy).not.toHaveBeenCalled()
     expect(screen.getByTestId('editor-textarea').value).toBe('unsaved work')
-    expect(screen.getByText('readme.md')).toBeTruthy()
+    // Scoped to the editor: the tree also shows a readme.md row now.
+    expect(within(screen.getByTestId('file-editor')).getByText('readme.md')).toBeTruthy()
   })
 
   it('confirming the discard opens the new file editor', async () => {
@@ -724,13 +782,13 @@ describe('ProjectPage stale-response guard', () => {
     await waitFor(() => expect(mockTree).toHaveBeenCalledWith('pa'))
 
     rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
-    await screen.findByText('b-only.txt')
+    await screen.findByTestId('file-row-b-only.txt')
 
     resolveA({ tree: treeA })
     // Give the late resolution a tick to (incorrectly) commit.
     await new Promise(r => setTimeout(r, 0))
-    expect(screen.queryByText('a-only.txt')).toBeNull()
-    expect(screen.getByText('b-only.txt')).toBeTruthy()
+    expect(screen.queryByTestId('file-row-a-only.txt')).toBeNull()
+    expect(screen.getByTestId('file-row-b-only.txt')).toBeTruthy()
   })
 })
 
@@ -749,18 +807,18 @@ describe('ProjectPage stale-mutation guard', () => {
     vi.spyOn(window, 'prompt').mockReturnValue('slow-dir')
 
     const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
-    await screen.findByText('a-only.txt')
+    await screen.findByTestId('file-row-a-only.txt')
     fireEvent.click(screen.getByText('New folder'))         // A's mutation, pending
     await waitFor(() => expect(mockMkdir).toHaveBeenCalled())
 
     rerender(<ProjectPage project={{ id: 'pb', name: 'B' }} />)
-    await screen.findByText('b-only.txt')
+    await screen.findByTestId('file-row-b-only.txt')
 
     resolveMkdir({})                                        // A's run() resumes: refresh('pa')
     await new Promise(r => setTimeout(r, 0))
     await new Promise(r => setTimeout(r, 0))
-    expect(screen.queryByText('a-only.txt')).toBeNull()
-    expect(screen.getByText('b-only.txt')).toBeTruthy()
+    expect(screen.queryByTestId('file-row-a-only.txt')).toBeNull()
+    expect(screen.getByTestId('file-row-b-only.txt')).toBeTruthy()
   })
 })
 
@@ -820,7 +878,7 @@ describe('ProjectPage stale-refresh generation theft', () => {
     vi.spyOn(window, 'prompt').mockReturnValue('slow-dir')
 
     const { rerender } = render(<ProjectPage project={{ id: 'pa', name: 'A' }} />)
-    await screen.findByText('a-only.txt')
+    await screen.findByTestId('file-row-a-only.txt')
     fireEvent.click(screen.getByText('New folder'))          // A's mutation, pending
     await waitFor(() => expect(mockMkdir).toHaveBeenCalled())
 
@@ -830,7 +888,7 @@ describe('ProjectPage stale-refresh generation theft', () => {
     resolveMkdir({})                                         // stale A follow-up refresh runs first
     await new Promise(r => setTimeout(r, 0))
     resolveB({ tree: treeB })                                // B resolves LAST
-    expect(await screen.findByText('b-only.txt')).toBeTruthy()
-    expect(screen.queryByText('a-only.txt')).toBeNull()
+    expect(await screen.findByTestId('file-row-b-only.txt')).toBeTruthy()
+    expect(screen.queryByTestId('file-row-a-only.txt')).toBeNull()
   })
 })


### PR DESCRIPTION
The explorer's left tree pane listed folders only; files were reachable only through the right pane. This PR adds file rows to the tree:

- Root-level files and files inside expanded folders render in the tree, below their sibling folders (backend tree order, dirs first).
- Clicking a tree file opens it in the editor, going through the existing dirty-buffer confirm guard.
- Tree files are drag sources (same DnD payload as right-pane rows) and carry the full file context menu (Open / Download / Cut / Copy / Rename / Delete).
- A cut file is dimmed in the tree, matching the right pane.
- The file currently open in the editor is highlighted in the tree.
- Files are NOT drop targets — drops continue to land on folders only.
- The expand chevron now shows for any folder with children (previously only subfolders counted, so a folder holding only files had no chevron and its contents were invisible in the tree).

Tests: 66 ProjectPage tests (6 new for tree file rows), full frontend suite 249 passing. Four existing tests were switched from text queries to testids because root files now legitimately render in both panes.