### PR TITLE
feat(chat): project file explorer beside project conversations

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useCallback, useRef } from 'react'
+import { useEffect, useCallback, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
 import ProjectPage from './ProjectPage'
+import ProjectChatSplit from './ProjectChatSplit'
 import useConversations from '../../hooks/useConversations'
 import useProjects from '../../hooks/useProjects'
 import useChat from '../../hooks/useChat'
@@ -16,6 +17,11 @@ export default function ChatPage() {
   const { conversationId, projectId } = useParams()
   const convId = conversationId || null
   const navigate = useNavigate()
+
+  // Bumped when a chat run completes — the run may have written project
+  // files via the project-files tools, so the explorer strip re-reads
+  // the tree.
+  const [filesRefreshKey, setFilesRefreshKey] = useState(0)
 
   const { conversations, refresh, create, remove, removeMany, rename, patchConversation } = useConversations()
   const { projects, refresh: refreshProjects, create: createProject, rename: renameProject, remove: removeProject } = useProjects()
@@ -78,10 +84,13 @@ export default function ChatPage() {
     }
   }, [convId, conversation, streaming, sendMessage])
 
-  // Refresh conversation list when streaming completes (for auto-title)
+  // Refresh conversation list when streaming completes (for auto-title),
+  // and re-read the project file tree — the run may have created or
+  // edited files.
   useEffect(() => {
     if (!streaming && conversation) {
       refresh()
+      setFilesRefreshKey(k => k + 1)
     }
   }, [streaming]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -92,6 +101,15 @@ export default function ChatPage() {
       refresh()
     }
   }, [runReady]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Project of the ACTIVE conversation — drives the file-explorer strip
+  // next to the chat. Gated on the loaded conversation matching the route
+  // so a stale `conversation` (mid-switch) can't show the previous chat's
+  // project files; unknown project ids (deleted elsewhere) drop the strip.
+  const conversationProject =
+    convId && conversation && conversation.id === convId && conversation.project_id
+      ? projects.find(p => p.id === conversation.project_id) || null
+      : null
 
   const handleRename = useCallback(async (id, title) => {
     await rename(id, title)
@@ -248,6 +266,12 @@ export default function ChatPage() {
           onEditorDirtyChange={(d) => { editorDirtyRef.current = d }}
         />
       ) : (
+      <ProjectChatSplit
+        project={conversationProject}
+        conversationId={convId}
+        refreshKey={filesRefreshKey}
+        onEditorDirtyChange={(d) => { editorDirtyRef.current = d }}
+      >
       <ChatArea
         conversation={conversation}
         awaitingConversation={!!convId && (!conversation || conversation.id !== convId)}
@@ -274,6 +298,7 @@ export default function ChatPage() {
         onReloadConversation={loadConversation}
         onRefreshConversations={refresh}
       />
+      </ProjectChatSplit>
       )}
     </div>
   )

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useState } from 'react'
+import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
@@ -102,14 +102,33 @@ export default function ChatPage() {
     }
   }, [runReady]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Project of the ACTIVE conversation — drives the file-explorer strip
-  // next to the chat. Gated on the loaded conversation matching the route
-  // so a stale `conversation` (mid-switch) can't show the previous chat's
-  // project files; unknown project ids (deleted elsewhere) drop the strip.
-  const conversationProject =
-    convId && conversation && conversation.id === convId && conversation.project_id
-      ? projects.find(p => p.id === conversation.project_id) || null
-      : null
+  // Effective project of the ACTIVE conversation — drives the file-explorer
+  // strip next to the chat. Spin-offs store project_id = NULL and inherit
+  // membership from their root (the DB triggers enforce this and the server
+  // resolves the chain the same way), so walk up through the loaded list;
+  // the list is also refreshed after moves, so a moved active conversation
+  // switches strips without a conversation reload. Falls back to the loaded
+  // conversation's own field when the list row isn't present (fresh chat not
+  // yet in the paginated list) — gated on the id matching the route so a
+  // stale mid-switch `conversation` can't show the previous chat's files.
+  // Unknown project ids (deleted elsewhere) drop the strip.
+  const effectiveProjectId = useMemo(() => {
+    if (!convId) return null
+    const byId = new Map(conversations.map(c => [c.id, c]))
+    let row = byId.get(convId)
+    if (row) {
+      const seen = new Set()
+      while (row.parent_conversation_id && byId.has(row.parent_conversation_id) && !seen.has(row.id)) {
+        seen.add(row.id)
+        row = byId.get(row.parent_conversation_id)
+      }
+      return row.project_id || null
+    }
+    return conversation && conversation.id === convId ? (conversation.project_id || null) : null
+  }, [convId, conversations, conversation])
+  const conversationProject = effectiveProjectId
+    ? projects.find(p => p.id === effectiveProjectId) || null
+    : null
 
   const handleRename = useCallback(async (id, title) => {
     await rename(id, title)
@@ -225,21 +244,27 @@ export default function ChatPage() {
 
   const handleDelete = useCallback(async (id) => {
     const shouldNavigate = activeWillBeDeleted([id])
+    // Deleting the active conversation (or an ancestor whose cascade
+    // includes it) unmounts a possibly-dirty file editor via the
+    // navigation below — run the same discard guard as the other
+    // navigation paths, and let cancel abort the deletion.
+    if (shouldNavigate && !confirmDiscardEdits()) return
     await remove(id)
     // Deleted conversations may have belonged to a project — refresh the
     // cached per-project counts so a section can't claim chats it no
     // longer has.
     await refreshProjects()
     if (shouldNavigate) navigate('/chat')
-  }, [remove, refreshProjects, activeWillBeDeleted, navigate])
+  }, [remove, refreshProjects, activeWillBeDeleted, navigate, confirmDiscardEdits])
 
   const handleDeleteMany = useCallback(async (ids) => {
     if (!ids || ids.length === 0) return
     const shouldNavigate = activeWillBeDeleted(ids)
+    if (shouldNavigate && !confirmDiscardEdits()) return
     await removeMany(ids)
     await refreshProjects()
     if (shouldNavigate) navigate('/chat')
-  }, [removeMany, refreshProjects, activeWillBeDeleted, navigate])
+  }, [removeMany, refreshProjects, activeWillBeDeleted, navigate, confirmDiscardEdits])
 
   return (
     <div className="flex-1 flex overflow-hidden">

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -153,12 +153,16 @@ export default function ChatPage() {
   // navigation unmounts the editor without its own close handler, so the
   // navigation entry points below confirm before discarding. (Browser
   // close/reload is guarded by the editor's beforeunload handler.)
+  //
+  // The ref is NOT cleared here: some guarded actions await a mutation
+  // that can fail, leaving the editor mounted with its dirty buffer — a
+  // pre-cleared ref would let the next navigation discard those edits
+  // without asking (codex iteration 3, P2). The editor resets the flag
+  // itself when it actually unmounts or its dirty state changes.
   const editorDirtyRef = useRef(false)
   const confirmDiscardEdits = useCallback(() => {
     if (!editorDirtyRef.current) return true
-    if (!window.confirm('Discard unsaved changes?')) return false
-    editorDirtyRef.current = false
-    return true
+    return window.confirm('Discard unsaved changes?')
   }, [])
 
   const handleCreate = useCallback(async () => {
@@ -195,9 +199,10 @@ export default function ChatPage() {
 
   const handleDeleteProject = useCallback(async (id) => {
     // Deleting the project backing the active conversation's explorer
-    // strip unmounts a possibly-dirty file editor (and removes the files
+    // strip — or the project page currently open (route projectId) —
+    // unmounts a possibly-dirty file editor (and removes the files
     // behind it) — run the discard guard first, cancel aborts.
-    if (id === effectiveProjectId && !confirmDiscardEdits()) return
+    if ((id === effectiveProjectId || id === projectId) && !confirmDiscardEdits()) return
     // Conversations are detached server-side, not deleted — refresh the
     // list so they reappear as unfiled.
     await removeProject(id)

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -112,8 +112,8 @@ export default function ChatPage() {
   // yet in the paginated list) — gated on the id matching the route so a
   // stale mid-switch `conversation` can't show the previous chat's files.
   // Unknown project ids (deleted elsewhere) drop the strip.
-  const effectiveProjectId = useMemo(() => {
-    if (!convId) return null
+  const { activeRootId, effectiveProjectId } = useMemo(() => {
+    if (!convId) return { activeRootId: null, effectiveProjectId: null }
     const byId = new Map(conversations.map(c => [c.id, c]))
     let row = byId.get(convId)
     if (row) {
@@ -122,9 +122,13 @@ export default function ChatPage() {
         seen.add(row.id)
         row = byId.get(row.parent_conversation_id)
       }
-      return row.project_id || null
+      return { activeRootId: row.id, effectiveProjectId: row.project_id || null }
     }
-    return conversation && conversation.id === convId ? (conversation.project_id || null) : null
+    return {
+      activeRootId: convId,
+      effectiveProjectId:
+        conversation && conversation.id === convId ? (conversation.project_id || null) : null,
+    }
   }, [convId, conversations, conversation])
   const conversationProject = effectiveProjectId
     ? projects.find(p => p.id === effectiveProjectId) || null
@@ -190,18 +194,27 @@ export default function ChatPage() {
   }, [createProject])
 
   const handleDeleteProject = useCallback(async (id) => {
+    // Deleting the project backing the active conversation's explorer
+    // strip unmounts a possibly-dirty file editor (and removes the files
+    // behind it) — run the discard guard first, cancel aborts.
+    if (id === effectiveProjectId && !confirmDiscardEdits()) return
     // Conversations are detached server-side, not deleted — refresh the
     // list so they reappear as unfiled.
     await removeProject(id)
     await refresh()
     // Don't leave the URL pointing at the project page we just deleted.
     if (projectId === id) navigate('/chat')
-  }, [removeProject, refresh, projectId, navigate])
+  }, [removeProject, refresh, projectId, navigate, effectiveProjectId, confirmDiscardEdits])
 
   const handleMoveMany = useCallback(async (ids, projectId) => {
+    // Moving the active conversation's root changes its effective
+    // project; the strip then swaps (or disappears) and the split's
+    // reset effect closes the editor — same silent-loss path as above.
+    // ids are already root-resolved by the sidebar.
+    if (ids.includes(activeRootId) && !confirmDiscardEdits()) return
     await Promise.all(ids.map(id => updateConversation(id, { project_id: projectId })))
     await Promise.all([refresh(), refreshProjects()])
-  }, [refresh, refreshProjects])
+  }, [refresh, refreshProjects, activeRootId, confirmDiscardEdits])
 
   // Empty-state composer: create a conversation, then queue the typed
   // message so it sends as soon as the new conversation loads.

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -199,3 +199,54 @@ describe('ChatPage delete → project count refresh', () => {
     expect(mockListProjects).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('ChatPage project conversation split view', () => {
+  afterEach(() => localStorage.clear())
+
+  function renderConversationRoute() {
+    return render(
+      <MemoryRouter initialEntries={['/chat/abc']}>
+        <Routes>
+          <Route path="/chat/:conversationId" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+  }
+
+  it('shows the file-explorer strip when the conversation belongs to a project', async () => {
+    const { screen: s } = await import('@testing-library/react')
+    mockGetConversation.mockResolvedValue({
+      id: 'abc', title: 'T', main_service: 'vllm-test', project_id: 'p1',
+      messages: [], active_run: null, last_run: null,
+    })
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Fancy', conversation_count: 1 }],
+    })
+    renderConversationRoute()
+    await waitFor(() => expect(s.getByTestId('project-chat-split')).toBeInTheDocument())
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledWith('p1'))
+    expect(s.getByTestId('explorer-strip')).toBeInTheDocument()
+  })
+
+  it('renders no strip for a conversation without a project', async () => {
+    const { screen: s } = await import('@testing-library/react')
+    renderConversationRoute()
+    await waitFor(() => expect(mockGetConversation).toHaveBeenCalled())
+    // Give the split a chance to (incorrectly) appear before asserting.
+    await new Promise(r => setTimeout(r, 0))
+    expect(s.queryByTestId('project-chat-split')).toBeNull()
+    expect(mockFilesTree).not.toHaveBeenCalled()
+  })
+
+  it('renders no strip when the conversation points at an unknown project', async () => {
+    const { screen: s } = await import('@testing-library/react')
+    mockGetConversation.mockResolvedValue({
+      id: 'abc', title: 'T', main_service: 'vllm-test', project_id: 'ghost',
+      messages: [], active_run: null, last_run: null,
+    })
+    renderConversationRoute()
+    await waitFor(() => expect(mockGetConversation).toHaveBeenCalled())
+    await new Promise(r => setTimeout(r, 0))
+    expect(s.queryByTestId('project-chat-split')).toBeNull()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -250,3 +250,92 @@ describe('ChatPage project conversation split view', () => {
     expect(s.queryByTestId('project-chat-split')).toBeNull()
   })
 })
+
+describe('ChatPage spin-off project inheritance (regression: PR #87 codex 1.2)', () => {
+  afterEach(() => localStorage.clear())
+
+  it('shows the explorer for a spin-off whose root belongs to a project', async () => {
+    const { screen: s } = await import('@testing-library/react')
+    // Spin-offs store project_id = null (DB triggers enforce it) and
+    // inherit membership from their root conversation.
+    mockGetConversation.mockResolvedValue({
+      id: 'spin', title: 'S', main_service: 'vllm-test',
+      parent_conversation_id: 'root1', project_id: null,
+      messages: [], active_run: null, last_run: null,
+    })
+    mockListConversations.mockResolvedValue({
+      conversations: [
+        { id: 'root1', title: 'R', parent_conversation_id: null, project_id: 'p1', updated_at: '2026-01-01' },
+        { id: 'spin', title: 'S', parent_conversation_id: 'root1', project_id: null, updated_at: '2026-01-01' },
+      ],
+    })
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Fancy', conversation_count: 1 }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/chat/spin']}>
+        <Routes>
+          <Route path="/chat/:conversationId" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(s.getByTestId('project-chat-split')).toBeInTheDocument())
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledWith('p1'))
+  })
+})
+
+describe('ChatPage dirty-editor delete guard (regression: PR #87 codex 1.3)', () => {
+  afterEach(() => localStorage.clear())
+
+  async function openAndDirtySplitEditor() {
+    const { screen: s } = await import('@testing-library/react')
+    const { fireEvent } = await import('@testing-library/react')
+    mockGetConversation.mockResolvedValue({
+      id: 'abc', title: 'T', main_service: 'vllm-test', project_id: 'p1',
+      messages: [], active_run: null, last_run: null,
+    })
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Fancy', conversation_count: 1 }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/chat/abc']}>
+        <Routes>
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(s.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(s.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(s.getByTestId('editor-textarea')).toBeInTheDocument())
+    fireEvent.change(s.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+  }
+
+  it('cancelling the discard prompt aborts deleting the active conversation', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onDelete('abc') })
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockDeleteConversation).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('confirming the discard prompt lets the deletion proceed', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onDelete('abc') })
+    expect(mockDeleteConversation).toHaveBeenCalledWith('abc')
+    confirmSpy.mockRestore()
+  })
+
+  it('bulk delete honours the same guard', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onDeleteMany(['abc']) })
+    expect(mockDeleteConversations).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onDeleteMany(['abc']) })
+    expect(mockDeleteConversations).toHaveBeenCalledWith(['abc'])
+    confirmSpy.mockRestore()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -407,3 +407,85 @@ describe('ChatPage dirty-editor guards on project mutations (regression: PR #87 
     confirmSpy.mockRestore()
   })
 })
