### PR TITLE
fix(chat): align collapsed-rail expanders across all three panels

### DIFF
--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -508,28 +508,35 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
   }, [collapsed])
 
   if (collapsed) {
+    // The collapsed rail mirrors the main Sidebar's geometry (h-16
+    // bordered header, w-8 h-8 toggle, text-sm icon) so the expander
+    // chevrons of all collapsed panels sit on one line.
     return (
       <div
-        className="w-10 border-r border-border flex flex-col items-center bg-app flex-shrink-0 py-2 gap-1"
+        className="w-10 border-r border-border flex flex-col items-center bg-app flex-shrink-0"
         data-testid="chat-sidebar-collapsed"
       >
-        <button
-          onClick={() => setCollapsed(false)}
-          className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
-          title="Show conversations"
-          aria-label="Show conversations"
-          aria-expanded={false}
-        >
-          <i className="fa-solid fa-angles-right text-xs"></i>
-        </button>
-        <button
-          onClick={onCreate}
-          className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
-          title="New conversation"
-          aria-label="New conversation"
-        >
-          <i className="fa-solid fa-plus text-xs"></i>
-        </button>
+        <div className="h-16 w-full border-b border-border-subtle flex items-center justify-center flex-shrink-0">
+          <button
+            onClick={() => setCollapsed(false)}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
+            title="Show conversations"
+            aria-label="Show conversations"
+            aria-expanded={false}
+          >
+            <i className="fa-solid fa-angles-right text-sm"></i>
+          </button>
+        </div>
+        <div className="py-4">
+          <button
+            onClick={onCreate}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
+            title="New conversation"
+            aria-label="New conversation"
+          >
+            <i className="fa-solid fa-plus text-sm"></i>
+          </button>
+        </div>
       </div>
     )
   }

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -139,16 +139,23 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
   return (
     <div ref={containerRef} className="flex-1 flex overflow-hidden min-w-0" data-testid="project-chat-split">
       {collapsed && (
-        <div className="w-8 flex-shrink-0 border-r border-border bg-app flex flex-col items-center py-2">
-          <button
-            onClick={() => setCollapsed(false)}
-            className="text-fg-subtle hover:text-fg p-1.5 cursor-pointer"
-            title={`Show ${project.name} files`}
-            aria-label="Show file explorer"
-          >
-            <i className="fa-solid fa-angles-right text-xs"></i>
-          </button>
-          <i className="fa-solid fa-folder text-xs text-amber-500/50 mt-2" title={project.name}></i>
+        // Same geometry as the other collapsed rails (main Sidebar,
+        // ChatSidebar): h-16 bordered header, w-8 h-8 toggle, text-sm
+        // icon — the expander chevrons of all collapsed panels line up.
+        <div className="w-10 flex-shrink-0 border-r border-border bg-app flex flex-col items-center">
+          <div className="h-16 w-full border-b border-border-subtle flex items-center justify-center flex-shrink-0">
+            <button
+              onClick={() => setCollapsed(false)}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
+              title={`Show ${project.name} files`}
+              aria-label="Show file explorer"
+            >
+              <i className="fa-solid fa-angles-right text-sm"></i>
+            </button>
+          </div>
+          <div className="py-4">
+            <i className="fa-solid fa-folder text-sm text-amber-500/50" title={project.name}></i>
+          </div>
         </div>
       )}
       {/* The pane stays MOUNTED while collapsed (display:none) so an


### PR DESCRIPTION
With the main sidebar, conversations list, and project file explorer all collapsed, the three `»` expanders sat at different heights with different button/icon sizes and rail widths.

Both mini-rails (conversations, explorer) now copy the main `Sidebar`'s collapsed geometry — `h-16` bordered header with a centered `w-8 h-8` toggle and `text-sm` icon, secondary actions in a `py-4` block below — so all three chevrons align on one line.

Visual-only; existing aria-labels/testids unchanged, 41 affected tests pass, lint and build at baseline.