+
+describe('ChatPage failed-mutation dirty guard stays armed (regression: PR #87 codex 3.2)', () => {
+  afterEach(() => localStorage.clear())
+
+  async function openAndDirtySplitEditor() {
+    const { screen: s, fireEvent } = await import('@testing-library/react')
+    mockGetConversation.mockResolvedValue({
+      id: 'abc', title: 'T', main_service: 'vllm-test', project_id: 'p1',
+      messages: [], active_run: null, last_run: null,
+    })
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Fancy', conversation_count: 1 }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/chat/abc']}>
+        <Routes>
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(s.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(s.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(s.getByTestId('editor-textarea')).toBeInTheDocument())
+    fireEvent.change(s.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+    return s
+  }
+
+  it('a rejected move keeps the dirty guard armed for the next navigation', async () => {
+    const s = await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    confirmSpy.mockClear()
+    mockUpdateConversation.mockRejectedValueOnce(new Error('boom'))
+    await act(async () => {
+      await sidebarProps.current.onMoveMany(['abc'], 'p2').catch(() => {})
+    })
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    // Editor still mounted with its buffer after the failure…
+    expect(s.getByTestId('editor-textarea').value).toBe('edited')
+
+    // …so the NEXT navigation must ask again, not silently discard.
+    confirmSpy.mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onSelect('other') })
+    expect(confirmSpy).toHaveBeenCalledTimes(2)
+    expect(s.getByTestId('editor-textarea').value).toBe('edited')
+    confirmSpy.mockRestore()
+  })
+})
+
+describe('ChatPage project-page delete guard (regression: PR #87 codex 3.1)', () => {
+  afterEach(() => localStorage.clear())
+
+  it('deleting the project open on the project page prompts while its editor is dirty', async () => {
+    const { screen: s, fireEvent } = await import('@testing-library/react')
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'P', conversation_count: 0 }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/chat/project/p1']}>
+        <Routes>
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
+          <Route path="/chat/project/:projectId" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    const row = await s.findByTestId('file-row-a.md')
+    await act(async () => { row.click() })
+    const ta = await s.findByTestId('editor-textarea')
+    fireEvent.change(ta, { target: { value: 'unsaved edits' } })
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    confirmSpy.mockClear()
+    await act(async () => { await sidebarProps.current.onDeleteProject('p1') })
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockDeleteProject).not.toHaveBeenCalled()
+    expect(s.getByTestId('editor-textarea').value).toBe('unsaved edits')
+
+    confirmSpy.mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onDeleteProject('p1') })
+    expect(mockDeleteProject).toHaveBeenCalledWith('p1')
+    confirmSpy.mockRestore()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ChatPage.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.test.jsx
@@ -21,7 +21,8 @@ vi.mock('../../hooks/useServicesSSE', () => ({
 
 const { mockGetConversation, mockListConversations, mockCancelActiveRun,
         mockListProjects, mockDeleteConversation, mockDeleteConversations,
-        mockFilesTree, mockGetFileContent } = vi.hoisted(() => ({
+        mockFilesTree, mockGetFileContent, mockUpdateConversation,
+        mockDeleteProject } = vi.hoisted(() => ({
   mockGetConversation: vi.fn(),
   mockListConversations: vi.fn(),
   mockCancelActiveRun: vi.fn(),
@@ -30,6 +31,8 @@ const { mockGetConversation, mockListConversations, mockCancelActiveRun,
   mockDeleteConversations: vi.fn(),
   mockFilesTree: vi.fn(),
   mockGetFileContent: vi.fn(),
+  mockUpdateConversation: vi.fn(),
+  mockDeleteProject: vi.fn(),
 }))
 vi.mock('../../services/chat', async (importActual) => ({
   ...(await importActual()),
@@ -41,6 +44,8 @@ vi.mock('../../services/chat', async (importActual) => ({
   deleteConversations: (...a) => mockDeleteConversations(...a),
   getProjectFilesTree: (...a) => mockFilesTree(...a),
   getProjectFileContent: (...a) => mockGetFileContent(...a),
+  updateConversation: (...a) => mockUpdateConversation(...a),
+  deleteProject: (...a) => mockDeleteProject(...a),
 }))
 
 // streamChat is never expected to fire here (no active run), but stub it to a
@@ -67,6 +72,8 @@ beforeEach(() => {
     tree: [{ name: 'a.md', path: 'a.md', type: 'file', size: 1, modified_at: 1 }],
   })
   mockGetFileContent.mockReset().mockResolvedValue({ path: 'a.md', content: 'body', revision: 'r1' })
+  mockUpdateConversation.mockReset().mockResolvedValue({ ok: true })
+  mockDeleteProject.mockReset().mockResolvedValue({ ok: true })
   mockStreamChat.mockImplementation(() => new Promise(() => {}))
   sidebarProps.current = null
 })
@@ -336,6 +343,67 @@ describe('ChatPage dirty-editor delete guard (regression: PR #87 codex 1.3)', ()
     confirmSpy.mockReturnValue(true)
     await act(async () => { await sidebarProps.current.onDeleteMany(['abc']) })
     expect(mockDeleteConversations).toHaveBeenCalledWith(['abc'])
+    confirmSpy.mockRestore()
+  })
+})
+
+describe('ChatPage dirty-editor guards on project mutations (regression: PR #87 codex 2.1)', () => {
+  afterEach(() => localStorage.clear())
+
+  async function openAndDirtySplitEditor() {
+    const { screen: s, fireEvent } = await import('@testing-library/react')
+    mockGetConversation.mockResolvedValue({
+      id: 'abc', title: 'T', main_service: 'vllm-test', project_id: 'p1',
+      messages: [], active_run: null, last_run: null,
+    })
+    mockListProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Fancy', conversation_count: 1 }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/chat/abc']}>
+        <Routes>
+          <Route path="/chat/:conversationId?" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(s.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(s.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(s.getByTestId('editor-textarea')).toBeInTheDocument())
+    fireEvent.change(s.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+  }
+
+  it('moving the active root prompts; cancel sends no update', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onMoveMany(['abc'], 'p2') })
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockUpdateConversation).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onMoveMany(['abc'], 'p2') })
+    expect(mockUpdateConversation).toHaveBeenCalledWith('abc', { project_id: 'p2' })
+    confirmSpy.mockRestore()
+  })
+
+  it('moving other conversations does not prompt', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    await act(async () => { await sidebarProps.current.onMoveMany(['other'], 'p2') })
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(mockUpdateConversation).toHaveBeenCalledWith('other', { project_id: 'p2' })
+    confirmSpy.mockRestore()
+  })
+
+  it('deleting the active project prompts; cancel sends no delete', async () => {
+    await openAndDirtySplitEditor()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await act(async () => { await sidebarProps.current.onDeleteProject('p1') })
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockDeleteProject).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    await act(async () => { await sidebarProps.current.onDeleteProject('p1') })
+    expect(mockDeleteProject).toHaveBeenCalledWith('p1')
     confirmSpy.mockRestore()
   })
 })

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import ThemeSwitcher from '../ThemeSwitcher'
 
+const COLLAPSED_KEY = 'llmdock.chatSidebar.collapsed'
+
+function readCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
 function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggleSelect, confirmDelete, setConfirmDelete, onSelect, onDelete, renaming, onRenameStart, onRenameConfirm }) {
   const isSpinoff = !!conv.parent_conversation_id
   const inputRef = useRef(null)
@@ -304,6 +314,7 @@ function ProjectHeader({ project, collapsed, active, onToggleCollapse, onOpenPro
 }
 
 export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], activeProjectId = null, onOpenProject, onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
+  const [collapsed, setCollapsed] = useState(readCollapsed)
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [renaming, setRenaming] = useState(null)
   const [confirmDeleteProject, setConfirmDeleteProject] = useState(null)
@@ -488,11 +499,57 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
     )
   }
 
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLLAPSED_KEY, String(collapsed))
+    } catch {
+      /* localStorage unavailable — keep in-memory state only */
+    }
+  }, [collapsed])
+
+  if (collapsed) {
+    return (
+      <div
+        className="w-10 border-r border-border flex flex-col items-center bg-app flex-shrink-0 py-2 gap-1"
+        data-testid="chat-sidebar-collapsed"
+      >
+        <button
+          onClick={() => setCollapsed(false)}
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
+          title="Show conversations"
+          aria-label="Show conversations"
+          aria-expanded={false}
+        >
+          <i className="fa-solid fa-angles-right text-xs"></i>
+        </button>
+        <button
+          onClick={onCreate}
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
+          title="New conversation"
+          aria-label="New conversation"
+        >
+          <i className="fa-solid fa-plus text-xs"></i>
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div className="w-72 border-r border-border flex flex-col bg-app flex-shrink-0">
       {/* Header */}
       <div className="p-3 border-b border-border">
-        <div className="flex justify-end mb-2"><ThemeSwitcher /></div>
+        <div className="flex justify-between items-center mb-2">
+          <button
+            onClick={() => setCollapsed(true)}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
+            title="Hide conversations"
+            aria-label="Hide conversations"
+            aria-expanded={true}
+          >
+            <i className="fa-solid fa-angles-left text-xs"></i>
+          </button>
+          <ThemeSwitcher />
+        </div>
         <button
           onClick={onCreate}
           className="w-full px-3 py-2 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -380,3 +380,45 @@ describe('ChatSidebar active-run indicator', () => {
     expect(indicatorFor('C')).toBeNull()
   })
 })
+
+describe('ChatSidebar collapse', () => {
+  afterEach(() => localStorage.removeItem('llmdock.chatSidebar.collapsed'))
+
+  it('collapses to a thin rail and expands back, persisting the choice', () => {
+    renderSidebar()
+    expect(screen.getByText('New Conversation')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Hide conversations'))
+    expect(screen.getByTestId('chat-sidebar-collapsed')).toBeInTheDocument()
+    expect(screen.queryByText('New Conversation')).toBeNull()
+    expect(localStorage.getItem('llmdock.chatSidebar.collapsed')).toBe('true')
+
+    fireEvent.click(screen.getByLabelText('Show conversations'))
+    expect(screen.queryByTestId('chat-sidebar-collapsed')).toBeNull()
+    expect(screen.getByText('New Conversation')).toBeInTheDocument()
+    expect(localStorage.getItem('llmdock.chatSidebar.collapsed')).toBe('false')
+  })
+
+  it('starts collapsed when the stored preference says so', () => {
+    localStorage.setItem('llmdock.chatSidebar.collapsed', 'true')
+    renderSidebar()
+    expect(screen.getByTestId('chat-sidebar-collapsed')).toBeInTheDocument()
+  })
+
+  it('the collapsed rail still offers New Conversation', () => {
+    localStorage.setItem('llmdock.chatSidebar.collapsed', 'true')
+    const onCreate = vi.fn()
+    render(
+      <ChatSidebar
+        conversations={conversations}
+        activeId={null}
+        onSelect={() => {}}
+        onCreate={onCreate}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('New conversation'))
+    expect(onCreate).toHaveBeenCalled()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -138,7 +138,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
 
   return (
     <div ref={containerRef} className="flex-1 flex overflow-hidden min-w-0" data-testid="project-chat-split">
-      {collapsed ? (
+      {collapsed && (
         <div className="w-8 flex-shrink-0 border-r border-border bg-app flex flex-col items-center py-2">
           <button
             onClick={() => setCollapsed(false)}
@@ -150,33 +150,40 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
           </button>
           <i className="fa-solid fa-folder text-xs text-amber-500/50 mt-2" title={project.name}></i>
         </div>
-      ) : (
-        <>
-          <div
-            className="flex-shrink-0 border-r border-border overflow-hidden"
-            style={{ width: shownWidth != null ? `${shownWidth}px` : '20%', minWidth: `${MIN_WIDTH}px` }}
-            data-testid="explorer-strip"
-          >
-            <ProjectExplorerPane
-              project={project}
-              refreshKey={refreshKey + savedBump}
-              editingPath={editing?.path ?? null}
-              onOpenFile={handleOpenFile}
-              onCollapse={() => setCollapsed(true)}
-            />
-          </div>
-          <div
-            onMouseDown={(e) => { e.preventDefault(); setDragging(true) }}
-            className={`w-1.5 flex-shrink-0 cursor-col-resize -ml-1 z-10 ${
-              dragging ? 'bg-accent-strong/40' : 'hover:bg-accent-strong/30'
-            }`}
-            title="Drag to resize"
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize file explorer"
-            data-testid="explorer-divider"
-          ></div>
-        </>
+      )}
+      {/* The pane stays MOUNTED while collapsed (display:none) so an
+          in-flight upload keeps its state alive and its follow-up
+          refresh lands in the tree the user sees on re-expand (codex
+          iteration 3, P2). */}
+      <div
+        className="flex-shrink-0 border-r border-border overflow-hidden"
+        style={{
+          display: collapsed ? 'none' : undefined,
+          width: shownWidth != null ? `${shownWidth}px` : '20%',
+          minWidth: `${MIN_WIDTH}px`,
+        }}
+        data-testid="explorer-strip"
+      >
+        <ProjectExplorerPane
+          project={project}
+          refreshKey={refreshKey + savedBump}
+          editingPath={editing?.path ?? null}
+          onOpenFile={handleOpenFile}
+          onCollapse={() => setCollapsed(true)}
+        />
+      </div>
+      {!collapsed && (
+        <div
+          onMouseDown={(e) => { e.preventDefault(); setDragging(true) }}
+          className={`w-1.5 flex-shrink-0 cursor-col-resize -ml-1 z-10 ${
+            dragging ? 'bg-accent-strong/40' : 'hover:bg-accent-strong/30'
+          }`}
+          title="Drag to resize"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize file explorer"
+          data-testid="explorer-divider"
+        ></div>
       )}
 
       <div className="flex-1 flex min-w-0 relative">

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -46,10 +46,17 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
 
   const projectId = project?.id
 
+  // ChatPage passes onEditorDirtyChange as a fresh inline function every
+  // render. Hold it behind a ref so notifyDirty stays identity-stable —
+  // otherwise the editor-reset effect below would re-fire on every parent
+  // rerender (each streaming delta!) and silently unmount a dirty editor
+  // (codex iteration 1, P1).
+  const onDirtyRef = useRef(onEditorDirtyChange)
+  useEffect(() => { onDirtyRef.current = onEditorDirtyChange }, [onEditorDirtyChange])
   const notifyDirty = useCallback((d) => {
     dirtyRef.current = d
-    onEditorDirtyChange?.(d)
-  }, [onEditorDirtyChange])
+    onDirtyRef.current?.(d)
+  }, [])
 
   // Switching conversation (or project) closes the overlay. The dirty
   // guard for that navigation lives in ChatPage (confirmDiscardEdits),

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 import ProjectExplorerPane from './ProjectExplorerPane'
 import ProjectFileEditor from './ProjectFileEditor'
 
@@ -76,6 +76,31 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
     try { localStorage.setItem(WIDTH_KEY, String(width)) } catch { /* ignore */ }
   }, [width])
 
+  // A stored width is only known to fit the display it was saved on. Track
+  // the container's current 45% bound and clamp at render — otherwise a
+  // width persisted on a wide window swallows the whole split (and the
+  // chat) after the window narrows, until the next drag.
+  const [maxWidth, setMaxWidth] = useState(null)
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const measure = () => {
+      const w = el.getBoundingClientRect().width
+      if (w > 0) setMaxWidth(Math.max(MIN_WIDTH, Math.floor(w * MAX_FRACTION)))
+    }
+    measure()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measure)
+      return () => window.removeEventListener('resize', measure)
+    }
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+    // Re-attach when the split appears: with no project there IS no
+    // container, and the ref is still null on that first pass.
+  }, [projectId])
+  const shownWidth = width != null && maxWidth != null ? Math.min(width, maxWidth) : width
+
   // Divider drag: window-level listeners while dragging, clamped to
   // [MIN_WIDTH, 45% of the split container].
   useEffect(() => {
@@ -129,7 +154,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
         <>
           <div
             className="flex-shrink-0 border-r border-border overflow-hidden"
-            style={{ width: width != null ? `${width}px` : '20%', minWidth: `${MIN_WIDTH}px` }}
+            style={{ width: shownWidth != null ? `${shownWidth}px` : '20%', minWidth: `${MIN_WIDTH}px` }}
             data-testid="explorer-strip"
           >
             <ProjectExplorerPane

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -1,0 +1,174 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import ProjectExplorerPane from './ProjectExplorerPane'
+import ProjectFileEditor from './ProjectFileEditor'
+
+const WIDTH_KEY = 'llmdock.chatExplorer.width'
+const COLLAPSED_KEY = 'llmdock.chatExplorer.collapsed'
+
+const MIN_WIDTH = 160
+const MAX_FRACTION = 0.45
+
+function readStoredWidth() {
+  try {
+    const v = parseInt(localStorage.getItem(WIDTH_KEY), 10)
+    return Number.isFinite(v) && v >= MIN_WIDTH ? v : null
+  } catch {
+    return null
+  }
+}
+
+function readStoredCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+// Splits the conversation area when the conversation belongs to a project:
+// a resizable file-explorer strip on the left (20% by default), the chat
+// (children) on the right. Without a project it renders the chat alone.
+// Opening a file from the strip overlays the editor on the chat region so
+// the conversation stays loaded underneath.
+export default function ProjectChatSplit({ project, conversationId, refreshKey = 0, onEditorDirtyChange, children }) {
+  const [collapsed, setCollapsed] = useState(readStoredCollapsed)
+  // null = never resized: the strip uses the 20% default until the first
+  // drag pins a pixel width.
+  const [width, setWidth] = useState(readStoredWidth)
+  const [dragging, setDragging] = useState(false)
+  // {path, isNew} when the editor overlay is open.
+  const [editing, setEditing] = useState(null)
+  // Editor saves bump this so the pane re-reads the tree (a saved new
+  // file must appear); combined with the parent's refreshKey.
+  const [savedBump, setSavedBump] = useState(0)
+  const containerRef = useRef(null)
+  const dirtyRef = useRef(false)
+
+  const projectId = project?.id
+
+  const notifyDirty = useCallback((d) => {
+    dirtyRef.current = d
+    onEditorDirtyChange?.(d)
+  }, [onEditorDirtyChange])
+
+  // Switching conversation (or project) closes the overlay. The dirty
+  // guard for that navigation lives in ChatPage (confirmDiscardEdits),
+  // which fires before the route changes — by the time this effect runs
+  // the discard is already confirmed.
+  useEffect(() => {
+    setEditing(null)
+    notifyDirty(false)
+  }, [conversationId, projectId, notifyDirty])
+
+  useEffect(() => {
+    try { localStorage.setItem(COLLAPSED_KEY, String(collapsed)) } catch { /* ignore */ }
+  }, [collapsed])
+
+  useEffect(() => {
+    if (width == null) return
+    try { localStorage.setItem(WIDTH_KEY, String(width)) } catch { /* ignore */ }
+  }, [width])
+
+  // Divider drag: window-level listeners while dragging, clamped to
+  // [MIN_WIDTH, 45% of the split container].
+  useEffect(() => {
+    if (!dragging) return
+    const onMove = (e) => {
+      const rect = containerRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const max = Math.max(MIN_WIDTH, Math.floor(rect.width * MAX_FRACTION))
+      setWidth(Math.min(Math.max(e.clientX - rect.left, MIN_WIDTH), max))
+    }
+    const onUp = () => setDragging(false)
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [dragging])
+
+  const handleOpenFile = useCallback((path, isNew) => {
+    // Re-clicking the open file is a no-op (nothing would be discarded —
+    // confirming just remounts the same editor).
+    if (editing?.path === path) return
+    if (editing && dirtyRef.current && !window.confirm('Discard unsaved changes?')) return
+    notifyDirty(false)
+    setEditing({ path, isNew })
+  }, [editing, notifyDirty])
+
+  const handleCloseEditor = useCallback(() => {
+    setEditing(null)
+    notifyDirty(false)
+  }, [notifyDirty])
+
+  if (!project) return children
+
+  return (
+    <div ref={containerRef} className="flex-1 flex overflow-hidden min-w-0" data-testid="project-chat-split">
+      {collapsed ? (
+        <div className="w-8 flex-shrink-0 border-r border-border bg-app flex flex-col items-center py-2">
+          <button
+            onClick={() => setCollapsed(false)}
+            className="text-fg-subtle hover:text-fg p-1.5 cursor-pointer"
+            title={`Show ${project.name} files`}
+            aria-label="Show file explorer"
+          >
+            <i className="fa-solid fa-angles-right text-xs"></i>
+          </button>
+          <i className="fa-solid fa-folder text-xs text-amber-500/50 mt-2" title={project.name}></i>
+        </div>
+      ) : (
+        <>
+          <div
+            className="flex-shrink-0 border-r border-border overflow-hidden"
+            style={{ width: width != null ? `${width}px` : '20%', minWidth: `${MIN_WIDTH}px` }}
+            data-testid="explorer-strip"
+          >
+            <ProjectExplorerPane
+              project={project}
+              refreshKey={refreshKey + savedBump}
+              editingPath={editing?.path ?? null}
+              onOpenFile={handleOpenFile}
+              onCollapse={() => setCollapsed(true)}
+            />
+          </div>
+          <div
+            onMouseDown={(e) => { e.preventDefault(); setDragging(true) }}
+            className={`w-1.5 flex-shrink-0 cursor-col-resize -ml-1 z-10 ${
+              dragging ? 'bg-accent-strong/40' : 'hover:bg-accent-strong/30'
+            }`}
+            title="Drag to resize"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize file explorer"
+            data-testid="explorer-divider"
+          ></div>
+        </>
+      )}
+
+      <div className="flex-1 flex min-w-0 relative">
+        {children}
+        {editing && (
+          <div className="absolute inset-0 z-30 bg-app flex" data-testid="editor-overlay">
+            <ProjectFileEditor
+              key={`${project.id}:${editing.path}`}
+              projectId={project.id}
+              path={editing.path}
+              isNew={editing.isNew}
+              onDirtyChange={notifyDirty}
+              onClose={handleCloseEditor}
+              onSaved={() => {
+                setEditing(prev => (prev ? { ...prev, isNew: false } : prev))
+                setSavedBump(b => b + 1)
+              }}
+            />
+          </div>
+        )}
+        {/* Transparent shield so mousemove keeps flowing during a drag even
+            over iframes/artifacts rendered inside the chat. */}
+        {dragging && <div className="absolute inset-0 z-40 cursor-col-resize"></div>}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
@@ -2,14 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import ProjectChatSplit from './ProjectChatSplit'
 
-const { mockFilesTree, mockGetFileContent, mockSaveFileContent } = vi.hoisted(() => ({
+const { mockFilesTree, mockGetFileContent, mockSaveFileContent, mockUpload } = vi.hoisted(() => ({
   mockFilesTree: vi.fn(),
   mockGetFileContent: vi.fn(),
   mockSaveFileContent: vi.fn(),
+  mockUpload: vi.fn(),
 }))
 vi.mock('../../services/chat', () => ({
   getProjectFilesTree: (...a) => mockFilesTree(...a),
-  uploadProjectFile: vi.fn(),
+  uploadProjectFile: (...a) => mockUpload(...a),
   getProjectFileContent: (...a) => mockGetFileContent(...a),
   saveProjectFileContent: (...a) => mockSaveFileContent(...a),
 }))
@@ -23,6 +24,7 @@ beforeEach(() => {
   })
   mockGetFileContent.mockReset().mockResolvedValue({ path: 'a.md', content: 'hello', revision: 'r1' })
   mockSaveFileContent.mockReset().mockResolvedValue({ name: 'a.md', path: 'a.md', type: 'file' })
+  mockUpload.mockReset().mockResolvedValue({ ok: true })
 })
 
 afterEach(() => {
@@ -62,13 +64,15 @@ describe('ProjectChatSplit', () => {
     await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
 
     fireEvent.click(screen.getByLabelText('Hide file explorer'))
-    expect(screen.queryByTestId('explorer-strip')).toBeNull()
+    // The strip stays mounted (in-flight pane work must survive a
+    // collapse) but is hidden.
+    expect(screen.getByTestId('explorer-strip')).not.toBeVisible()
     expect(localStorage.getItem('llmdock.chatExplorer.collapsed')).toBe('true')
     // Chat stays visible while collapsed.
     expect(screen.getByTestId('the-chat')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Show file explorer'))
-    expect(screen.getByTestId('explorer-strip')).toBeInTheDocument()
+    expect(screen.getByTestId('explorer-strip')).toBeVisible()
     expect(localStorage.getItem('llmdock.chatExplorer.collapsed')).toBe('false')
   })
 
@@ -208,5 +212,36 @@ describe('ProjectChatSplit restored-width clamping (regression: PR #87 codex 2.3
     // 800px stored, container 1000px → clamped to 450px at render.
     expect(screen.getByTestId('explorer-strip').style.width).toBe('450px')
     rectSpy.mockRestore()
+  })
+})
+
+describe('ProjectChatSplit in-flight upload survives collapse (regression: PR #87 codex 3.3)', () => {
+  it('an upload started before collapsing lands in the visible tree after re-expand', async () => {
+    let resolveUpload
+    mockUpload.mockImplementationOnce(() => new Promise(r => { resolveUpload = r }))
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    expect(mockFilesTree).toHaveBeenCalledTimes(1)
+
+    // Start an upload, then collapse while it is still in flight.
+    const file = new File(['x'], 'up.txt', { type: 'text/plain' })
+    fireEvent.change(screen.getByTestId('explorer-file-input'), { target: { files: [file] } })
+    fireEvent.click(screen.getByLabelText('Hide file explorer'))
+
+    // Re-expand, then let the upload finish: its follow-up refresh must
+    // hit the pane the user sees (the pane stayed mounted throughout).
+    fireEvent.click(screen.getByLabelText('Show file explorer'))
+    mockFilesTree.mockResolvedValueOnce({
+      tree: [
+        { name: 'a.md', path: 'a.md', type: 'file', size: 3 },
+        { name: 'up.txt', path: 'up.txt', type: 'file', size: 1 },
+      ],
+    })
+    resolveUpload({ ok: true })
+    await waitFor(() => expect(screen.getByTestId('tree-node-up.txt')).toBeInTheDocument())
   })
 })

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
@@ -164,3 +164,31 @@ describe('ProjectChatSplit', () => {
     confirmSpy.mockRestore()
   })
 })
+
+describe('ProjectChatSplit parent-rerender stability (regression: PR #87 codex 1.1)', () => {
+  it('keeps a dirty editor open when the parent rerenders with a fresh dirty-callback identity', async () => {
+    // ChatPage passes onEditorDirtyChange as an inline lambda, so its
+    // identity changes every parent render (each streaming delta). That
+    // must not re-fire the editor-reset effect.
+    const { rerender } = render(
+      <ProjectChatSplit project={project} conversationId="c1" onEditorDirtyChange={() => {}}>
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+
+    for (let i = 0; i < 3; i++) {
+      rerender(
+        <ProjectChatSplit project={project} conversationId="c1" onEditorDirtyChange={() => {}}>
+          <div data-testid="the-chat" />
+        </ProjectChatSplit>
+      )
+    }
+
+    expect(screen.getByTestId('editor-overlay')).toBeInTheDocument()
+    expect(screen.getByTestId('editor-textarea').value).toBe('edited')
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import ProjectChatSplit from './ProjectChatSplit'
+
+const { mockFilesTree, mockGetFileContent, mockSaveFileContent } = vi.hoisted(() => ({
+  mockFilesTree: vi.fn(),
+  mockGetFileContent: vi.fn(),
+  mockSaveFileContent: vi.fn(),
+}))
+vi.mock('../../services/chat', () => ({
+  getProjectFilesTree: (...a) => mockFilesTree(...a),
+  uploadProjectFile: vi.fn(),
+  getProjectFileContent: (...a) => mockGetFileContent(...a),
+  saveProjectFileContent: (...a) => mockSaveFileContent(...a),
+}))
+
+const project = { id: 'p1', name: 'Fancy Project' }
+
+beforeEach(() => {
+  localStorage.clear()
+  mockFilesTree.mockReset().mockResolvedValue({
+    tree: [{ name: 'a.md', path: 'a.md', type: 'file', size: 3 }],
+  })
+  mockGetFileContent.mockReset().mockResolvedValue({ path: 'a.md', content: 'hello', revision: 'r1' })
+  mockSaveFileContent.mockReset().mockResolvedValue({ name: 'a.md', path: 'a.md', type: 'file' })
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('ProjectChatSplit', () => {
+  it('renders only the chat when the conversation has no project', () => {
+    render(
+      <ProjectChatSplit project={null} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    expect(screen.getByTestId('the-chat')).toBeInTheDocument()
+    expect(screen.queryByTestId('project-chat-split')).toBeNull()
+  })
+
+  it('shows the explorer strip at the 20% default next to the chat for a project conversation', async () => {
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    expect(screen.getByTestId('the-chat')).toBeInTheDocument()
+    const strip = screen.getByTestId('explorer-strip')
+    expect(strip.style.width).toBe('20%')
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+  })
+
+  it('collapses to a rail and expands back, persisting the choice', async () => {
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Hide file explorer'))
+    expect(screen.queryByTestId('explorer-strip')).toBeNull()
+    expect(localStorage.getItem('llmdock.chatExplorer.collapsed')).toBe('true')
+    // Chat stays visible while collapsed.
+    expect(screen.getByTestId('the-chat')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Show file explorer'))
+    expect(screen.getByTestId('explorer-strip')).toBeInTheDocument()
+    expect(localStorage.getItem('llmdock.chatExplorer.collapsed')).toBe('false')
+  })
+
+  it('drag on the divider resizes the strip within bounds and persists the width', async () => {
+    const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800, x: 0, y: 0, toJSON: () => {},
+    })
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+
+    fireEvent.mouseDown(screen.getByTestId('explorer-divider'))
+    fireEvent.mouseMove(window, { clientX: 300 })
+    expect(screen.getByTestId('explorer-strip').style.width).toBe('300px')
+
+    // Clamped to 45% of the container (450px of 1000px)…
+    fireEvent.mouseMove(window, { clientX: 900 })
+    expect(screen.getByTestId('explorer-strip').style.width).toBe('450px')
+    // …and to the minimum on the other side.
+    fireEvent.mouseMove(window, { clientX: 10 })
+    expect(screen.getByTestId('explorer-strip').style.width).toBe('160px')
+
+    fireEvent.mouseUp(window)
+    expect(localStorage.getItem('llmdock.chatExplorer.width')).toBe('160')
+    rectSpy.mockRestore()
+  })
+
+  it('opening a file overlays the editor on the chat; closing removes it', async () => {
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(screen.getByTestId('editor-overlay')).toBeInTheDocument())
+    expect(mockGetFileContent).toHaveBeenCalledWith('p1', 'a.md')
+    // Chat stays mounted underneath.
+    expect(screen.getByTestId('the-chat')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Close editor'))
+    expect(screen.queryByTestId('editor-overlay')).toBeNull()
+  })
+
+  it('switching conversation closes the editor overlay', async () => {
+    const { rerender } = render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(screen.getByTestId('editor-overlay')).toBeInTheDocument())
+
+    rerender(
+      <ProjectChatSplit project={project} conversationId="c2">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    expect(screen.queryByTestId('editor-overlay')).toBeNull()
+  })
+
+  it('a dirty editor asks before opening another file', async () => {
+    mockFilesTree.mockResolvedValue({
+      tree: [
+        { name: 'a.md', path: 'a.md', type: 'file', size: 3 },
+        { name: 'b.md', path: 'b.md', type: 'file', size: 3 },
+      ],
+    })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('tree-node-a.md'))
+    await waitFor(() => expect(screen.getByTestId('editor-textarea')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('editor-textarea'), { target: { value: 'edited' } })
+    fireEvent.click(screen.getByTestId('tree-node-b.md'))
+    expect(confirmSpy).toHaveBeenCalled()
+    // Declined: still editing a.md.
+    expect(screen.getByTestId('editor-textarea').value).toBe('edited')
+
+    confirmSpy.mockReturnValue(true)
+    fireEvent.click(screen.getByTestId('tree-node-b.md'))
+    await waitFor(() => expect(mockGetFileContent).toHaveBeenCalledWith('p1', 'b.md'))
+    confirmSpy.mockRestore()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.test.jsx
@@ -192,3 +192,21 @@ describe('ProjectChatSplit parent-rerender stability (regression: PR #87 codex 1
     expect(screen.getByTestId('editor-textarea').value).toBe('edited')
   })
 })
+
+describe('ProjectChatSplit restored-width clamping (regression: PR #87 codex 2.3)', () => {
+  it('clamps a stored width from a wider display to 45% of the current container', async () => {
+    const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, right: 1000, bottom: 800, width: 1000, height: 800, x: 0, y: 0, toJSON: () => {},
+    })
+    localStorage.setItem('llmdock.chatExplorer.width', '800')
+    render(
+      <ProjectChatSplit project={project} conversationId="c1">
+        <div data-testid="the-chat" />
+      </ProjectChatSplit>
+    )
+    await waitFor(() => expect(screen.getByTestId('tree-node-a.md')).toBeInTheDocument())
+    // 800px stored, container 1000px → clamped to 450px at render.
+    expect(screen.getByTestId('explorer-strip').style.width).toBe('450px')
+    rectSpy.mockRestore()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getProjectFilesTree, uploadProjectFile } from '../../services/chat'
+import { findNode, TreeFile, TreeDir } from './projectTree'
+
+// File-explorer strip shown to the left of the chat when the conversation
+// belongs to a project. Read-mostly: browse the tree, open a file in the
+// editor overlay, create a file, upload into the root, refresh. The full
+// explorer (move/copy/delete/DnD) stays on the project page.
+export default function ProjectExplorerPane({ project, refreshKey = 0, editingPath = null, onOpenFile, onCollapse }) {
+  const [tree, setTree] = useState([])
+  const [expanded, setExpanded] = useState(() => new Set())
+  const [error, setError] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const fileInputRef = useRef(null)
+  // Monotonic request generation + project binding, same discipline as
+  // ProjectPage: a slow response for the previous project must not
+  // install its rows under the project now displayed.
+  const genRef = useRef(0)
+  const projectIdRef = useRef(project?.id)
+  projectIdRef.current = project?.id
+
+  const refresh = useCallback(async () => {
+    const pid = project?.id
+    if (!pid) return
+    if (projectIdRef.current !== pid) return
+    const gen = ++genRef.current
+    const stillCurrent = () => genRef.current === gen && projectIdRef.current === pid
+    try {
+      const data = await getProjectFilesTree(pid)
+      if (!stillCurrent()) return
+      setTree(data.tree || [])
+      setError(null)
+    } catch (err) {
+      if (!stillCurrent()) return
+      setError(err.message)
+    }
+  }, [project?.id])
+
+  useEffect(() => {
+    setTree([])
+    setExpanded(new Set())
+    setError(null)
+    setBusy(false)
+    refresh()
+  }, [refresh])
+
+  // External refresh signal (a chat run finished and may have written
+  // files, the editor overlay saved, …).
+  useEffect(() => {
+    if (refreshKey > 0) refresh()
+  }, [refreshKey, refresh])
+
+  const toggle = useCallback((path) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  const handleNewFile = useCallback(() => {
+    const name = window.prompt('File name')
+    if (!name || !name.trim()) return
+    const path = name.trim().replace(/^\/+|\/+$/g, '')
+    if (!path) return
+    // If it already exists, open it instead of silently overwriting on save.
+    const existing = findNode(tree, path)
+    onOpenFile?.(path, !existing)
+  }, [tree, onOpenFile])
+
+  const handleFilesPicked = useCallback(async (e) => {
+    const files = Array.from(e.target.files || [])
+    e.target.value = '' // allow re-picking the same file later
+    if (files.length === 0) return
+    const pid = project?.id
+    setBusy(true)
+    setError(null)
+    try {
+      for (const file of files) {
+        try {
+          await uploadProjectFile(pid, file, { dir: '' })
+        } catch (err) {
+          if (err.code === 'already_exists' &&
+              window.confirm(`"${file.name}" already exists. Overwrite?`)) {
+            await uploadProjectFile(pid, file, { dir: '', overwrite: true })
+          } else if (err.code !== 'already_exists') {
+            throw err
+          }
+        }
+      }
+      await refresh()
+    } catch (err) {
+      if (projectIdRef.current === pid) setError(err.message)
+    } finally {
+      if (projectIdRef.current === pid) setBusy(false)
+    }
+  }, [project?.id, refresh])
+
+  if (!project) return null
+
+  return (
+    <div className="h-full flex flex-col bg-app select-none" data-testid="project-explorer-pane">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        onChange={handleFilesPicked}
+        className="hidden"
+        data-testid="explorer-file-input"
+      />
+
+      {/* Header: project name + collapse */}
+      <div className="px-3 py-2 border-b border-border flex items-center gap-2 flex-shrink-0">
+        <i className="fa-solid fa-folder-open text-xs text-amber-500/80 flex-shrink-0"></i>
+        <span className="flex-1 min-w-0 truncate text-xs font-semibold text-fg uppercase tracking-wide">
+          {project.name}
+        </span>
+        <button
+          onClick={onCollapse}
+          className="text-fg-subtle hover:text-fg p-1 -m-1 cursor-pointer"
+          title="Hide file explorer"
+          aria-label="Hide file explorer"
+        >
+          <i className="fa-solid fa-angles-left text-xs"></i>
+        </button>
+      </div>
+
+      {error && (
+        <div className="mx-2 mt-2 px-2 py-1.5 bg-danger-subtle text-danger-fg rounded text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* Tree */}
+      <div className="flex-1 overflow-auto py-2 px-1.5">
+        {tree.length === 0 && !error && (
+          <div className="p-4 text-center text-[11px] text-fg-subtle">
+            No files yet.
+          </div>
+        )}
+        {tree.map(node => (
+          node.type === 'dir' ? (
+            <TreeDir
+              key={node.path}
+              node={node}
+              depth={0}
+              expanded={expanded}
+              editingPath={editingPath}
+              onToggle={toggle}
+              onOpenFile={(n) => onOpenFile?.(n.path, false)}
+            />
+          ) : (
+            <TreeFile
+              key={node.path}
+              node={node}
+              depth={0}
+              editingPath={editingPath}
+              onOpen={(n) => onOpenFile?.(n.path, false)}
+            />
+          )
+        ))}
+      </div>
+
+      {/* Footer actions */}
+      <div className="px-2 py-1.5 border-t border-border flex items-center justify-around flex-shrink-0">
+        <button
+          onClick={handleNewFile}
+          disabled={busy}
+          className="text-fg-subtle hover:text-fg p-1.5 cursor-pointer disabled:opacity-50"
+          title="New file" aria-label="New file"
+        >
+          <i className="fa-solid fa-file-circle-plus text-xs"></i>
+        </button>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={busy}
+          className="text-fg-subtle hover:text-fg p-1.5 cursor-pointer disabled:opacity-50"
+          title="Upload files" aria-label="Upload files"
+        >
+          <i className="fa-solid fa-file-arrow-up text-xs"></i>
+        </button>
+        <button
+          onClick={refresh}
+          disabled={busy}
+          className="text-fg-subtle hover:text-fg p-1.5 cursor-pointer disabled:opacity-50"
+          title="Refresh" aria-label="Refresh file tree"
+        >
+          <i className="fa-solid fa-rotate-right text-xs"></i>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
@@ -46,9 +46,16 @@ export default function ProjectExplorerPane({ project, refreshKey = 0, editingPa
   }, [refresh])
 
   // External refresh signal (a chat run finished and may have written
-  // files, the editor overlay saved, …).
+  // files, the editor overlay saved, …). Only key CHANGES refresh — the
+  // mount-time value is already covered by the effect above, and the key
+  // stays positive after the first completed run, so re-firing on mount
+  // would double-fetch every time the pane (re)appears.
+  const lastKeyRef = useRef(refreshKey)
   useEffect(() => {
-    if (refreshKey > 0) refresh()
+    if (refreshKey !== lastKeyRef.current) {
+      lastKeyRef.current = refreshKey
+      refresh()
+    }
   }, [refreshKey, refresh])
 
   const toggle = useCallback((path) => {

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { getProjectFilesTree, uploadProjectFile } from '../../services/chat'
-import { findNode, TreeFile, TreeDir } from './projectTree'
+import { findNode } from './projectTreeUtils'
+import { TreeFile, TreeDir } from './projectTree'
 
 // File-explorer strip shown to the left of the chat when the conversation
 // belongs to a project. Read-mostly: browse the tree, open a file in the

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.test.jsx
@@ -117,3 +117,16 @@ describe('ProjectExplorerPane', () => {
     expect(screen.getByTestId('tree-node-other.md')).toBeInTheDocument()
   })
 })
+
+describe('ProjectExplorerPane mount fetch count (regression: PR #87 codex 2.4)', () => {
+  it('mounting with an already-positive refreshKey issues a single tree read', async () => {
+    const { rerender } = render(<ProjectExplorerPane project={project} refreshKey={3} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockFilesTree).toHaveBeenCalledTimes(1)
+
+    // A later key CHANGE still refreshes.
+    rerender(<ProjectExplorerPane project={project} refreshKey={4} />)
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(2))
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.test.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import ProjectExplorerPane from './ProjectExplorerPane'
+
+const { mockFilesTree, mockUpload } = vi.hoisted(() => ({
+  mockFilesTree: vi.fn(),
+  mockUpload: vi.fn(),
+}))
+vi.mock('../../services/chat', () => ({
+  getProjectFilesTree: (...a) => mockFilesTree(...a),
+  uploadProjectFile: (...a) => mockUpload(...a),
+}))
+
+const project = { id: 'p1', name: 'Fancy Project' }
+
+const TREE = [
+  {
+    name: 'docs', path: 'docs', type: 'dir', children: [
+      { name: 'notes.md', path: 'docs/notes.md', type: 'file', size: 10 },
+    ],
+  },
+  { name: 'README.md', path: 'README.md', type: 'file', size: 5 },
+]
+
+beforeEach(() => {
+  mockFilesTree.mockReset().mockResolvedValue({ tree: TREE })
+  mockUpload.mockReset().mockResolvedValue({ ok: true })
+})
+
+afterEach(() => cleanup())
+
+describe('ProjectExplorerPane', () => {
+  it('fetches and renders the project tree; expanding a folder reveals children', async () => {
+    render(<ProjectExplorerPane project={project} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
+    expect(mockFilesTree).toHaveBeenCalledWith('p1')
+    expect(screen.getByText('Fancy Project')).toBeInTheDocument()
+
+    // Children hidden until the folder is expanded.
+    expect(screen.queryByTestId('tree-node-docs/notes.md')).toBeNull()
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    expect(screen.getByTestId('tree-node-docs/notes.md')).toBeInTheDocument()
+    // Clicking the folder again collapses it.
+    fireEvent.click(screen.getByTestId('tree-node-docs'))
+    expect(screen.queryByTestId('tree-node-docs/notes.md')).toBeNull()
+  })
+
+  it('clicking a file reports it as an existing file', async () => {
+    const onOpenFile = vi.fn()
+    render(<ProjectExplorerPane project={project} onOpenFile={onOpenFile} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('tree-node-README.md'))
+    expect(onOpenFile).toHaveBeenCalledWith('README.md', false)
+  })
+
+  it('collapse button invokes onCollapse', async () => {
+    const onCollapse = vi.fn()
+    render(<ProjectExplorerPane project={project} onCollapse={onCollapse} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Hide file explorer'))
+    expect(onCollapse).toHaveBeenCalled()
+  })
+
+  it('refresh button and refreshKey bumps re-read the tree', async () => {
+    const { rerender } = render(<ProjectExplorerPane project={project} refreshKey={0} />)
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByLabelText('Refresh file tree'))
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(2))
+
+    rerender(<ProjectExplorerPane project={project} refreshKey={1} />)
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(3))
+  })
+
+  it('new file prompts for a name; an unknown path opens as new, a known one as existing', async () => {
+    const onOpenFile = vi.fn()
+    const promptSpy = vi.spyOn(window, 'prompt')
+    render(<ProjectExplorerPane project={project} onOpenFile={onOpenFile} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-README.md')).toBeInTheDocument())
+
+    promptSpy.mockReturnValueOnce('fresh.md')
+    fireEvent.click(screen.getByLabelText('New file'))
+    expect(onOpenFile).toHaveBeenLastCalledWith('fresh.md', true)
+
+    promptSpy.mockReturnValueOnce('README.md')
+    fireEvent.click(screen.getByLabelText('New file'))
+    expect(onOpenFile).toHaveBeenLastCalledWith('README.md', false)
+
+    promptSpy.mockRestore()
+  })
+
+  it('uploads picked files into the project root and refreshes', async () => {
+    render(<ProjectExplorerPane project={project} />)
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(1))
+
+    const file = new File(['x'], 'up.txt', { type: 'text/plain' })
+    fireEvent.change(screen.getByTestId('explorer-file-input'), { target: { files: [file] } })
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledWith('p1', file, { dir: '' }))
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(2))
+  })
+
+  it('a stale tree response for the previous project is discarded', async () => {
+    let resolveP1
+    mockFilesTree.mockImplementationOnce(() => new Promise(r => { resolveP1 = r }))
+    const { rerender } = render(<ProjectExplorerPane project={project} />)
+    await waitFor(() => expect(mockFilesTree).toHaveBeenCalledTimes(1))
+
+    mockFilesTree.mockResolvedValueOnce({ tree: [{ name: 'other.md', path: 'other.md', type: 'file' }] })
+    rerender(<ProjectExplorerPane project={{ id: 'p2', name: 'Other' }} />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-other.md')).toBeInTheDocument())
+
+    // Late p1 response must not clobber p2's rows.
+    resolveP1({ tree: TREE })
+    await new Promise(r => setTimeout(r, 0))
+    expect(screen.queryByTestId('tree-node-README.md')).toBeNull()
+    expect(screen.getByTestId('tree-node-other.md')).toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -7,8 +7,8 @@ import ProjectFileEditor from './ProjectFileEditor'
 import ContextMenu from './ContextMenu'
 import {
   findNode, listDir, parentDir, baseName, isSelfOrDescendant, ancestorsOf,
-  TreeFile, TreeDir,
-} from './projectTree'
+} from './projectTreeUtils'
+import { TreeFile, TreeDir } from './projectTree'
 
 // The DataTransfer type carrying the dragged entry's project-relative
 // path. A custom type keeps foreign drags (text, files from the OS) from

--- a/dashboard/frontend/src/components/chat/ProjectPage.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectPage.jsx
@@ -5,51 +5,15 @@ import {
 } from '../../services/chat'
 import ProjectFileEditor from './ProjectFileEditor'
 import ContextMenu from './ContextMenu'
+import {
+  findNode, listDir, parentDir, baseName, isSelfOrDescendant, ancestorsOf,
+  TreeFile, TreeDir,
+} from './projectTree'
 
 // The DataTransfer type carrying the dragged entry's project-relative
 // path. A custom type keeps foreign drags (text, files from the OS) from
 // being mistaken for an internal move.
 const DND_TYPE = 'application/x-llmdock-path'
-
-function findNode(nodes, path) {
-  for (const n of nodes) {
-    if (n.path === path) return n
-    if (n.type === 'dir' && n.children) {
-      const hit = findNode(n.children, path)
-      if (hit) return hit
-    }
-  }
-  return null
-}
-
-// Children of a directory path ('' = project root).
-function listDir(tree, dirPath) {
-  if (!dirPath) return tree
-  const node = findNode(tree, dirPath)
-  return node && node.type === 'dir' ? (node.children || []) : null
-}
-
-function parentDir(path) {
-  const i = path.lastIndexOf('/')
-  return i === -1 ? '' : path.slice(0, i)
-}
-
-function baseName(path) {
-  return path.split('/').pop()
-}
-
-function isSelfOrDescendant(dirPath, ofPath) {
-  return dirPath === ofPath || dirPath.startsWith(ofPath + '/')
-}
-
-// All ancestor dir paths of a path, root ('') excluded:
-// 'a/b/c' -> ['a', 'a/b'].
-function ancestorsOf(path) {
-  const out = []
-  const parts = path.split('/')
-  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join('/'))
-  return out
-}
 
 // First name that doesn't collide inside dirPath: "a.txt" -> "a (copy).txt"
 // -> "a (copy 2).txt". Works off the client tree snapshot; a stale snapshot
@@ -72,100 +36,6 @@ function formatSize(bytes) {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
-
-// One file row in the left tree pane. Files aren't drop targets (drops go
-// to folders), but they are drag sources and carry the full context menu.
-function TreeFile({ node, depth, editingPath, cutPath, onOpen, onMenu, onDragStart }) {
-  return (
-    <div
-      draggable
-      onClick={() => onOpen(node)}
-      onContextMenu={e => onMenu(e, node)}
-      onDragStart={e => onDragStart(e, node)}
-      className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
-        editingPath === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
-      } ${cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''}`}
-      style={{ paddingLeft: `${8 + depth * 14}px` }}
-      data-testid={`tree-node-${node.path}`}
-    >
-      <span className="w-4 flex-shrink-0"></span>
-      <i className="fa-regular fa-file text-xs text-fg-faint flex-shrink-0"></i>
-      <span className="flex-1 min-w-0 truncate">{node.name}</span>
-    </div>
-  )
-}
-
-// One folder row in the left tree pane (recursive over children; the
-// backend sorts dirs before files, so children render in tree order).
-function TreeDir({ node, depth, expanded, selectedDir, editingPath, dropTarget, cutPath,
-                   onToggle, onSelect, onOpenFile, onMenu, onDragStart, onDragOver, onDragLeave, onDrop }) {
-  const children = node.children || []
-  const isExpanded = expanded.has(node.path)
-  return (
-    <>
-      <div
-        draggable
-        onClick={() => onSelect(node.path)}
-        onContextMenu={e => onMenu(e, node)}
-        onDragStart={e => onDragStart(e, node)}
-        onDragOver={e => onDragOver(e, node.path)}
-        onDragLeave={() => onDragLeave(node.path)}
-        onDrop={e => onDrop(e, node.path)}
-        className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
-          selectedDir === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
-        } ${dropTarget === node.path ? 'ring-1 ring-accent-strong bg-accent-subtle' : ''} ${
-          cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''
-        }`}
-        style={{ paddingLeft: `${8 + depth * 14}px` }}
-        data-testid={`tree-node-${node.path}`}
-      >
-        <button
-          onClick={e => { e.stopPropagation(); onToggle(node.path) }}
-          className={`w-4 flex-shrink-0 text-fg-faint cursor-pointer ${children.length ? '' : 'invisible'}`}
-          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${node.path}`}
-          tabIndex={-1}
-        >
-          <i className={`fa-solid fa-chevron-${isExpanded ? 'down' : 'right'} text-[9px]`}></i>
-        </button>
-        <i className={`fa-solid fa-folder${selectedDir === node.path ? '-open' : ''} text-xs text-amber-500/80 flex-shrink-0`}></i>
-        <span className="flex-1 min-w-0 truncate">{node.name}</span>
-      </div>
-      {isExpanded && children.map(child => (
-        child.type === 'dir' ? (
-          <TreeDir
-            key={child.path}
-            node={child}
-            depth={depth + 1}
-            expanded={expanded}
-            selectedDir={selectedDir}
-            editingPath={editingPath}
-            dropTarget={dropTarget}
-            cutPath={cutPath}
-            onToggle={onToggle}
-            onSelect={onSelect}
-            onOpenFile={onOpenFile}
-            onMenu={onMenu}
-            onDragStart={onDragStart}
-            onDragOver={onDragOver}
-            onDragLeave={onDragLeave}
-            onDrop={onDrop}
-          />
-        ) : (
-          <TreeFile
-            key={child.path}
-            node={child}
-            depth={depth + 1}
-            editingPath={editingPath}
-            cutPath={cutPath}
-            onOpen={onOpenFile}
-            onMenu={onMenu}
-            onDragStart={onDragStart}
-          />
-        )
-      ))}
-    </>
-  )
 }
 
 export default function ProjectPage({ project, onEditorDirtyChange }) {

--- a/dashboard/frontend/src/components/chat/projectTree.jsx
+++ b/dashboard/frontend/src/components/chat/projectTree.jsx
@@ -1,45 +1,7 @@
-// Project file-tree primitives shared by ProjectPage (full explorer) and
-// ProjectExplorerPane (the strip shown next to a project conversation).
-
-export function findNode(nodes, path) {
-  for (const n of nodes) {
-    if (n.path === path) return n
-    if (n.type === 'dir' && n.children) {
-      const hit = findNode(n.children, path)
-      if (hit) return hit
-    }
-  }
-  return null
-}
-
-// Children of a directory path ('' = project root).
-export function listDir(tree, dirPath) {
-  if (!dirPath) return tree
-  const node = findNode(tree, dirPath)
-  return node && node.type === 'dir' ? (node.children || []) : null
-}
-
-export function parentDir(path) {
-  const i = path.lastIndexOf('/')
-  return i === -1 ? '' : path.slice(0, i)
-}
-
-export function baseName(path) {
-  return path.split('/').pop()
-}
-
-export function isSelfOrDescendant(dirPath, ofPath) {
-  return dirPath === ofPath || dirPath.startsWith(ofPath + '/')
-}
-
-// All ancestor dir paths of a path, root ('') excluded:
-// 'a/b/c' -> ['a', 'a/b'].
-export function ancestorsOf(path) {
-  const out = []
-  const parts = path.split('/')
-  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join('/'))
-  return out
-}
+// Project file-tree row components shared by ProjectPage (full explorer)
+// and ProjectExplorerPane (the strip shown next to a project
+// conversation). Non-component helpers live in projectTreeUtils.js.
+import { isSelfOrDescendant } from './projectTreeUtils'
 
 // One file row in a tree pane. Files aren't drop targets (drops go to
 // folders), but they are drag sources and carry the full context menu.

--- a/dashboard/frontend/src/components/chat/projectTree.jsx
+++ b/dashboard/frontend/src/components/chat/projectTree.jsx
@@ -1,0 +1,140 @@
+// Project file-tree primitives shared by ProjectPage (full explorer) and
+// ProjectExplorerPane (the strip shown next to a project conversation).
+
+export function findNode(nodes, path) {
+  for (const n of nodes) {
+    if (n.path === path) return n
+    if (n.type === 'dir' && n.children) {
+      const hit = findNode(n.children, path)
+      if (hit) return hit
+    }
+  }
+  return null
+}
+
+// Children of a directory path ('' = project root).
+export function listDir(tree, dirPath) {
+  if (!dirPath) return tree
+  const node = findNode(tree, dirPath)
+  return node && node.type === 'dir' ? (node.children || []) : null
+}
+
+export function parentDir(path) {
+  const i = path.lastIndexOf('/')
+  return i === -1 ? '' : path.slice(0, i)
+}
+
+export function baseName(path) {
+  return path.split('/').pop()
+}
+
+export function isSelfOrDescendant(dirPath, ofPath) {
+  return dirPath === ofPath || dirPath.startsWith(ofPath + '/')
+}
+
+// All ancestor dir paths of a path, root ('') excluded:
+// 'a/b/c' -> ['a', 'a/b'].
+export function ancestorsOf(path) {
+  const out = []
+  const parts = path.split('/')
+  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join('/'))
+  return out
+}
+
+// One file row in a tree pane. Files aren't drop targets (drops go to
+// folders), but they are drag sources and carry the full context menu.
+// Drag-and-drop and context-menu handlers are optional — a read-mostly
+// pane simply omits them.
+export function TreeFile({ node, depth, editingPath, cutPath, onOpen, onMenu, onDragStart }) {
+  return (
+    <div
+      draggable={!!onDragStart}
+      onClick={() => onOpen(node)}
+      onContextMenu={onMenu ? e => onMenu(e, node) : undefined}
+      onDragStart={onDragStart ? e => onDragStart(e, node) : undefined}
+      className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
+        editingPath === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
+      } ${cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''}`}
+      style={{ paddingLeft: `${8 + depth * 14}px` }}
+      data-testid={`tree-node-${node.path}`}
+    >
+      <span className="w-4 flex-shrink-0"></span>
+      <i className="fa-regular fa-file text-xs text-fg-faint flex-shrink-0"></i>
+      <span className="flex-1 min-w-0 truncate">{node.name}</span>
+    </div>
+  )
+}
+
+// One folder row in a tree pane (recursive over children; the backend
+// sorts dirs before files, so children render in tree order). When
+// onSelect is omitted (read-mostly pane), clicking the row toggles
+// expansion instead of selecting the directory.
+export function TreeDir({ node, depth, expanded, selectedDir, editingPath, dropTarget, cutPath,
+                          onToggle, onSelect, onOpenFile, onMenu, onDragStart, onDragOver, onDragLeave, onDrop }) {
+  const children = node.children || []
+  const isExpanded = expanded.has(node.path)
+  return (
+    <>
+      <div
+        draggable={!!onDragStart}
+        onClick={() => (onSelect ? onSelect(node.path) : onToggle(node.path))}
+        onContextMenu={onMenu ? e => onMenu(e, node) : undefined}
+        onDragStart={onDragStart ? e => onDragStart(e, node) : undefined}
+        onDragOver={onDragOver ? e => onDragOver(e, node.path) : undefined}
+        onDragLeave={onDragLeave ? () => onDragLeave(node.path) : undefined}
+        onDrop={onDrop ? e => onDrop(e, node.path) : undefined}
+        className={`flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer rounded ${
+          selectedDir === node.path ? 'bg-accent-subtle text-fg' : 'text-fg-muted hover:bg-surface-muted'
+        } ${dropTarget === node.path ? 'ring-1 ring-accent-strong bg-accent-subtle' : ''} ${
+          cutPath && isSelfOrDescendant(node.path, cutPath) ? 'opacity-50' : ''
+        }`}
+        style={{ paddingLeft: `${8 + depth * 14}px` }}
+        data-testid={`tree-node-${node.path}`}
+      >
+        <button
+          onClick={e => { e.stopPropagation(); onToggle(node.path) }}
+          className={`w-4 flex-shrink-0 text-fg-faint cursor-pointer ${children.length ? '' : 'invisible'}`}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${node.path}`}
+          tabIndex={-1}
+        >
+          <i className={`fa-solid fa-chevron-${isExpanded ? 'down' : 'right'} text-[9px]`}></i>
+        </button>
+        <i className={`fa-solid fa-folder${selectedDir === node.path ? '-open' : ''} text-xs text-amber-500/80 flex-shrink-0`}></i>
+        <span className="flex-1 min-w-0 truncate">{node.name}</span>
+      </div>
+      {isExpanded && children.map(child => (
+        child.type === 'dir' ? (
+          <TreeDir
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            expanded={expanded}
+            selectedDir={selectedDir}
+            editingPath={editingPath}
+            dropTarget={dropTarget}
+            cutPath={cutPath}
+            onToggle={onToggle}
+            onSelect={onSelect}
+            onOpenFile={onOpenFile}
+            onMenu={onMenu}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+          />
+        ) : (
+          <TreeFile
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            editingPath={editingPath}
+            cutPath={cutPath}
+            onOpen={onOpenFile}
+            onMenu={onMenu}
+            onDragStart={onDragStart}
+          />
+        )
+      ))}
+    </>
+  )
+}

--- a/dashboard/frontend/src/components/chat/projectTreeUtils.js
+++ b/dashboard/frontend/src/components/chat/projectTreeUtils.js
@@ -1,0 +1,43 @@
+// Path/tree helpers shared by ProjectPage, ProjectExplorerPane and the
+// tree row components. Kept free of JSX so react-refresh stays happy
+// with projectTree.jsx exporting only components.
+
+export function findNode(nodes, path) {
+  for (const n of nodes) {
+    if (n.path === path) return n
+    if (n.type === 'dir' && n.children) {
+      const hit = findNode(n.children, path)
+      if (hit) return hit
+    }
+  }
+  return null
+}
+
+// Children of a directory path ('' = project root).
+export function listDir(tree, dirPath) {
+  if (!dirPath) return tree
+  const node = findNode(tree, dirPath)
+  return node && node.type === 'dir' ? (node.children || []) : null
+}
+
+export function parentDir(path) {
+  const i = path.lastIndexOf('/')
+  return i === -1 ? '' : path.slice(0, i)
+}
+
+export function baseName(path) {
+  return path.split('/').pop()
+}
+
+export function isSelfOrDescendant(dirPath, ofPath) {
+  return dirPath === ofPath || dirPath.startsWith(ofPath + '/')
+}
+
+// All ancestor dir paths of a path, root ('') excluded:
+// 'a/b/c' -> ['a', 'a/b'].
+export function ancestorsOf(path) {
+  const out = []
+  const parts = path.split('/')
+  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join('/'))
+  return out
+}


### PR DESCRIPTION
## What

When a conversation belongs to a project, the conversation screen splits in two: a **project file-explorer strip on the left** (20% default width, drag-resizable via the divider, collapsible, both persisted in localStorage) and the **chat on the rest**. Conversations without a project are unchanged.

Also adds a **collapse toggle to the conversations list** (ChatSidebar → thin rail with expand + new-conversation buttons, persisted).

## How

- `projectTree.jsx` — `TreeDir`/`TreeFile` and the path helpers extracted from `ProjectPage` so both explorers share one implementation (DnD/context-menu handlers became optional for the read-mostly pane).
- `ProjectExplorerPane` — the strip: browse/expand the tree, open a file, new file, upload into the root, refresh. Same stale-response generation guard as `ProjectPage`. Re-reads the tree when a chat run completes, since the model may have written files through the project-files tools.
- `ProjectChatSplit` — the split container. Opening a file overlays `ProjectFileEditor` on the chat region (the conversation stays loaded underneath); dirty-editor state feeds ChatPage's existing navigation guard, and switching conversations closes the overlay.
- `ChatSidebar` — collapse/expand with localStorage persistence, following the main `Sidebar` pattern.

## Testing

- 24 new vitest cases (explorer pane, split behavior incl. drag-resize clamping and dirty-file guard, sidebar collapse, ChatPage wiring); full suite green except the 4 pre-existing `api.test.js` failures that also fail on `main`.
- `npm run build` passes; `npm run lint` adds no new errors (one warning of a class already present in the codebase).