### PR TITLE
feat: resizable chat sidebar

### DIFF
--- a/chat-mockup.html
+++ b/chat-mockup.html
@@ -1,0 +1,1411 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>llm-dock — Chat Window Design</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400;1,8..60,500&display=swap" rel="stylesheet">
+<style>
+  /* ========================================
+     DESIGN SYSTEM: "Warm Newspaper"
+     Influences: NZS editorial, IBM Plex, zine marginalia
+     Dominant: #BF3618 (burnt sienna)
+     Accent: #0D9488 (teal)
+     ======================================== */
+
+  :root {
+    --bg: #F7F5F1;
+    --bg-white: #FFFFFF;
+    --surface: #F0EDE8;
+    --surface-dark: #E8E4DE;
+    --ink: #1A1714;
+    --ink-body: #332E28;
+    --ink-secondary: #7A7367;
+    --ink-faint: #AAA49A;
+    --ink-rule: #D4CFC7;
+    --red: #BF3618;
+    --red-light: #D96B4F;
+    --red-bg: rgba(191, 54, 24, 0.06);
+    --red-bg-strong: rgba(191, 54, 24, 0.12);
+    --teal: #0D9488;
+    --teal-bg: rgba(13, 148, 136, 0.08);
+    --amber: #B45309;
+    --amber-bg: rgba(180, 83, 9, 0.06);
+    --green: #15803D;
+    --green-bg: rgba(21, 128, 61, 0.08);
+    --critique-bg: #FEF3C7;
+    --critique-border: #D97706;
+    --critique-text: #92400E;
+    --mono: 'IBM Plex Mono', monospace;
+    --serif: 'Source Serif 4', 'Georgia', serif;
+  }
+
+  *, *::before, *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html { font-size: 15px; }
+
+  body {
+    font-family: var(--serif);
+    color: var(--ink-body);
+    background: var(--bg);
+    height: 100vh;
+    display: grid;
+    grid-template-columns: 248px 1fr;
+    grid-template-rows: 52px 1fr 64px;
+    grid-template-areas:
+      "sidebar header"
+      "sidebar messages"
+      "sidebar input";
+    overflow: hidden;
+    line-height: 1.55;
+  }
+
+  /* ========== HEADER ========== */
+  .header {
+    grid-area: header;
+    background: var(--bg-white);
+    display: flex;
+    align-items: center;
+    padding: 0 1.25rem;
+    border-bottom: 1px solid var(--ink-rule);
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .header-model {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+
+  .header-model-label {
+    font-family: var(--mono);
+    font-size: 0.6rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-secondary);
+  }
+
+  .header-model-name {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--ink);
+  }
+
+  .header-sep {
+    width: 1px;
+    height: 1.25rem;
+    background: var(--ink-rule);
+    flex-shrink: 0;
+  }
+
+  .header-param {
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    color: var(--ink-secondary);
+  }
+
+  .header-spacer { flex: 1; }
+
+  .mcp-toggles {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .mcp-label {
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-right: 0.25rem;
+  }
+
+  .mcp-toggle {
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    padding: 0.2rem 0.55rem;
+    border: 1px solid var(--ink-rule);
+    background: var(--bg-white);
+    color: var(--ink-secondary);
+    cursor: pointer;
+    transition: all 0.12s;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    line-height: 1;
+  }
+
+  .mcp-toggle.on {
+    border-color: var(--red);
+    color: var(--red);
+    background: var(--red-bg);
+  }
+
+  .mcp-toggle:hover { border-color: var(--ink-secondary); }
+
+  .mcp-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--ink-faint);
+  }
+
+  .mcp-toggle.on .mcp-dot { background: var(--red); }
+
+  /* ========== SIDEBAR ========== */
+  .sidebar {
+    grid-area: sidebar;
+    background: var(--bg-white);
+    border-right: 1px solid var(--ink-rule);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .sidebar-logo {
+    padding: 0.75rem 1rem;
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--ink);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--ink-rule);
+  }
+
+  .sidebar-logo-mark {
+    width: 14px;
+    height: 14px;
+    background: var(--red);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 8px;
+    font-weight: 700;
+  }
+
+  .sidebar-new {
+    margin: 0.6rem 0.75rem;
+    padding: 0.5rem;
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    font-weight: 500;
+    background: var(--ink);
+    color: white;
+    border: none;
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    transition: background 0.12s;
+  }
+
+  .sidebar-new:hover { background: #333; }
+
+  .sidebar-nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+  }
+
+  .sidebar-group-label {
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    padding: 0.5rem 1rem 0.3rem;
+  }
+
+  .sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+    transition: all 0.1s;
+    position: relative;
+  }
+
+  .sidebar-item:hover { background: var(--surface); }
+
+  .sidebar-item.active {
+    background: var(--red-bg);
+    border-left-color: var(--red);
+  }
+
+  .sidebar-item-title {
+    font-family: var(--serif);
+    font-size: 0.82rem;
+    color: var(--ink-body);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sidebar-item.active .sidebar-item-title {
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .sidebar-item-meta {
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    color: var(--ink-faint);
+    flex-shrink: 0;
+  }
+
+  .sidebar-branch {
+    color: var(--red-light);
+    font-size: 0.6rem;
+    margin-right: -0.15rem;
+  }
+
+  .sidebar-item.spinoff {
+    padding-left: 2rem;
+  }
+
+  .sidebar-item.spinoff::before {
+    content: '│';
+    position: absolute;
+    left: 1.2rem;
+    color: var(--ink-rule);
+    font-family: var(--mono);
+    font-size: 0.7rem;
+  }
+
+  .sidebar-item.spinoff::after {
+    content: '└';
+    position: absolute;
+    left: 1.2rem;
+    color: var(--ink-rule);
+    font-family: var(--mono);
+    font-size: 0.7rem;
+  }
+
+  .sidebar-item.spinoff-branch {
+    position: relative;
+  }
+
+  .sidebar-item.spinoff-branch::before {
+    content: '';
+    position: absolute;
+    left: 1.2rem;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--ink-rule);
+  }
+
+  .sidebar-footer {
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--ink-rule);
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    color: var(--ink-faint);
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .sidebar-footer span { cursor: pointer; }
+  .sidebar-footer span:hover { color: var(--ink-secondary); }
+
+  /* ========== MESSAGES ========== */
+  .messages {
+    grid-area: messages;
+    overflow-y: auto;
+    padding: 1rem 1rem 1.25rem 1rem;
+    scroll-behavior: smooth;
+  }
+
+  .messages {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .msg-row {
+    display: grid;
+    grid-template-columns: 40px 1fr 230px;
+    column-gap: 0;
+  }
+
+  .spine {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+  }
+
+  .spine-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .spine-dot.user {
+    background: var(--ink-secondary);
+  }
+
+  .spine-dot.assistant {
+    background: var(--red);
+  }
+
+  .spine-dot.streaming {
+    background: var(--red);
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(1.5); }
+  }
+
+  .spine-line {
+    width: 1px;
+    background: var(--ink-rule);
+    flex: 1;
+    min-height: 8px;
+  }
+
+  .spine-branch {
+    flex: 1;
+    min-height: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+  }
+
+  .spine-branch-line {
+    width: 1px;
+    flex: 1;
+    background: var(--ink-rule);
+    border-style: dashed;
+  }
+
+  .spine-branch-hook {
+    width: 10px;
+    height: 10px;
+    border-right: 1px dashed var(--red-light);
+    border-bottom: 1px dashed var(--red-light);
+    transform: rotate(-45deg);
+    margin-bottom: 4px;
+  }
+
+  .msg-body {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    padding-top: 0.2rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .msg-body.user-body {
+    padding-left: 1.5rem;
+  }
+
+  .msg-gutter {
+    padding-left: 0.75rem;
+    padding-right: 0.5rem;
+    padding-top: 0.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  /* Message header metadata */
+  .msg-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+    flex-wrap: wrap;
+  }
+
+  .msg-role {
+    font-family: var(--mono);
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .msg-role.user { color: var(--ink-secondary); }
+  .msg-role.assistant { color: var(--red); }
+
+  .msg-meta {
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    color: var(--ink-faint);
+  }
+
+  .msg-meta-sep {
+    color: var(--ink-rule);
+  }
+
+  /* Message content */
+  .msg-content {
+    font-size: 0.92rem;
+    line-height: 1.62;
+    color: var(--ink-body);
+  }
+
+  .msg-content p { margin-bottom: 0.65rem; }
+  .msg-content p:last-child { margin-bottom: 0; }
+  .msg-content strong { font-weight: 600; color: var(--ink); }
+
+  .msg-content code {
+    font-family: var(--mono);
+    font-size: 0.82em;
+    background: var(--surface);
+    padding: 0.1em 0.35em;
+    border: 1px solid var(--ink-rule);
+    color: var(--ink);
+  }
+
+  .msg-content pre {
+    background: var(--ink);
+    color: #E8E4DE;
+    padding: 0.75rem 1rem;
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    margin: 0.65rem 0;
+  }
+
+  .msg-content h4 {
+    font-size: 0.88rem;
+    font-weight: 600;
+    margin: 0.85rem 0 0.35rem;
+    color: var(--ink);
+  }
+
+  .msg-content ul {
+    padding-left: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .msg-content li { margin-bottom: 0.2rem; }
+
+  /* User message styling */
+  .user-body .msg-content {
+    border-left: 2px solid var(--surface-dark);
+    padding-left: 0.85rem;
+  }
+
+  /* ========== TOOL CALL (in gutter) ========== */
+  .tool-call {
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    line-height: 1.5;
+    color: var(--ink-secondary);
+    border-left: 2px solid var(--teal);
+    padding-left: 0.55rem;
+    position: relative;
+  }
+
+  .tool-call::before {
+    content: '';
+    position: absolute;
+    left: -2px;
+    top: 0.6rem;
+    width: 1.25rem;
+    height: 1px;
+    border-top: 1px dashed var(--teal);
+    opacity: 0.4;
+  }
+
+  .tool-name {
+    font-weight: 600;
+    color: var(--teal);
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .tool-icon {
+    font-size: 0.6rem;
+    opacity: 0.7;
+  }
+
+  .tool-status {
+    font-size: 0.5rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    opacity: 0.6;
+  }
+
+  .tool-status.done { color: var(--green); }
+  .tool-status.running { color: var(--amber); }
+
+  .tool-args {
+    color: var(--ink-faint);
+    margin: 0.15rem 0;
+  }
+
+  .tool-args dt {
+    color: var(--ink-faint);
+    font-style: italic;
+  }
+
+  .tool-result {
+    margin-top: 0.3rem;
+    padding-top: 0.3rem;
+    border-top: 1px solid var(--ink-rule);
+    color: var(--green);
+    font-size: 0.63rem;
+  }
+
+  .tool-connector {
+    position: absolute;
+    left: -20px;
+    top: 0.55rem;
+    width: 1rem;
+    height: 1px;
+    border-top: 1px dashed var(--teal);
+    opacity: 0.3;
+  }
+
+  /* ========== ARTIFACT ========== */
+  .artifact {
+    border: 1px solid var(--ink-rule);
+    margin: 0.65rem 0;
+    background: var(--bg-white);
+    overflow: hidden;
+  }
+
+  .artifact-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.3rem 0.6rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--ink-rule);
+    font-family: var(--mono);
+  }
+
+  .artifact-head-left {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-secondary);
+  }
+
+  .artifact-tag {
+    font-size: 0.5rem;
+    font-weight: 600;
+    background: var(--ink);
+    color: white;
+    padding: 0.1rem 0.35rem;
+    letter-spacing: 0.1em;
+  }
+
+  .artifact-title {
+    font-size: 0.68rem;
+    font-weight: 500;
+    color: var(--ink);
+  }
+
+  .artifact-body {
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    background: white;
+  }
+
+  .artifact-body svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ========== CRITIQUE ANNOTATION ========== */
+  .critique-note {
+    border-left: 2px solid var(--critique-border);
+    background: var(--critique-bg);
+    padding: 0.4rem 0.55rem;
+    font-family: var(--mono);
+    position: relative;
+  }
+
+  .critique-note::after {
+    content: '';
+    position: absolute;
+    left: -6px;
+    top: 0.5rem;
+    width: 4px;
+    height: 4px;
+    background: var(--critique-border);
+  }
+
+  .critique-ref {
+    font-size: 0.52rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--critique-text);
+    margin-bottom: 0.15rem;
+  }
+
+  .critique-span {
+    font-family: var(--serif);
+    font-size: 0.72rem;
+    font-style: italic;
+    color: var(--ink-secondary);
+    border-left: 1px solid var(--critique-border);
+    padding-left: 0.35rem;
+    margin-bottom: 0.2rem;
+    line-height: 1.45;
+  }
+
+  .critique-comment {
+    font-size: 0.68rem;
+    line-height: 1.5;
+    color: var(--ink-body);
+  }
+
+  .critique-severity {
+    display: inline-block;
+    font-size: 0.5rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.08rem 0.3rem;
+    margin-left: 0.3rem;
+  }
+
+  .critique-severity.error {
+    background: rgba(191, 54, 24, 0.15);
+    color: #991B1B;
+  }
+
+  .critique-severity.warning {
+    background: rgba(180, 83, 9, 0.15);
+    color: var(--amber);
+  }
+
+  .critique-severity.info {
+    background: rgba(74, 85, 95, 0.12);
+    color: #4B5563;
+  }
+
+  .critique-spacer {
+    height: 1px;
+  }
+
+  /* ========== STREAMING MESSAGE ========== */
+  .streaming-cursor {
+    display: inline-block;
+    width: 2px;
+    height: 0.9em;
+    margin-left: 1px;
+    background: var(--red);
+    animation: blink-cursor 0.9s step-end infinite;
+    vertical-align: text-bottom;
+  }
+
+  @keyframes blink-cursor {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
+  .stream-status {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    color: var(--amber);
+  }
+
+  .stream-dot {
+    width: 5px;
+    height: 5px;
+    background: var(--red);
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+
+  .stream-idle .stream-dot {
+    background: var(--amber);
+    animation: none;
+  }
+
+  .stream-idle { color: var(--amber); }
+
+  /* ========== FORMAT DRIFT ========== */
+  .drift {
+    font-family: var(--mono);
+    font-size: 0.62rem;
+    color: var(--amber);
+    margin-top: 0.5rem;
+    padding: 0.3rem 0.5rem;
+    border-left: 2px solid var(--amber);
+    background: var(--amber-bg);
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+  }
+
+  .drift-icon { font-size: 0.65rem; }
+
+  .drift-detail {
+    font-size: 0.58rem;
+    color: var(--ink-secondary);
+    margin-top: 0.25rem;
+    padding-left: 0.5rem;
+    border-left: 1px solid var(--ink-rule);
+  }
+
+  /* ========== THINKING BLOCK ========== */
+  .thinking {
+    margin-top: 0.35rem;
+  }
+
+  .thinking-toggle {
+    font-family: var(--mono);
+    font-size: 0.6rem;
+    color: var(--ink-faint);
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0;
+  }
+
+  .thinking-toggle:hover { color: var(--ink-secondary); }
+
+  .thinking-count {
+    font-size: 0.52rem;
+    color: var(--ink-faint);
+  }
+
+  .thinking-content {
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--ink-secondary);
+    font-style: italic;
+    margin-top: 0.25rem;
+    padding: 0.45rem 0.6rem;
+    background: var(--surface);
+    border-left: 2px solid var(--surface-dark);
+  }
+
+  /* ========== SPINOFF INDICATOR ========== */
+  .spinoff-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.65rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px dashed var(--ink-rule);
+    background: var(--bg);
+    font-family: var(--mono);
+    font-size: 0.62rem;
+    color: var(--ink-faint);
+  }
+
+  .spinoff-indicator-line {
+    width: 1.25rem;
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  .spinoff-indicator-line::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 1px;
+    height: 1rem;
+    border-left: 1px dashed var(--ink-rule);
+  }
+
+  .spinoff-indicator-line::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-bottom: 1px dashed var(--red-light);
+    border-right: 1px dashed var(--red-light);
+    transform: rotate(-45deg);
+    transform-origin: bottom left;
+  }
+
+  .spinoff-arrow {
+    color: var(--red-light);
+  }
+
+  /* ========== HEARTBEAT ========== */
+  .heartbeat {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    color: var(--ink-faint);
+    margin-top: 0.35rem;
+  }
+
+  .heartbeat-line {
+    width: 0.75rem;
+    height: 1px;
+    border-top: 1px dashed var(--ink-faint);
+  }
+
+  /* ========== INPUT BAR ========== */
+  .input-bar {
+    grid-area: input;
+    background: var(--bg-white);
+    border-top: 1px solid var(--ink-rule);
+    padding: 0.5rem 1.25rem;
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+
+  .input-status {
+    position: absolute;
+    top: -1.5rem;
+    left: 1.25rem;
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    color: var(--ink-faint);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .input-wrap {
+    flex: 1;
+    position: relative;
+  }
+
+  .input-textarea {
+    width: 100%;
+    font-family: var(--serif);
+    font-size: 0.88rem;
+    line-height: 1.5;
+    border: 1px solid var(--ink-rule);
+    padding: 0.5rem 0.7rem;
+    resize: none;
+    background: var(--bg);
+    color: var(--ink-body);
+    outline: none;
+    min-height: 36px;
+    max-height: 120px;
+  }
+
+  .input-textarea::placeholder {
+    color: var(--ink-faint);
+    font-style: italic;
+  }
+
+  .input-send {
+    width: 36px;
+    height: 36px;
+    background: var(--red);
+    color: white;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    flex-shrink: 0;
+    align-self: flex-end;
+    transition: background 0.12s;
+  }
+
+  .input-send:hover { background: #A03010; }
+
+  .input-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-self: flex-end;
+    padding-bottom: 0.25rem;
+  }
+
+  .input-action {
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    color: var(--ink-faint);
+    background: none;
+    border: 1px solid transparent;
+    cursor: pointer;
+    padding: 0.15rem 0.3rem;
+    letter-spacing: 0.04em;
+    transition: all 0.1s;
+  }
+
+  .input-action:hover {
+    color: var(--ink-secondary);
+    border-color: var(--ink-rule);
+  }
+
+  /* ========== VERDICT ========== */
+  .verdict {
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.45rem;
+    border: 1px solid;
+    margin-bottom: 0.4rem;
+  }
+
+  .verdict.minor {
+    color: var(--amber);
+    border-color: rgba(180, 83, 9, 0.3);
+    background: var(--amber-bg);
+  }
+
+  /* ========== TOOLTIP HELPERS ========== */
+  .design-note {
+    font-family: var(--mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--ink-rule);
+  }
+
+  .msg-gap {
+    height: 1rem;
+  }
+
+  /* Scrollbar styling */
+  .messages::-webkit-scrollbar,
+  .sidebar-nav::-webkit-scrollbar { width: 5px; }
+  .messages::-webkit-scrollbar-track,
+  .sidebar-nav::-webkit-scrollbar-track { background: transparent; }
+  .messages::-webkit-scrollbar-thumb,
+  .sidebar-nav::-webkit-scrollbar-thumb { background: var(--ink-rule); }
+  .messages::-webkit-scrollbar-thumb:hover,
+  .sidebar-nav::-webkit-scrollbar-thumb:hover { background: var(--ink-faint); }
+
+  /* ========== DESIGN LABEL ========== */
+  .design-label {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background: var(--ink);
+    color: white;
+    font-family: var(--mono);
+    font-size: 0.55rem;
+    padding: 0.25rem 0.5rem;
+    letter-spacing: 0.05em;
+    z-index: 100;
+  }
+</style>
+</head>
+<body>
+  <!-- ==================== HEADER ==================== -->
+  <header class="header">
+    <div class="header-model">
+      <span class="header-model-label">Main</span>
+      <span class="header-model-name">vllm-qwen3-6-27b-bf16</span>
+    </div>
+    <div class="header-sep"></div>
+    <div class="header-model">
+      <span class="header-model-label">Sidekick</span>
+      <span class="header-model-name" style="color: var(--ink-secondary);">llama3.1-8b-instruct</span>
+    </div>
+    <div class="header-sep"></div>
+    <span class="header-param">max-model-len 131072</span>
+    <span class="header-param">ctx 32k</span>
+    <span class="header-spacer"></span>
+    <div class="mcp-toggles">
+      <span class="mcp-label">MCP</span>
+      <button class="mcp-toggle on">
+        <span class="mcp-dot"></span>sympy-math
+      </button>
+      <button class="mcp-toggle on">
+        <span class="mcp-dot"></span>schemdraw
+      </button>
+      <button class="mcp-toggle">
+        <span class="mcp-dot"></span>render-html
+      </button>
+    </div>
+  </header>
+
+  <!-- ==================== SIDEBAR ==================== -->
+  <aside class="sidebar">
+    <div class="sidebar-logo">
+      <div class="sidebar-logo-mark">LD</div>
+      llm-dock
+    </div>
+    <button class="sidebar-new">+ New Conversation</button>
+    <nav class="sidebar-nav">
+      <div class="sidebar-group-label">Today</div>
+      <div class="sidebar-item active">
+        <span class="sidebar-item-title">vLLM GPU sizing for FP8 models</span>
+        <span class="sidebar-item-meta">14:32</span>
+      </div>
+      <div class="sidebar-item spinoff spinoff-branch">
+        <span class="sidebar-branch">&#8629;</span>
+        <span class="sidebar-item-title">Compare with llama.cpp GGUF</span>
+        <span class="sidebar-item-meta">15:01</span>
+      </div>
+      <div class="sidebar-item" style="margin-top: 0.25rem;">
+        <span class="sidebar-item-title">Docker Compose v3 migration</span>
+        <span class="sidebar-item-meta">11:45</span>
+      </div>
+      <div class="sidebar-group-label" style="margin-top: 0.5rem;">Yesterday</div>
+      <div class="sidebar-item">
+        <span class="sidebar-item-title">RTX PRO 6000 benchmark results</span>
+        <span class="sidebar-item-meta">23 Apr</span>
+      </div>
+      <div class="sidebar-item">
+        <span class="sidebar-item-title">Open WebUI embedding config</span>
+        <span class="sidebar-item-meta">23 Apr</span>
+      </div>
+      <div class="sidebar-item">
+        <span class="sidebar-item-title">CUDA 12.8 upgrade notes</span>
+        <span class="sidebar-item-meta">22 Apr</span>
+      </div>
+    </nav>
+    <div class="sidebar-footer">
+      <span>Services &middot; 4 running</span>
+      <span>GPU 67%</span>
+    </div>
+  </aside>
+
+  <!-- ==================== MESSAGES ==================== -->
+  <main class="messages">
+
+    <!-- ---- MSG 1: Assistant (with artifact SVG, tool call in gutter) ---- -->
+    <div class="msg-row" style="grid-row: auto;">
+      <div class="spine">
+        <div class="spine-dot assistant"></div>
+        <div class="spine-line"></div>
+      </div>
+      <div class="msg-body">
+        <div class="msg-head">
+          <span class="msg-role assistant">vllm-qwen3-6-27b</span>
+          <span class="msg-meta">14:28</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <span class="msg-meta">187 tok</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <span class="msg-meta">1.2s</span>
+        </div>
+        <div class="msg-content">
+          <p>The circuit diagram for your full-bridge rectifier is ready. I generated it using <code>schemdraw</code> &mdash; it includes the four diodes, input AC source, and output capacitor.</p>
+          <div class="artifact">
+            <div class="artifact-head">
+              <div class="artifact-head-left">
+                <span class="artifact-tag">SVG</span>
+                <span class="artifact-title">Full-Bridge Rectifier</span>
+              </div>
+              <span style="font-size: 0.55rem; color: var(--ink-faint);">schemdraw &middot; 4.2 KB</span>
+            </div>
+            <div class="artifact-body">
+              <svg width="340" height="160" viewBox="0 0 340 160" xmlns="http://www.w3.org/2000/svg">
+                <g stroke="none" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <!-- Wires -->
+                  <line x1="30" y1="80" x2="100" y2="80" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="240" y1="80" x2="310" y2="80" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="100" y1="80" x2="100" y2="40" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="100" y1="80" x2="100" y2="120" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="240" y1="80" x2="240" y2="40" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="240" y1="80" x2="240" y2="120" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="100" y1="40" x2="240" y2="40" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="100" y1="120" x2="240" y2="120" stroke="#1A1714" stroke-width="1.5"/>
+                  <!-- Diode symbols (D1, D2, D3, D4) -->
+                  <polygon points="97,58 103,72 103,48" fill="#1A1714" stroke="none"/>
+                  <line x1="103" y1="46" x2="103" y2="74" stroke="#1A1714" stroke-width="1.5"/>
+                  <polygon points="237,48 243,72 243,58" fill="#1A1714" stroke="none"/>
+                  <line x1="243" y1="46" x2="243" y2="74" stroke="#1A1714" stroke-width="1.5"/>
+                  <polygon points="237,88 243,112 243,98" fill="#1A1714" stroke="none"/>
+                  <line x1="243" y1="86" x2="243" y2="114" stroke="#1A1714" stroke-width="1.5"/>
+                  <polygon points="97,88 103,112 103,98" fill="#1A1714" stroke="none"/>
+                  <line x1="103" y1="86" x2="103" y2="114" stroke="#1A1714" stroke-width="1.5"/>
+                  <!-- Labels -->
+                  <text x="110" y="52" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">D1</text>
+                  <text x="253" y="52" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">D2</text>
+                  <text x="253" y="104" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">D4</text>
+                  <text x="110" y="104" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">D3</text>
+                  <!-- Terminal caps -->
+                  <circle cx="30" cy="80" r="3" fill="#BF3618"/>
+                  <circle cx="310" cy="80" r="3" fill="#1A1714"/>
+                  <text x="14" y="74" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">AC</text>
+                  <text x="268" y="74" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7A7367">DC</text>
+                  <!-- Output labels -->
+                  <line x1="170" y1="40" x2="170" y2="24" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="250" y1="24" x2="290" y2="24" stroke="#1A1714" stroke-width="1"/>
+                  <text x="250" y="30" font-family="IBM Plex Mono, monospace" font-size="7" fill="#BF3618">+</text>
+                  <line x1="170" y1="120" x2="170" y2="136" stroke="#1A1714" stroke-width="1.5"/>
+                  <line x1="250" y1="136" x2="290" y2="136" stroke="#1A1714" stroke-width="1"/>
+                  <text x="250" y="142" font-family="IBM Plex Mono, monospace" font-size="7" fill="#BF3618">&minus;</text>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <p>The peak output voltage will be <code>V<sub>out</sub> &asymp; V<sub>peak</sub> &minus; 1.4V</code> accounting for the two-diode forward drop. If you need ripple calculation for a given load &mdash; I can work that out.</p>
+        </div>
+        <!-- Spinoff branch indicator -->
+        <div class="spinoff-indicator">
+          <div class="spinoff-indicator-line"></div>
+          <span class="spinoff-arrow">&#8629;</span>
+          <span>Spinoff: "Compare with llama.cpp GGUF performance"</span>
+        </div>
+      </div>
+      <div class="msg-gutter">
+        <div class="tool-call">
+          <div class="tool-connector"></div>
+          <div class="tool-name">
+            <span class="tool-icon">&#9003;</span>
+            schemdraw-circuits__draw_circuit
+          </div>
+          <dl class="tool-args">
+            <div><dt>diodes</dt>&ensp;<dd>4</dd></div>
+            <div><dt>topology</dt>&ensp;<dd>full-bridge</dd></div>
+            <div><dt>output</dt>&ensp;<dd>svg</dd></div>
+          </dl>
+          <div class="tool-result">
+            &check; 428 bytes &middot; svg &middot; 214ms
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ---- MSG 2: User follow-up ---- -->
+    <div class="msg-row" style="grid-row: auto;">
+      <div class="spine">
+        <div class="spine-dot user"></div>
+        <div class="spine-line"></div>
+      </div>
+      <div class="msg-body">
+        <div class="msg-head">
+          <span class="msg-role user">You</span>
+          <span class="msg-meta">14:29</span>
+        </div>
+        <div class="msg-content">
+          <p>Can you work out the ripple for a 1000&micro;F capacitor at 50mA? Also calculate what happens when I switch to the <code>llama3.1-8b</code> model &mdash; what's the memory difference between loading this as FP8 vs GGUF q4_k_m on my RTX PRO 6000?</p>
+        </div>
+      </div>
+      <div class="msg-gutter"></div>
+    </div>
+
+    <!-- ---- MSG 3: Assistant with tool call, critique, and format drift ---- -->
+    <div class="msg-row" style="grid-row: auto;">
+      <div class="spine">
+        <div class="spine-dot assistant"></div>
+        <div class="spine-line"></div>
+      </div>
+      <div class="msg-body">
+        <div class="msg-head">
+          <span class="msg-role assistant">vllm-qwen3-6-27b</span>
+          <span class="msg-meta">14:29</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <span class="msg-meta">342 tok</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <span class="msg-meta">2.8s</span>
+        </div>
+
+        <!-- Thinking block -->
+        <div class="thinking">
+          <button class="thinking-toggle">
+            <span>&#9654;</span>
+            <span>Thinking</span>
+            <span class="thinking-count">1,204 chars</span>
+          </button>
+          <div class="thinking-content">
+            For the ripple voltage, I'll use the standard capacitor discharge formula: Vr = I / (f &middot; C), where f is the ripple frequency at 100 Hz for full-wave rectification, C = 1000&micro;F, and I = 50mA. This gives Vr &asymp; 0.5V. For the memory comparison, the llama3.1-8b model is approximately 8 billion parameters. FP8 uses 1 byte per parameter for weights plus activations, roughly 16 GB peak. GGUF q4_k_m compresses weights to ~4.6 bits per parameter on average (not exactly 4 due to quantization overhead), so about 4.4 GB for the file, with peak RAM during loading around 6&ndash;7 GB. On a 96 GB card, both are well within bounds, but q4_k_m leaves far more headroom for context window allocations.
+          </div>
+        </div>
+
+        <div class="msg-content">
+          <h4>Ripple Voltage</h4>
+          <p>Using sympy for the exact calculation:</p>
+          <pre>Vr(pp) = I &divide; (f &middot; C)
+       = 0.05 &divide; (100 &middot; 0.001)
+       = <strong>0.50 V pp</strong></pre>
+          <p>That's manageable for most linear regulator inputs. You'd need roughly 3.5V headroom on the input after accounting for this ripple.</p>
+
+          <h4>Model Memory Comparison &mdash; llama3.1-8b</h4>
+          <p><strong>FP8 (safetensors):</strong> Weights at 8 bits &asymp; 8 GB file size. Activation overhead during inference typically doubles this, so expect <strong>14&ndash;18 GB VRAM</strong> peak depending on context window. With vLLM's PagedAttention, you get efficient KV cache sharing.</p>
+          <p><strong>GGUF q4_k_m:</strong> Compressed weights at ~4.55 bits per parameter average &asymp; <strong>4.4 GB file</strong>. Peak VRAM during inference with llama.cpp: <strong>6&ndash;7 GB</strong> even at full context, since activations stay in a tight buffer.</p>
+          <p>On your RTX PRO 6000 (96 GB), both run easily. The q4_k_m version leaves room to run the sidekick model concurrently. The FP8 version trades ~2 GB of precision for the ability to leverage vLLM's tensor-parallel serving pipeline.</p>
+        </div>
+
+        <!-- Format drift warning -->
+        <div class="drift">
+          <span class="drift-icon">&#9888;</span>
+          <span>Partial JSON in code block (qwen3.6-format-drift)</span>
+        </div>
+        <div class="drift-detail">
+          Model began a JSON table with <code>{"format": "comparison"}</code> then reverted to prose. Content is legible &mdash; this is a known Qwen output-style inconsistency at longer completions.
+        </div>
+      </div>
+      <div class="msg-gutter">
+        <div class="tool-call">
+          <div class="tool-connector"></div>
+          <div class="tool-name">
+            <span class="tool-icon">&#9003;</span>
+            sympy-math__evaluate
+          </div>
+          <dl class="tool-args">
+            <div><dt>expr</dt>&ensp;<dd>0.05 / (100 * 0.001)</dd></div>
+          </dl>
+          <div class="tool-result">
+            &check; 0.5 &middot; 48ms
+          </div>
+        </div>
+
+        <!-- VERDICT + CRITIQUE ANNOTATIONS -->
+        <div style="margin-top: 0.75rem;">
+          <div class="verdict minor">Minor Issues &middot; 2 findings</div>
+          <div class="critique-note" style="margin-bottom: 0.4rem;">
+            <div class="critique-ref">
+              Precision &middot; sidekick: llama3.1-8b
+              <span class="critique-severity warning">warning</span>
+            </div>
+            <div class="critique-span">"14&ndash;18 GB VRAM peak"</div>
+            <div class="critique-comment">The 18 GB upper bound assumes full batch-size activation. With tensor-parallel-size=1 and max-num-seqs=1, vLLM will hold closer to 12&ndash;14 GB. This is fine for a single-user setup but worth noting.</div>
+          </div>
+          <div class="critique-note">
+            <div class="critique-ref">
+              Accuracy
+              <span class="critique-severity info">info</span>
+            </div>
+            <div class="critique-span">"4.55 bits per parameter average"</div>
+            <div class="critique-comment">The q4_k_m scheme uses mixed precision: some layers at Q6_K (6 bits), others at Q4_0 (4 bits). The effective average is closer to 4.52, not 4.55. The difference is negligible in practice. The 4.4 GB file size figure is correct.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ---- MSG 4: User ---- -->
+    <div class="msg-row" style="grid-row: auto;">
+      <div class="spine">
+        <div class="spine-dot user"></div>
+        <div class="spine-line"></div>
+      </div>
+      <div class="msg-body">
+        <div class="msg-head">
+          <span class="msg-role user">You</span>
+          <span class="msg-meta">14:31</span>
+        </div>
+        <div class="msg-content">
+          <p>Got it. Let's go with q4_k_m then &mdash; I can run both models at once. What does the docker-compose service definition look like for the llama.cpp container with <code>-ngl 99 -fa 1 -c 32768</code> and the GGUF file at <code>/models/llama-3.1-8b.Q4_K_M.gguf</code>?</p>
+        </div>
+      </div>
+      <div class="msg-gutter"></div>
+    </div>
+
+    <!-- ---- MSG 5: Streaming assistant (in progress) ---- -->
+    <div class="msg-row" style="grid-row: auto;">
+      <div class="spine">
+        <div class="spine-dot streaming"></div>
+        <div class="spine-line"></div>
+      </div>
+      <div class="msg-body">
+        <div class="msg-head">
+          <span class="msg-role assistant">vllm-qwen3-6-27b</span>
+          <span class="msg-meta">14:32</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <span class="msg-meta">201 tok</span>
+          <span class="msg-meta-sep">&middot;</span>
+          <div class="stream-status">
+            <span class="stream-dot"></span>
+            67 tok/s
+          </div>
+        </div>
+        <div class="msg-content">
+          <p>Here's the service definition for your <code>services.json</code>:</p>
+          <pre>{
+  "llama-3.1-8b-q4": {
+    "alias": "llama-3.1-8b-q4",
+    "port": 3304,
+    "api_key": "llmd-a1b2c3d4",
+    "model_path": "/models/llama-3.1-8b.Q4_K_M.gguf",
+    "template_type": "llamacpp",
+    "params": {
+      "-ngl": "99",
+      "-fa": "1",
+      "-c": "32768"
+    }
+  }
+}</pre>
+          <p>This maps to a docker-compose service with the following key properties:</p>
+          <ul>
+            <li><strong>Container port</strong>: 8080 &rarr; host port 3304</li>
+            <li><strong>GPU access</strong>: <code>devices: count: all</code> &mdash; shares your RTX PRO 6000 with the vLLM container</li>
+            <li><strong>Flash attention</strong>: enabled via <code>-fa 1</code></li>
+            <li><strong>Full offload</strong>: all 99 layers on GPU via <code>-ngl 99</code></li>
+            <li><strong>Context</strong>: 32k tokens, which at q4_k_m consumes roughly <strong>4&ndash;5 GB VRAM</strong> for KV cache alone</li>
+          </ul>
+          <p>You can add this to <code>services.json</code> and the dashboard will regenerate <code>docker-compose.yml</code> on the next save. The container will register itself with Open WebUI at <code>http://localhost:3304/v1/chat/completions</code><span class="streaming-cursor"></span></p>
+        </div>
+        <div class="heartbeat">
+          <div class="heartbeat-line"></div>
+          <span>idle 0.3s &mdash; tool round gap</span>
+        </div>
+      </div>
+      <div class="msg-gutter">
+        <div class="tool-call" style="opacity: 0.5;">
+          <div class="tool-connector"></div>
+          <div class="tool-name">
+            <span class="tool-icon">&#9003;</span>
+            sympy-math__evaluate
+            <span class="tool-status running">&#9776; running</span>
+          </div>
+          <dl class="tool-args">
+            <div><dt>expr</dt>&ensp;<dd>KV_cache_bytes(32768, ...)</dd></div>
+          </dl>
+        </div>
+      </div>
+    </div>
+
+    <!-- Final spine to close -->
+    <div style="grid-column: 1; grid-row: auto;">
+      <div class="spine">
+        <div style="height: 60px;"></div>
+      </div>
+    </div>
+  </main>
+
+  <!-- ==================== INPUT BAR ==================== -->
+  <div class="input-bar" style="position: relative;">
+    <div class="input-status">
+      <span class="stream-dot"></span>
+      Streaming active &middot; type to queue
+    </div>
+    <div class="input-actions">
+      <button class="input-action">&#8899; image</button>
+    </div>
+    <div class="input-wrap">
+      <textarea class="input-textarea" placeholder="Reply to this conversation..." rows="1"></textarea>
+    </div>
+    <button class="input-send">&#9654;</button>
+  </div>
+
+  <div class="design-label">Warm Newspaper &middot; Source Serif 4 + IBM Plex Mono &middot; #BF3618 / #0D9488</div>
+</body>
+</html>

--- a/dashboard/chat/db.py
+++ b/dashboard/chat/db.py
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS messages (
     content         TEXT NOT NULL DEFAULT '',
     reasoning_content TEXT,
     model_service   TEXT,
+    error           TEXT,
     seq             INTEGER NOT NULL,
     created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 );
@@ -178,6 +179,7 @@ class ChatDB:
             ("conversations", "mcp_servers_json", "ALTER TABLE conversations ADD COLUMN mcp_servers_json TEXT"),
             ("messages", "tool_calls_json", "ALTER TABLE messages ADD COLUMN tool_calls_json TEXT"),
             ("messages", "parse_warning_json", "ALTER TABLE messages ADD COLUMN parse_warning_json TEXT"),
+            ("messages", "error", "ALTER TABLE messages ADD COLUMN error TEXT"),
             # No FK here: sqlite's ALTER TABLE can't add one, so project
             # detachment on delete is handled explicitly in delete_project.
             ("conversations", "project_id", "ALTER TABLE conversations ADD COLUMN project_id TEXT"),
@@ -493,6 +495,7 @@ class ChatDB:
             images_json=row["images_json"],
             tool_calls_json=row["tool_calls_json"],
             parse_warning_json=row["parse_warning_json"] if "parse_warning_json" in row.keys() else None,
+            error=row["error"] if "error" in row.keys() else None,
             seq=row["seq"],
             created_at=row["created_at"],
         )
@@ -545,11 +548,11 @@ class ChatDB:
         try:
             conn.execute(
                 """INSERT INTO messages
-                   (id, conversation_id, role, content, reasoning_content, model_service, images_json, tool_calls_json, parse_warning_json, seq)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   (id, conversation_id, role, content, reasoning_content, model_service, images_json, tool_calls_json, parse_warning_json, error, seq)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (msg.id, msg.conversation_id, msg.role, msg.content,
                  msg.reasoning_content, msg.model_service, msg.images_json, msg.tool_calls_json,
-                 msg.parse_warning_json, msg.seq),
+                 msg.parse_warning_json, msg.error, msg.seq),
             )
             if should_close:
                 conn.commit()
@@ -963,6 +966,42 @@ class ChatDB:
 
     def fail_chat_run(self, run_id: str, error: str) -> Optional[ChatRun]:
         return self.update_chat_run_status(run_id, ChatRunStatus.FAILED, error=error)
+
+    def fail_chat_run_with_message(
+        self, run_id: str, error: str, assistant_msg: Message,
+    ) -> Optional[Message]:
+        """Atomically save a partial assistant message and mark the run failed.
+
+        Terminal-guarded: if the run is already terminal (e.g. cancelled), the
+        guarded UPDATE changes 0 rows and the transaction is rolled back.
+        On success returns the persisted message (with seq and error assigned).
+        """
+        now = "strftime('%Y-%m-%dT%H:%M:%SZ','now')"
+        terminal_ph = ",".join("?" for _ in TERMINAL_STATUSES)
+        conn = self._get_conn()
+        try:
+            assistant_msg.seq = self.next_seq(assistant_msg.conversation_id, conn=conn)
+            assistant_msg.error = error
+            self.add_message(assistant_msg, conn=conn)
+            cur = conn.execute(
+                f"""UPDATE chat_runs SET status = ?, error = ?, completed_at = {now}
+                    WHERE id = ? AND status NOT IN ({terminal_ph})""",
+                (ChatRunStatus.FAILED, error, run_id, *sorted(TERMINAL_STATUSES)),
+            )
+            if cur.rowcount == 0:
+                conn.rollback()
+                return None
+            conn.execute(
+                f"UPDATE conversations SET updated_at = {now} WHERE id = ?",
+                (assistant_msg.conversation_id,),
+            )
+            conn.commit()
+            return assistant_msg
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            self._close_conn(conn)
 
     def cancel_chat_run(self, run_id: str) -> Optional[ChatRun]:
         return self.update_chat_run_status(run_id, ChatRunStatus.CANCELLED)

--- a/dashboard/chat/models.py
+++ b/dashboard/chat/models.py
@@ -15,6 +15,7 @@ class Message:
     images_json: Optional[str] = None
     tool_calls_json: Optional[str] = None
     parse_warning_json: Optional[str] = None
+    error: Optional[str] = None
     created_at: Optional[str] = None
 
     def to_dict(self):
@@ -36,6 +37,8 @@ class Message:
             d["tool_calls"] = tool_calls
         if parse_warning:
             d["parse_warning"] = parse_warning
+        if self.error:
+            d["error"] = self.error
         return d
 
 

--- a/dashboard/chat/persistence.py
+++ b/dashboard/chat/persistence.py
@@ -21,7 +21,7 @@ orchestration (recovery, the cancel registry, list/active lookups) stays on the
 DB directly — those are durable-coordination concerns, not part of running a
 single stream, and an ephemeral mode wires up its own (or no) manager.
 """
-from .models import ChatRun
+from .models import ChatRun, Message
 from .runs import ChatRunStatus
 
 
@@ -47,8 +47,12 @@ class PersistencePolicy:
         the run was already terminal (cancelled mid-stream)."""
         raise NotImplementedError
 
-    def fail(self, run_id, error):
-        """Mark the run failed with the given error text."""
+    def fail(self, run_id, error, partial_msg=None):
+        """Mark the run failed with the given error text.
+
+        If partial_msg is given, persist it as an error message with the
+        accumulated content/reasoning before the failure.
+        """
         raise NotImplementedError
 
     def cancel(self, run_id):
@@ -73,8 +77,11 @@ class DbPersistencePolicy(PersistencePolicy):
     def complete(self, run_id, assistant_msg, artifacts):
         return self.db.complete_run_with_message(run_id, assistant_msg, artifacts)
 
-    def fail(self, run_id, error):
-        self.db.fail_chat_run(run_id, error)
+    def fail(self, run_id, error, partial_msg=None):
+        if partial_msg is not None:
+            self.db.fail_chat_run_with_message(run_id, error, partial_msg)
+        else:
+            self.db.fail_chat_run(run_id, error)
 
     def cancel(self, run_id):
         self.db.cancel_chat_run(run_id)
@@ -108,7 +115,7 @@ class NullPersistencePolicy(PersistencePolicy):
         self.messages.append(assistant_msg)
         return assistant_msg
 
-    def fail(self, run_id, error):
+    def fail(self, run_id, error, partial_msg=None):
         pass
 
     def cancel(self, run_id):

--- a/dashboard/docker_utils.py
+++ b/dashboard/docker_utils.py
@@ -127,6 +127,7 @@ def get_docker_services():
     model_path_map = {}
     model_name_map = {}
     kind_map = {}
+    favorite_map = {}
     for service_name in allowed_services:
         config = compose_mgr.get_service_from_db(service_name)
         if config:
@@ -135,6 +136,7 @@ def get_docker_services():
             model_path_map[service_name] = config.get("model_path")
             model_name_map[service_name] = config.get("model_name")
             kind_map[service_name] = _service_kind(config)
+            favorite_map[service_name] = bool(config.get("favorite", False))
 
     # Get Open WebUI registered URLs (one query for all services)
     openwebui_urls = get_openwebui_registered_urls()
@@ -177,6 +179,7 @@ def get_docker_services():
                 "model_size": model_size,
                 "model_size_str": model_size_str,
                 "kind": kind_map.get(service_name, "chat"),
+                "favorite": favorite_map.get(service_name, False),
             }
 
     # Build complete services list from compose file
@@ -204,6 +207,7 @@ def get_docker_services():
                     "model_size": model_size,
                     "model_size_str": model_size_str,
                     "kind": kind_map.get(service_name, "chat"),
+                    "favorite": favorite_map.get(service_name, False),
                 }
             )
 

--- a/dashboard/frontend/src/components/ServicesTable.jsx
+++ b/dashboard/frontend/src/components/ServicesTable.jsx
@@ -17,6 +17,19 @@ function isInfra(name) {
   return name === 'open-webui'
 }
 
+function FavoriteButton({ service, onToggleFavorite }) {
+  if (isInfra(service.name)) return null
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onToggleFavorite(service.name) }}
+      className="shrink-0 p-0.5 -ml-1 rounded hover:bg-surface-muted cursor-pointer transition-colors"
+      title={service.favorite ? 'Remove from favorites' : 'Add to favorites'}
+    >
+      <i className={service.favorite ? 'fa-solid fa-star text-amber-400' : 'fa-regular fa-star text-fg-subtle hover:text-fg-muted'}></i>
+    </button>
+  )
+}
+
 function StatusDot({ status }) {
   const color = status === 'running'
     ? 'bg-success'
@@ -167,7 +180,7 @@ function Toast({ message, onDone }) {
 
 export default function ServicesTable() {
   const navigate = useNavigate()
-  const { services, error, connected, refresh } = useServicesSSE()
+  const { services, error, connected, refresh, toggleFavorite } = useServicesSSE()
   const [transitioning, setTransitioning] = useState({})
   const [toast, setToast] = useState(null)
   const [search, setSearch] = useState('')
@@ -205,6 +218,14 @@ export default function ServicesTable() {
     }
   }, [refresh])
 
+  const handleToggleFavorite = useCallback(async (name) => {
+    try {
+      await toggleFavorite(name)
+    } catch (err) {
+      setToast(`Failed to toggle favorite for ${name}: ${err.message}`)
+    }
+  }, [toggleFavorite])
+
   const handleEdit = (name) => {
     navigate(`/services/${name}`)
   }
@@ -235,6 +256,9 @@ export default function ServicesTable() {
 
   const term = search.trim().toLowerCase()
   const visible = term ? services.filter(s => s.name.toLowerCase().includes(term)) : services
+  const favVisible = visible.filter(s => s.favorite)
+  const otherVisible = visible.filter(s => !s.favorite)
+  const showSeparator = favVisible.length > 0 && otherVisible.length > 0
 
   function ConnectionDot({ connected, error }) {
     let color
@@ -314,20 +338,39 @@ export default function ServicesTable() {
               : `No services matching "${search}"`}
           </div>
         ) : (
-          visible.map(svc => (
-            <ServiceCard
-              key={svc.name}
-              service={svc}
-              transitioning={transitioning}
-              onStart={handleStart}
-              onStop={handleStop}
-              onRestart={handleRestart}
-              onSetPublicPort={handleSetPublicPort}
-              onEdit={handleEdit}
-              onViewLogs={handleViewLogs}
-              onDelete={handleDelete}
-            />
-          ))
+          <>
+            {favVisible.map(svc => (
+              <ServiceCard
+                key={svc.name}
+                service={svc}
+                transitioning={transitioning}
+                onStart={handleStart}
+                onStop={handleStop}
+                onRestart={handleRestart}
+                onSetPublicPort={handleSetPublicPort}
+                onToggleFavorite={handleToggleFavorite}
+                onEdit={handleEdit}
+                onViewLogs={handleViewLogs}
+                onDelete={handleDelete}
+              />
+            ))}
+            {showSeparator && <div className="border-t border-border my-2" />}
+            {otherVisible.map(svc => (
+              <ServiceCard
+                key={svc.name}
+                service={svc}
+                transitioning={transitioning}
+                onStart={handleStart}
+                onStop={handleStop}
+                onRestart={handleRestart}
+                onSetPublicPort={handleSetPublicPort}
+                onToggleFavorite={handleToggleFavorite}
+                onEdit={handleEdit}
+                onViewLogs={handleViewLogs}
+                onDelete={handleDelete}
+              />
+            ))}
+          </>
         )}
       </div>
 
@@ -358,20 +401,43 @@ export default function ServicesTable() {
                 </td>
               </tr>
             ) : (
-              visible.map(svc => (
-                <ServiceRow
-                  key={svc.name}
-                  service={svc}
-                  transitioning={transitioning}
-                  onStart={handleStart}
-                  onStop={handleStop}
-                  onRestart={handleRestart}
-                  onSetPublicPort={handleSetPublicPort}
-                  onEdit={handleEdit}
-                  onViewLogs={handleViewLogs}
-                  onDelete={handleDelete}
-                />
-              ))
+              <>
+                {favVisible.map(svc => (
+                  <ServiceRow
+                    key={svc.name}
+                    service={svc}
+                    transitioning={transitioning}
+                    onStart={handleStart}
+                    onStop={handleStop}
+                    onRestart={handleRestart}
+                    onSetPublicPort={handleSetPublicPort}
+                    onToggleFavorite={handleToggleFavorite}
+                    onEdit={handleEdit}
+                    onViewLogs={handleViewLogs}
+                    onDelete={handleDelete}
+                  />
+                ))}
+                {showSeparator && (
+                  <tr>
+                    <td colSpan={7} className="px-6 py-1.5 bg-surface-strong border-y border-border-subtle" />
+                  </tr>
+                )}
+                {otherVisible.map(svc => (
+                  <ServiceRow
+                    key={svc.name}
+                    service={svc}
+                    transitioning={transitioning}
+                    onStart={handleStart}
+                    onStop={handleStop}
+                    onRestart={handleRestart}
+                    onSetPublicPort={handleSetPublicPort}
+                    onToggleFavorite={handleToggleFavorite}
+                    onEdit={handleEdit}
+                    onViewLogs={handleViewLogs}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </>
             )}
           </tbody>
         </table>
@@ -440,7 +506,7 @@ function PortCell({ service, onSetPublicPort }) {
 
 // Mobile (md:hidden) stacked card — same data/actions as a table row,
 // no horizontal scroll (issue #39).
-function ServiceCard({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onEdit, onViewLogs, onDelete }) {
+function ServiceCard({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onToggleFavorite, onEdit, onViewLogs, onDelete }) {
   const engine = getEngine(service.name)
   const infra = isInfra(service.name)
 
@@ -448,6 +514,7 @@ function ServiceCard({ service, transitioning, onStart, onStop, onRestart, onSet
     <div className={`rounded-lg border border-border p-3 ${service.status === 'running' ? 'bg-success-subtle' : 'bg-surface-muted'}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex items-center font-medium text-fg">
+          <FavoriteButton service={service} onToggleFavorite={onToggleFavorite} />
           {!infra ? (
             <button
               onClick={() => onEdit(service.name)}
@@ -514,7 +581,7 @@ function ServiceCard({ service, transitioning, onStart, onStop, onRestart, onSet
   )
 }
 
-function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onEdit, onViewLogs, onDelete }) {
+function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetPublicPort, onToggleFavorite, onEdit, onViewLogs, onDelete }) {
   const engine = getEngine(service.name)
   const infra = isInfra(service.name)
 
@@ -523,6 +590,7 @@ function ServiceRow({ service, transitioning, onStart, onStop, onRestart, onSetP
       <td className="px-6 py-3 whitespace-nowrap">
         <div className="flex flex-col">
           <div className="flex items-center font-medium text-fg">
+            <FavoriteButton service={service} onToggleFavorite={onToggleFavorite} />
             {!infra ? (
               <button
                 onClick={() => onEdit(service.name)}

--- a/dashboard/frontend/src/components/chat/ChatPage.jsx
+++ b/dashboard/frontend/src/components/chat/ChatPage.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import ChatSidebar from './ChatSidebar'
 import ChatArea from './ChatArea'
 import ProjectPage from './ProjectPage'
 import ProjectChatSplit from './ProjectChatSplit'
+import SidebarSplit from './SidebarSplit'
 import useConversations from '../../hooks/useConversations'
 import useProjects from '../../hooks/useProjects'
 import useChat from '../../hooks/useChat'
@@ -284,25 +284,47 @@ export default function ChatPage() {
     if (shouldNavigate) navigate('/chat')
   }, [removeMany, refreshProjects, activeWillBeDeleted, navigate, confirmDiscardEdits])
 
+  const sidebarRef = useRef(null)
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (!(e.metaKey || e.ctrlKey)) return
+      const active = document.activeElement
+      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) return
+      if (e.key === '[') {
+        e.preventDefault()
+        sidebarRef.current?.adjustWidth(-20)
+      } else if (e.key === ']') {
+        e.preventDefault()
+        sidebarRef.current?.adjustWidth(20)
+      } else if (e.key === 'b') {
+        e.preventDefault()
+        sidebarRef.current?.toggleCollapse()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   return (
-    <div className="flex-1 flex overflow-hidden">
-      <ChatSidebar
-        conversations={conversations}
-        activeId={convId}
-        onSelect={handleSelect}
-        onCreate={handleCreate}
-        onDelete={handleDelete}
-        onDeleteMany={handleDeleteMany}
-        onRename={handleRename}
-        projects={projects}
-        activeProjectId={projectId || null}
-        onOpenProject={handleOpenProject}
-        onCreateProject={handleCreateProject}
-        onRenameProject={renameProject}
-        onDeleteProject={handleDeleteProject}
-        onCreateInProject={handleCreateInProject}
-        onMoveMany={handleMoveMany}
-      />
+    <SidebarSplit
+      ref={sidebarRef}
+      conversations={conversations}
+      activeId={convId}
+      onSelect={handleSelect}
+      onCreate={handleCreate}
+      onDelete={handleDelete}
+      onDeleteMany={handleDeleteMany}
+      onRename={handleRename}
+      projects={projects}
+      activeProjectId={projectId || null}
+      onOpenProject={handleOpenProject}
+      onCreateProject={handleCreateProject}
+      onRenameProject={renameProject}
+      onDeleteProject={handleDeleteProject}
+      onCreateInProject={handleCreateInProject}
+      onMoveMany={handleMoveMany}
+    >
       {projectId ? (
         <ProjectPage
           project={projects.find(p => p.id === projectId) || null}
@@ -343,6 +365,6 @@ export default function ChatPage() {
       />
       </ProjectChatSplit>
       )}
-    </div>
+    </SidebarSplit>
   )
 }

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,15 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 
-const COLLAPSED_KEY = 'llmdock.chatSidebar.collapsed'
-
-function readCollapsed() {
-  try {
-    return localStorage.getItem(COLLAPSED_KEY) === 'true'
-  } catch {
-    return false
-  }
-}
-
 function ConversationItem({ conv, activeId, depth, selectMode, selected, onToggleSelect, confirmDelete, setConfirmDelete, onSelect, onDelete, renaming, onRenameStart, onRenameConfirm }) {
   const isSpinoff = !!conv.parent_conversation_id
   const inputRef = useRef(null)
@@ -312,8 +302,7 @@ function ProjectHeader({ project, collapsed, active, onToggleCollapse, onOpenPro
   )
 }
 
-export default function ChatSidebar({ conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], activeProjectId = null, onOpenProject, onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
-  const [collapsed, setCollapsed] = useState(readCollapsed)
+export default function ChatSidebar({ onCollapse, conversations, activeId, onSelect, onCreate, onDelete, onDeleteMany, onRename, projects = [], activeProjectId = null, onOpenProject, onCreateProject, onRenameProject, onDeleteProject, onCreateInProject, onMoveMany }) {
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [renaming, setRenaming] = useState(null)
   const [confirmDeleteProject, setConfirmDeleteProject] = useState(null)
@@ -498,55 +487,13 @@ export default function ChatSidebar({ conversations, activeId, onSelect, onCreat
     )
   }
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(COLLAPSED_KEY, String(collapsed))
-    } catch {
-      /* localStorage unavailable — keep in-memory state only */
-    }
-  }, [collapsed])
-
-  if (collapsed) {
-    // The collapsed rail mirrors the main Sidebar's geometry (h-16
-    // bordered header, w-8 h-8 toggle, text-sm icon) so the expander
-    // chevrons of all collapsed panels sit on one line.
-    return (
-      <div
-        className="w-10 border-r border-border flex flex-col items-center bg-app flex-shrink-0"
-        data-testid="chat-sidebar-collapsed"
-      >
-        <div className="h-16 w-full border-b border-border-subtle flex items-center justify-center flex-shrink-0">
-          <button
-            onClick={() => setCollapsed(false)}
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
-            title="Show conversations"
-            aria-label="Show conversations"
-            aria-expanded={false}
-          >
-            <i className="fa-solid fa-angles-right text-sm"></i>
-          </button>
-        </div>
-        <div className="py-4">
-          <button
-            onClick={onCreate}
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
-            title="New conversation"
-            aria-label="New conversation"
-          >
-            <i className="fa-solid fa-plus text-sm"></i>
-          </button>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className="w-72 border-r border-border flex flex-col bg-app flex-shrink-0">
+    <div className="w-full border-r border-border flex flex-col bg-app flex-shrink-0 h-full">
       {/* Header */}
       <div className="p-3 border-b border-border">
         <div className="flex justify-between items-center mb-2">
           <button
-            onClick={() => setCollapsed(true)}
+            onClick={onCollapse}
             className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
             title="Hide conversations"
             aria-label="Hide conversations"

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -489,19 +489,24 @@ export default function ChatSidebar({ onCollapse, conversations, activeId, onSel
 
   return (
     <div className="w-full border-r border-border flex flex-col bg-app flex-shrink-0 h-full">
-      {/* Header */}
+      {/* Title bar */}
+      <div className="px-3 py-2 border-b border-border flex items-center gap-2 flex-shrink-0">
+        <i className="fa-solid fa-message text-xs text-blue-400/80 flex-shrink-0"></i>
+        <span className="flex-1 min-w-0 truncate text-xs font-semibold text-fg uppercase tracking-wide">
+          Conversations
+        </span>
+        <button
+          onClick={onCollapse}
+          className="text-fg-subtle hover:text-fg p-1 -m-1 cursor-pointer"
+          title="Hide conversations"
+          aria-label="Hide conversations"
+        >
+          <i className="fa-solid fa-angles-left text-xs"></i>
+        </button>
+      </div>
+
+      {/* Actions */}
       <div className="p-3 border-b border-border">
-        <div className="flex justify-between items-center mb-2">
-          <button
-            onClick={onCollapse}
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface-muted cursor-pointer"
-            title="Hide conversations"
-            aria-label="Hide conversations"
-            aria-expanded={true}
-          >
-            <i className="fa-solid fa-angles-left text-xs"></i>
-          </button>
-        </div>
         <button
           onClick={onCreate}
           className="w-full px-3 py-2 bg-accent-strong hover:bg-accent-hover text-fg-inverse rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"

--- a/dashboard/frontend/src/components/chat/ChatSidebar.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.jsx
@@ -501,7 +501,7 @@ export default function ChatSidebar({ onCollapse, conversations, activeId, onSel
           title="Hide conversations"
           aria-label="Hide conversations"
         >
-          <i className="fa-solid fa-angles-left text-xs"></i>
+          <i className="fa-solid fa-angles-left text-sm"></i>
         </button>
       </div>
 

--- a/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
+++ b/dashboard/frontend/src/components/chat/ChatSidebar.test.jsx
@@ -24,7 +24,7 @@ const conversations = [
   { id: 'D',  title: 'D',  parent_conversation_id: null, updated_at: '2026-01-01' },
 ]
 
-function renderSidebar() {
+function renderSidebar(overrides) {
   return render(
     <ChatSidebar
       conversations={conversations}
@@ -33,6 +33,10 @@ function renderSidebar() {
       onCreate={() => {}}
       onDelete={() => {}}
       onDeleteMany={() => {}}
+      collapsed={false}
+      onCollapse={() => {}}
+      onExpand={() => {}}
+      {...overrides}
     />
   )
 }
@@ -177,6 +181,9 @@ describe('ChatSidebar project grouping', () => {
         onDeleteProject={() => {}}
         onCreateInProject={() => {}}
         onMoveMany={() => {}}
+        collapsed={false}
+        onCollapse={() => {}}
+        onExpand={() => {}}
         {...overrides}
       />
     )
@@ -215,6 +222,9 @@ describe('ChatSidebar project grouping', () => {
         onDelete={() => {}}
         onDeleteMany={() => {}}
         projects={[{ id: 'p9', name: 'Ghost', conversation_count: 3 }]}
+        collapsed={false}
+        onCollapse={() => {}}
+        onExpand={() => {}}
       />
     )
     expect(screen.queryByText('Empty project')).toBeNull()
@@ -323,6 +333,9 @@ describe('ChatSidebar project grouping', () => {
         onCreate={() => {}}
         onDelete={() => {}}
         onDeleteMany={() => {}}
+        collapsed={false}
+        onCollapse={() => {}}
+        onExpand={() => {}}
       />
     )
     for (const t of ['A', 'A1', 'B', 'C', 'D']) {
@@ -342,6 +355,9 @@ describe('ChatSidebar active-run indicator', () => {
         onCreate={() => {}}
         onDelete={() => {}}
         onDeleteMany={() => {}}
+        collapsed={false}
+        onCollapse={() => {}}
+        onExpand={() => {}}
       />
     )
   }
@@ -382,43 +398,10 @@ describe('ChatSidebar active-run indicator', () => {
 })
 
 describe('ChatSidebar collapse', () => {
-  afterEach(() => localStorage.removeItem('llmdock.chatSidebar.collapsed'))
-
-  it('collapses to a thin rail and expands back, persisting the choice', () => {
-    renderSidebar()
-    expect(screen.getByText('New Conversation')).toBeInTheDocument()
-
+  it('calls onCollapse when the hide button is clicked', () => {
+    const onCollapse = vi.fn()
+    renderSidebar({ onCollapse })
     fireEvent.click(screen.getByLabelText('Hide conversations'))
-    expect(screen.getByTestId('chat-sidebar-collapsed')).toBeInTheDocument()
-    expect(screen.queryByText('New Conversation')).toBeNull()
-    expect(localStorage.getItem('llmdock.chatSidebar.collapsed')).toBe('true')
-
-    fireEvent.click(screen.getByLabelText('Show conversations'))
-    expect(screen.queryByTestId('chat-sidebar-collapsed')).toBeNull()
-    expect(screen.getByText('New Conversation')).toBeInTheDocument()
-    expect(localStorage.getItem('llmdock.chatSidebar.collapsed')).toBe('false')
-  })
-
-  it('starts collapsed when the stored preference says so', () => {
-    localStorage.setItem('llmdock.chatSidebar.collapsed', 'true')
-    renderSidebar()
-    expect(screen.getByTestId('chat-sidebar-collapsed')).toBeInTheDocument()
-  })
-
-  it('the collapsed rail still offers New Conversation', () => {
-    localStorage.setItem('llmdock.chatSidebar.collapsed', 'true')
-    const onCreate = vi.fn()
-    render(
-      <ChatSidebar
-        conversations={conversations}
-        activeId={null}
-        onSelect={() => {}}
-        onCreate={onCreate}
-        onDelete={() => {}}
-        onDeleteMany={() => {}}
-      />
-    )
-    fireEvent.click(screen.getByLabelText('New conversation'))
-    expect(onCreate).toHaveBeenCalled()
+    expect(onCollapse).toHaveBeenCalled()
   })
 })

--- a/dashboard/frontend/src/components/chat/MessageBubble.jsx
+++ b/dashboard/frontend/src/components/chat/MessageBubble.jsx
@@ -79,6 +79,14 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
           <ThinkingBlock content={message.reasoning_content} />
         )}
 
+        {/* Error banner — shown when the model errored mid-generation */}
+        {!isUser && message.error && (
+          <div className="mb-2 rounded px-3 py-2 text-xs border border-danger bg-danger-subtle text-danger-fg">
+            <i className="fa-solid fa-triangle-exclamation mr-1.5"></i>
+            Generation failed: {message.error}
+          </div>
+        )}
+
         {/* Format-drift chip — flags Qwen3.6-style failure modes. Prefers
             persisted warning, falls back to client-side detection so older
             messages without parse_warning_json still surface a chip. */}
@@ -122,7 +130,9 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
         )}
 
         {/* Message content — hairline block with a colored left accent
-            spine, not a filled rounded bubble. */}
+            spine, not a filled rounded bubble. Only render if there's
+            content, images, or we're in edit mode. */}
+        {(message.content || messageImages.length > 0 || editing) && (
         <div className={`rounded border border-hairline border-l-2 px-4 py-3 ${
           isUser
             ? 'border-l-accent-strong bg-elevated text-fg'
@@ -171,8 +181,9 @@ export default function MessageBubble({ message, critique, critiqueLoading, hasS
                 </ReactMarkdown>
               </div>
             )
-          )}
+           )}
         </div>
+        )}
 
         {/* Action buttons */}
         {!isTemp && (

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -1,21 +1,12 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import ProjectExplorerPane from './ProjectExplorerPane'
 import ProjectFileEditor from './ProjectFileEditor'
+import useResizableWidth from '../../hooks/useResizableWidth'
 
 const WIDTH_KEY = 'llmdock.chatExplorer.width'
 const COLLAPSED_KEY = 'llmdock.chatExplorer.collapsed'
-
 const MIN_WIDTH = 160
 const MAX_FRACTION = 0.45
-
-function readStoredWidth() {
-  try {
-    const v = parseInt(localStorage.getItem(WIDTH_KEY), 10)
-    return Number.isFinite(v) && v >= MIN_WIDTH ? v : null
-  } catch {
-    return null
-  }
-}
 
 function readStoredCollapsed() {
   try {
@@ -32,16 +23,17 @@ function readStoredCollapsed() {
 // the conversation stays loaded underneath.
 export default function ProjectChatSplit({ project, conversationId, refreshKey = 0, onEditorDirtyChange, children }) {
   const [collapsed, setCollapsed] = useState(readStoredCollapsed)
-  // null = never resized: the strip uses the 20% default until the first
-  // drag pins a pixel width.
-  const [width, setWidth] = useState(readStoredWidth)
-  const [dragging, setDragging] = useState(false)
+  const { containerRef, currentWidth, dragging, startDrag } = useResizableWidth({
+    storageKey: WIDTH_KEY,
+    minWidth: MIN_WIDTH,
+    maxFraction: MAX_FRACTION,
+    defaultWidthPx: null,
+  })
   // {path, isNew} when the editor overlay is open.
   const [editing, setEditing] = useState(null)
   // Editor saves bump this so the pane re-reads the tree (a saved new
   // file must appear); combined with the parent's refreshKey.
   const [savedBump, setSavedBump] = useState(0)
-  const containerRef = useRef(null)
   const dirtyRef = useRef(false)
 
   const projectId = project?.id
@@ -71,55 +63,6 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
     try { localStorage.setItem(COLLAPSED_KEY, String(collapsed)) } catch { /* ignore */ }
   }, [collapsed])
 
-  useEffect(() => {
-    if (width == null) return
-    try { localStorage.setItem(WIDTH_KEY, String(width)) } catch { /* ignore */ }
-  }, [width])
-
-  // A stored width is only known to fit the display it was saved on. Track
-  // the container's current 45% bound and clamp at render — otherwise a
-  // width persisted on a wide window swallows the whole split (and the
-  // chat) after the window narrows, until the next drag.
-  const [maxWidth, setMaxWidth] = useState(null)
-  useLayoutEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const measure = () => {
-      const w = el.getBoundingClientRect().width
-      if (w > 0) setMaxWidth(Math.max(MIN_WIDTH, Math.floor(w * MAX_FRACTION)))
-    }
-    measure()
-    if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', measure)
-      return () => window.removeEventListener('resize', measure)
-    }
-    const ro = new ResizeObserver(measure)
-    ro.observe(el)
-    return () => ro.disconnect()
-    // Re-attach when the split appears: with no project there IS no
-    // container, and the ref is still null on that first pass.
-  }, [projectId])
-  const shownWidth = width != null && maxWidth != null ? Math.min(width, maxWidth) : width
-
-  // Divider drag: window-level listeners while dragging, clamped to
-  // [MIN_WIDTH, 45% of the split container].
-  useEffect(() => {
-    if (!dragging) return
-    const onMove = (e) => {
-      const rect = containerRef.current?.getBoundingClientRect()
-      if (!rect) return
-      const max = Math.max(MIN_WIDTH, Math.floor(rect.width * MAX_FRACTION))
-      setWidth(Math.min(Math.max(e.clientX - rect.left, MIN_WIDTH), max))
-    }
-    const onUp = () => setDragging(false)
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-    }
-  }, [dragging])
-
   const handleOpenFile = useCallback((path, isNew) => {
     // Re-clicking the open file is a no-op (nothing would be discarded —
     // confirming just remounts the same editor).
@@ -142,7 +85,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
         // Same geometry as the other collapsed rails (main Sidebar,
         // ChatSidebar): h-16 bordered header, w-8 h-8 toggle, text-sm
         // icon — the expander chevrons of all collapsed panels line up.
-        <div className="w-10 flex-shrink-0 border-r border-border bg-app flex flex-col items-center">
+        <div className="w-10 flex-shrink-0 border-r border-border-subtle flex flex-col items-center bg-app">
           <div className="h-16 w-full border-b border-border-subtle flex items-center justify-center flex-shrink-0">
             <button
               onClick={() => setCollapsed(false)}
@@ -166,7 +109,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
         className="flex-shrink-0 border-r border-border overflow-hidden"
         style={{
           display: collapsed ? 'none' : undefined,
-          width: shownWidth != null ? `${shownWidth}px` : '20%',
+          width: currentWidth != null ? `${currentWidth}px` : '20%',
           minWidth: `${MIN_WIDTH}px`,
         }}
         data-testid="explorer-strip"
@@ -181,7 +124,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
       </div>
       {!collapsed && (
         <div
-          onMouseDown={(e) => { e.preventDefault(); setDragging(true) }}
+          onMouseDown={startDrag}
           className={`w-1.5 flex-shrink-0 cursor-col-resize -ml-1 z-10 ${
             dragging ? 'bg-accent-strong/40' : 'hover:bg-accent-strong/30'
           }`}

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -96,8 +96,10 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
-          <div className="py-4">
-            <i className="fa-solid fa-folder text-sm text-amber-500/50" title={project.name}></i>
+          <div className="flex-1 flex items-center justify-center py-4 overflow-hidden">
+            <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }} title={project.name}>
+              {project.name}
+            </span>
           </div>
         </div>
       )}

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -96,7 +96,7 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
-          <div className="flex-1 flex items-center justify-center py-4 overflow-hidden">
+          <div className="py-4 overflow-hidden">
             <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }} title={project.name}>
               {project.name}
             </span>

--- a/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectChatSplit.jsx
@@ -96,10 +96,15 @@ export default function ProjectChatSplit({ project, conversationId, refreshKey =
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
-          <div className="py-4 overflow-hidden">
-            <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }} title={project.name}>
+          <div className="py-4 overflow-hidden w-full flex items-center justify-center">
+            <button
+              onClick={() => setCollapsed(false)}
+              className="text-[10px] font-semibold text-fg-subtle hover:text-fg uppercase tracking-widest cursor-pointer"
+              style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }}
+              title={`Show ${project.name} files`}
+            >
               {project.name}
-            </span>
+            </button>
           </div>
         </div>
       )}

--- a/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
+++ b/dashboard/frontend/src/components/chat/ProjectExplorerPane.jsx
@@ -130,7 +130,7 @@ export default function ProjectExplorerPane({ project, refreshKey = 0, editingPa
           title="Hide file explorer"
           aria-label="Hide file explorer"
         >
-          <i className="fa-solid fa-angles-left text-xs"></i>
+          <i className="fa-solid fa-angles-left text-sm"></i>
         </button>
       </div>
 

--- a/dashboard/frontend/src/components/chat/SidebarSplit.jsx
+++ b/dashboard/frontend/src/components/chat/SidebarSplit.jsx
@@ -61,7 +61,7 @@ const SidebarSplit = forwardRef(function SidebarSplit({ children, ...sidebarProp
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
-          <div className="flex-1 flex items-center justify-center py-4 overflow-hidden">
+          <div className="py-4 overflow-hidden">
             <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }}>
               Conversations
             </span>

--- a/dashboard/frontend/src/components/chat/SidebarSplit.jsx
+++ b/dashboard/frontend/src/components/chat/SidebarSplit.jsx
@@ -61,10 +61,15 @@ const SidebarSplit = forwardRef(function SidebarSplit({ children, ...sidebarProp
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
-          <div className="py-4 overflow-hidden">
-            <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }}>
+          <div className="py-4 overflow-hidden w-full flex items-center justify-center">
+            <button
+              onClick={handleExpand}
+              className="text-[10px] font-semibold text-fg-subtle hover:text-fg uppercase tracking-widest cursor-pointer"
+              style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }}
+              title="Show conversations"
+            >
               Conversations
-            </span>
+            </button>
           </div>
         </div>
       )}

--- a/dashboard/frontend/src/components/chat/SidebarSplit.jsx
+++ b/dashboard/frontend/src/components/chat/SidebarSplit.jsx
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
+import ChatSidebar from './ChatSidebar'
+import useResizableWidth from '../../hooks/useResizableWidth'
+
+const COLLAPSED_KEY = 'llmdock.chatSidebar.collapsed'
+const WIDTH_KEY = 'llmdock.chatSidebar.width'
+const MIN_WIDTH = 200
+const MAX_FRACTION = 0.35
+const DEFAULT_WIDTH = 288
+
+function readCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+const SidebarSplit = forwardRef(function SidebarSplit({ children, ...sidebarProps }, ref) {
+  const [collapsed, setCollapsed] = useState(readCollapsed)
+  const { containerRef, currentWidth, dragging, startDrag, setCurrentWidth } = useResizableWidth({
+    storageKey: WIDTH_KEY,
+    minWidth: MIN_WIDTH,
+    maxFraction: MAX_FRACTION,
+    defaultWidthPx: DEFAULT_WIDTH,
+  })
+
+  useImperativeHandle(ref, () => ({
+    adjustWidth: (delta) => {
+      const el = containerRef.current
+      if (!el) return
+      const max = Math.max(MIN_WIDTH, Math.floor(el.getBoundingClientRect().width * MAX_FRACTION))
+      setCurrentWidth(prev => Math.min(Math.max(prev + delta, MIN_WIDTH), max))
+    },
+    toggleCollapse: () => setCollapsed(prev => !prev),
+  }), [setCurrentWidth, containerRef])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLLAPSED_KEY, String(collapsed))
+    } catch {
+      /* ignore */
+    }
+  }, [collapsed])
+
+  const handleCollapse = useCallback(() => setCollapsed(true), [])
+  const handleExpand = useCallback(() => setCollapsed(false), [])
+
+  return (
+    <div ref={containerRef} className="flex-1 flex overflow-hidden">
+      {collapsed && (
+        <div className="w-10 flex-shrink-0 border-r border-border flex flex-col items-center bg-app">
+          <div className="h-16 w-full border-b border-border-subtle flex items-center justify-center flex-shrink-0">
+            <button
+              onClick={handleExpand}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-fg-muted hover:text-fg hover:bg-surface/60 transition-colors cursor-pointer"
+              title="Show conversations"
+              aria-label="Show conversations"
+              aria-expanded={false}
+            >
+              <i className="fa-solid fa-angles-right text-sm"></i>
+            </button>
+          </div>
+        </div>
+      )}
+      <div
+        className="flex-shrink-0"
+        style={{
+          display: collapsed ? 'none' : undefined,
+          width: `${currentWidth}px`,
+          minWidth: `${MIN_WIDTH}px`,
+        }}
+      >
+        <ChatSidebar
+          collapsed={collapsed}
+          onCollapse={handleCollapse}
+          onExpand={handleExpand}
+          {...sidebarProps}
+        />
+      </div>
+      {!collapsed && (
+        <div
+          onMouseDown={startDrag}
+          className={`w-1.5 flex-shrink-0 cursor-col-resize -ml-1 z-10 ${
+            dragging ? 'bg-accent-strong/40' : 'hover:bg-accent-strong/30'
+          }`}
+          title="Drag to resize"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+        ></div>
+      )}
+      <div className="flex-1 flex min-w-0 relative">
+        {children}
+        {dragging && <div className="absolute inset-0 z-40 cursor-col-resize"></div>}
+      </div>
+    </div>
+  )
+})
+
+export default SidebarSplit

--- a/dashboard/frontend/src/components/chat/SidebarSplit.jsx
+++ b/dashboard/frontend/src/components/chat/SidebarSplit.jsx
@@ -61,6 +61,11 @@ const SidebarSplit = forwardRef(function SidebarSplit({ children, ...sidebarProp
               <i className="fa-solid fa-angles-right text-sm"></i>
             </button>
           </div>
+          <div className="flex-1 flex items-center justify-center py-4 overflow-hidden">
+            <span className="text-[10px] font-semibold text-fg-subtle uppercase tracking-widest select-none" style={{ writingMode: 'vertical-lr', transform: 'rotate(180deg)' }}>
+              Conversations
+            </span>
+          </div>
         </div>
       )}
       <div

--- a/dashboard/frontend/src/hooks/useResizableWidth.js
+++ b/dashboard/frontend/src/hooks/useResizableWidth.js
@@ -1,0 +1,78 @@
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
+
+function readStoredWidth(storageKey, minWidth) {
+  try {
+    const v = parseInt(localStorage.getItem(storageKey), 10)
+    return Number.isFinite(v) && v >= minWidth ? v : null
+  } catch {
+    return null
+  }
+}
+
+export default function useResizableWidth({ storageKey, minWidth = 160, maxFraction = 0.45, defaultWidthPx }) {
+  const initialWidth = readStoredWidth(storageKey, minWidth) ?? defaultWidthPx
+  const [currentWidth, setCurrentWidth] = useState(initialWidth)
+  const [dragging, setDragging] = useState(false)
+  const containerRef = useRef(null)
+  const widthRef = useRef(currentWidth)
+
+  useEffect(() => {
+    widthRef.current = currentWidth
+  }, [currentWidth])
+
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const measure = () => {
+      const w = el.getBoundingClientRect().width
+      if (w > 0) {
+        const max = Math.max(minWidth, Math.floor(w * maxFraction))
+        if (widthRef.current > max) {
+          setCurrentWidth(prev => Math.min(prev, max))
+        }
+      }
+    }
+    measure()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measure)
+      return () => window.removeEventListener('resize', measure)
+    }
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [minWidth, maxFraction])
+
+  useEffect(() => {
+    if (currentWidth == null) return
+    try {
+      localStorage.setItem(storageKey, String(currentWidth))
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey, currentWidth])
+
+  useEffect(() => {
+    if (!dragging) return
+    const onMove = (e) => {
+      const rect = containerRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const max = Math.max(minWidth, Math.floor(rect.width * maxFraction))
+      setCurrentWidth(Math.min(Math.max(e.clientX - rect.left, minWidth), max))
+    }
+    const onUp = () => setDragging(false)
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [dragging, minWidth, maxFraction])
+
+  const startDrag = useCallback((e) => {
+    e.stopPropagation()
+    e.preventDefault()
+    setDragging(true)
+  }, [])
+
+  return { containerRef, currentWidth, dragging, startDrag, setCurrentWidth }
+}

--- a/dashboard/frontend/src/hooks/useServicesSSE.js
+++ b/dashboard/frontend/src/hooks/useServicesSSE.js
@@ -47,11 +47,20 @@ function applyDeltaToState(state, delta) {
     return state
   }
 
+  const base = serviceIndex !== -1 ? services[serviceIndex] : {}
   const updatedService = {
-    ...(serviceIndex !== -1 ? services[serviceIndex] : {}),
+    ...base,
     name: delta.service_name,
-    status: delta.status,
-    container_id: delta.container_id,
+  }
+
+  if (delta.status !== null && delta.status !== undefined) {
+    updatedService.status = delta.status
+  }
+  if (delta.container_id !== null && delta.container_id !== undefined) {
+    updatedService.container_id = delta.container_id
+  }
+  if (delta.metadata) {
+    Object.assign(updatedService, delta.metadata)
   }
 
   if (serviceIndex !== -1) {
@@ -78,6 +87,8 @@ export const sortServices = (services) => {
   return [...services].sort((a, b) => {
     if (a.name === 'open-webui') return -1
     if (b.name === 'open-webui') return 1
+    if (a.favorite && !b.favorite) return -1
+    if (!a.favorite && b.favorite) return 1
     return a.name.localeCompare(b.name)
   })
 }
@@ -336,6 +347,38 @@ export default function useServicesSSE() {
 
   const sortedServices = state.services ? sortServices(state.services) : null
 
+  const toggleFavorite = useCallback(async (serviceName) => {
+    if (!state.services) return
+    const svc = state.services.find(s => s.name === serviceName)
+    if (!svc) return
+
+    // Optimistic update
+    dispatch({ type: 'DELTA', payload: {
+      service_name: serviceName,
+      action: 'metadata-changed',
+      status: null,
+      container_id: null,
+      metadata: { favorite: !svc.favorite },
+    }})
+
+    try {
+      await fetchAPI(`/services/${serviceName}/favorite`, {
+        method: 'POST',
+        body: JSON.stringify({ favorite: !svc.favorite }),
+      })
+    } catch (err) {
+      // Revert on failure
+      dispatch({ type: 'DELTA', payload: {
+        service_name: serviceName,
+        action: 'metadata-changed',
+        status: null,
+        container_id: null,
+        metadata: { favorite: svc.favorite },
+      }})
+      throw err
+    }
+  }, [state.services])
+
   return {
     services: sortedServices,
     error,
@@ -345,5 +388,6 @@ export default function useServicesSSE() {
     running: state.running,
     stopped: state.stopped,
     refresh: startStream,
+    toggleFavorite,
   }
 }

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -649,6 +649,44 @@ def set_public_port(service_name):
         return jsonify({"error": str(e)}), 500
 
 
+@services_bp.route("/api/services/<service_name>/favorite", methods=["POST"])
+@require_auth
+@_serialize_db
+def set_favorite(service_name):
+    """Set or unset the favorite flag for a service."""
+    try:
+        if service_name == "open-webui":
+            return jsonify({"error": "Cannot favorite infrastructure services"}), 400
+
+        data = request.get_json(silent=True) or {}
+        favorite = bool(data.get("favorite", True))
+
+        compose_mgr = ComposeManager(COMPOSE_FILE)
+        service_config = compose_mgr.get_service_from_db(service_name)
+        if not service_config:
+            return jsonify({"error": f'Service "{service_name}" not found'}), 404
+
+        service_config["favorite"] = favorite
+        compose_mgr.update_service_in_db(service_name, service_config)
+
+        from services import event_manager
+        event_manager.emit({
+            "service_name": service_name,
+            "action": "metadata-changed",
+            "status": None,
+            "container_id": None,
+            "metadata": {"favorite": favorite},
+            "timestamp": time.time(),
+        })
+
+        logger.info(f"Service favorite updated: {service_name} -> {favorite}")
+        return jsonify({"success": True, "favorite": favorite}), 200
+
+    except Exception as e:
+        logger.error(f"Failed to update favorite: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
 # ============================================
 # SSE helpers
 # ============================================

--- a/dashboard/routes/services.py
+++ b/dashboard/routes/services.py
@@ -341,8 +341,10 @@ def update_service(service_name):
             if new_port in used_ports:
                 return jsonify({"error": f"Port {new_port} is already in use"}), 409
 
-        # Update in database
-        compose_mgr.update_service_in_db(service_name, data)
+        # Update in database — merge into existing to preserve fields not
+        # sent by the client (favorite, etc.)
+        existing.update(data)
+        compose_mgr.update_service_in_db(service_name, existing)
 
         # Rebuild compose file
         compose_mgr.rebuild_compose_file()
@@ -757,6 +759,8 @@ def services_stream():
                         "container_id": event["container_id"],
                         "timestamp": datetime.fromtimestamp(event["timestamp"]).isoformat() + "Z",
                     }
+                    if "metadata" in event:
+                        payload["metadata"] = event["metadata"]
                     yield "data: " + json.dumps(payload) + "\n\n"
                 else:
                     yield ": keepalive\n\n"

--- a/dashboard/tests/test_chat_background_runs.py
+++ b/dashboard/tests/test_chat_background_runs.py
@@ -216,8 +216,12 @@ def test_failed_send_clears_active_run_and_surfaces_error(ctx, monkeypatch):
 
     assert '"error": "model exploded"' in body  # error metadata surfaced on the stream
     assert db.get_active_run_for_conversation(conv.id) is None
-    # Failed run wrote no completed assistant message.
-    assert [m.role for m in db.get_messages(conv.id)] == ["user"]
+    # Failed run wrote a partial assistant message with accumulated content.
+    messages = db.get_messages(conv.id)
+    assert [m.role for m in messages] == ["user", "assistant"]
+    assistant = messages[1]
+    assert assistant.content == "partial"
+    assert assistant.error == "model exploded"
 
 
 # -- Startup recovery ----------------------------------------------------

--- a/design/chat-redesign/DECISIONS.md
+++ b/design/chat-redesign/DECISIONS.md
@@ -1,0 +1,71 @@
+# Chat redesign — decisions log
+
+Running record of what we keep / drop from the "Drydock" mock
+(`mock.html`). Becomes a GitHub issue at the end.
+
+## Decided
+
+### D1 — Vocabulary: DROP the nautical metaphor
+Use conventional, conversation-based terms everywhere. No harbor jargon.
+
+| Mock term | Use instead |
+|---|---|
+| Berth | Conversation |
+| Tender | Spin-off |
+| Dock tray | (minimized) spin-off taskbar |
+| Inspector | Critique panel |
+| Command console | Composer / message input |
+| Operator | You / user |
+
+Naming/labels only — this decision does not by itself accept or reject
+any visual treatment.
+
+### D2 — Collapse the global app nav (`components/Sidebar.jsx`) — RESOLVED
+Reclaim horizontal space for chat. Currently 224px with logo + text
+labels (Services / Chat / Tools) + user block. **Resolved:** collapsible
+with a pin/chevron toggle; collapsed = icons only (hover tooltips),
+expanded = icons + labels; state persisted in localStorage; applied on
+**all routes**; **default collapsed**.
+
+### D3 — Keep the active-conversation vertical-bar highlight
+The colored left vertical bar marking the active conversation row in the
+list stays. (Independent of palette choice — bar can be any accent.)
+
+> **Issue B filed:** https://github.com/teo-mateo/llm-dock/issues/28
+> (Projects + Conversation Artifacts) — covers D4, D5, D6.
+
+### D4 — Conversation Artifacts (NEW feature — separate issue)
+Full spec in `SPEC-conversation-artifacts.md`. Resolved: UNIFY into one
+conversation-scoped artifact store (existing per-message render outputs
+become `source='render'`); DB blob in a separate table (10 MB cap, MIME
+allowlist); tree nested under the conversation in the left sidebar grouped
+Uploaded / Generated; spin-offs get read-only access to the root's
+artifacts. Open: sign-off on the render-output migration + the proposed
+defaults (soft-delete user-only, the 3 model tools, referencing UX).
+
+### D5 — Introduce a Project entity (now)
+`projects(id, name, created_at, archived_at, default_main_service,
+default_sidekick_service, default_system_prompt, default_mcp_servers)`.
+`conversations.project_id` **nullable** (projects are opt-in grouping;
+spin-offs inherit parent's project, enforced equal). Artifacts (D4) are
+**project-scoped** when a conversation is in a project. Migration: wrap
+each existing root conversation (+ spin-offs) in an auto-named project.
+Open crux: artifact ownership for project-less conversations (see Open).
+
+## Open (to discuss)
+
+- D2 sub-decision: collapse mode (toggle+remembered / always icon rail /
+  hover-to-expand) and scope (all routes / chat only)
+- Visual styling of sidebar conversation rows: status LED + mono meta line
+  + spin-off tree connector — keep? (the active vertical bar is already
+  kept per D3)
+- Typography (Archivo / IBM Plex Mono / Newsreader serif for assistant)
+- Color palette (deep ink + amber/cyan vs. current gray/blue)
+- Instrument header strip (telemetry cluster, toggle switches, signal sweep)
+- Transcript-as-log (timeline spine, hairline blocks vs. bubbles)
+- Reasoning "tape" / tool instrument cards / drift chip styling
+- Composer treatment
+- Critique panel treatment
+- Spin-off window + taskbar treatment
+- Background atmosphere (grid, blooms, grain)
+- Streaming signal-sweep motion

--- a/design/chat-redesign/DESIGN-NOTES.md
+++ b/design/chat-redesign/DESIGN-NOTES.md
@@ -1,0 +1,98 @@
+# Chat window redesign — "Drydock"
+
+## Why a redesign
+
+The current chat UI is functionally complete but visually generic: default
+system sans, `gray-900/800/700` surfaces, `blue-600` everywhere, rounded
+chat bubbles. It reads like every other AI chat clone and doesn't reflect
+what this tool actually *is*: a single-operator console for docking and
+driving local models on a workstation, with model orchestration (main +
+sidekick critic), MCP tools, reasoning traces, and live telemetry.
+
+## Concept
+
+**Drydock** — a harbor-instrument console. Conversations are *berths*;
+spin-offs are *tenders*; the composer is a *command console*; the critique
+panel is an *inspector*. The aesthetic is **refined-industrial**: an
+oscilloscope / mission-control / high-end audio-interface feel. Dark, but
+not flat gray — deep "harbor at night" ink with hairline rules, corner
+ticks, status LEDs, and one signature live motion (a signal sweep during
+streaming).
+
+The memorable idea: **the operator types in monospace (a console prompt);
+the model answers in an editorial serif (a considered voice)**, all wrapped
+in industrial chrome with monospace telemetry. Nothing like the gray-bubble
+clone.
+
+## Type
+
+- **Archivo** — display / UI chrome (industrial grotesque; letter-spaced for
+  an "expanded instrument" feel on labels).
+- **IBM Plex Mono** — telemetry, labels, operator input, code, tool traces
+  (technical-instrument heritage; tabular numerals).
+- **Newsreader** — assistant prose only (gives generated answers an
+  authored, deliberate quality and a strong contrast with the mono chrome).
+
+No Inter / Roboto / system stack; no Space Grotesk.
+
+## Palette
+
+| Token | Value | Use |
+|------|-------|-----|
+| ink-900 | `#07090a` | app shell |
+| ink-800 | `#0c1213` | panels |
+| ink-700 | `#111a1c` | raised cards / inputs |
+| line | `rgba(140,170,175,.09)` | hairline borders |
+| amber | `#ff9d00` / `#ffbf57` | OPERATOR · primary actions · tools |
+| cyan | `#2fd6c2` / `#5fe3d3` | MACHINE · streaming · success-active |
+| coral | `#ff6f5e` | drift warnings · stop · destructive |
+| green | `#57d98a` | switch ON / tool OK |
+
+Warm amber = the operator and primary intent; cold cyan = the machine and
+its live pulse. The amber/cyan tension on deep harbor ink is the cohesive,
+non-cliché core (explicitly not blue-on-gray, not purple-on-white).
+
+## Spatial moves
+
+- **Berths rail** replaces the plain conversation list: status LED + display
+  title + mono meta, with a hairline tree connector for tenders (spin-offs)
+  and inline multi-select / bulk delete preserved.
+- **Instrument header strip**: model selectors as readout tiles
+  (`MAIN ▸ value ▾`), MCP tools as physical toggle switches, a live
+  telemetry cluster (tok/s, ctx, GPU, elapsed), and a coral STOP. A 1px
+  signal-sweep line sits under it while streaming.
+- **Transcript as a log**, not bubbles: a left timeline spine with tick
+  nodes; each turn is a hairline block with a colored left spine
+  (amber=operator, cyan=model) and a mono meta line (role · model · seq ·
+  time). Operator content is mono with a `▸` prompt; model prose is
+  Newsreader serif.
+- Reasoning = a collapsible **reasoning tape** (scanline texture). Tool
+  calls = **instrument cards** with a strace-like mono trace + status LED +
+  result readout. Artifacts, format-drift chip, heartbeat all restyled to
+  the instrument language.
+- **Command console** composer docked at the bottom (prompt glyph, inline
+  attach/tools, amber SEND, mono hint line, pending-critique + attachment
+  chips). The empty-state is the same console centered with a dock mark —
+  consistent with the feature we just shipped.
+- **Inspector rail** (critique) on the right in cyan; annotations as
+  margin-note cards with severity LEDs and an "insert ▸" action.
+- **Tender window** (spin-off) + **dock tray** (minimized) reuse the same
+  instrument chrome.
+
+## Motion (restrained)
+
+One signature moment: the streaming **signal sweep** (amber→cyan gradient
+travelling under the header and along the live block's spine) plus a
+pulsing cyan caret. Everything else is subtle hover/elevation. Refined, not
+maximalist — precision in hairlines, spacing (4/8/12/16/24 scale), and
+tabular telemetry carries the design.
+
+## Deliverable
+
+`mock.html` — a single self-contained file (Google Fonts + Font Awesome
+CDN, plain CSS, minimal JS) rendering one dense screen that exercises every
+existing capability: berths rail w/ tender + selection, instrument header,
+a full transcript (operator turn w/ image, model turn w/ reasoning tape +
+tool card + artifact + serif answer + code, a drift-warning block, a live
+streaming block), command console w/ chips, inspector rail, a floating
+tender + dock tray. It is a visual proposal, not wired to the app.

--- a/design/chat-redesign/SPEC-conversation-artifacts.md
+++ b/design/chat-redesign/SPEC-conversation-artifacts.md
@@ -1,0 +1,140 @@
+# Feature spec (draft) — Conversation Artifacts
+
+> Status: discussion. Becomes its **own** GitHub issue (separate from the
+> visual-redesign "what we keep" issue).
+
+## Intent (from user)
+
+A conversation-scoped store of files/images that:
+
+1. The **user can upload** to a conversation.
+2. The **model can generate**.
+3. Are **persisted** (user leans: in the DB as binary; files won't be large).
+4. Are shown in a **tree-like structure under the conversation**.
+5. Belong to the **main/root conversation only — not spin-offs**.
+6. The **user can delete**.
+7. The **user can reference in chat** (attach/mention into a message).
+8. Are managed by the model via **internal tools**: list / fetch / create
+   (at minimum).
+
+User acknowledges this is a larger change.
+
+## Hard constraint: naming collision
+
+Existing `Artifact` (DB table `artifacts`): `id, message_id,
+artifact_type, content TEXT, title, language` — per-message,
+model-generated **text** render outputs (code / HTML / SVG via
+`ArtifactRenderer.jsx`, render-html MCP). The new concept is
+conversation-scoped binary files. Must resolve naming/relationship
+(Decision A).
+
+## Environment facts
+
+- DB is **SQLite** (`chat.db`, with a `_migrate()` path) — BLOBs are fine;
+  keep blob bytes in a **separate table** so conversation/message row scans
+  don't drag large payloads.
+- Built-in model tools live under `chat/mcp_registry.py` (built-in MCP
+  servers like sympy-math, render-html). New artifact tools = a new
+  built-in tool group.
+- Images already supported as multimodal message content; text/binary
+  files are new.
+
+## Decisions (RESOLVED)
+
+- **A. Naming/collision → UNIFY.** One conversation-scoped artifact store.
+  The existing per-message render outputs become a subtype of artifact
+  (`source = 'render'`). Single term across the app: **Artifacts**
+  (not nautical — consistent with D1).
+- **B. Storage → DB blob, separate table.** Metadata table +
+  `conversation_artifact_blobs` for bytes. **10 MB/file** cap, MIME
+  allowlist (images, text, pdf, json, csv, common code) — configurable
+  constant.
+- **C. Tree → left sidebar, nested under the conversation**, grouped by
+  origin: **Uploaded** / **Generated** (Generated includes both model
+  `create_artifact` outputs and migrated render outputs).
+- **D. Spin-offs → read-only access.** A spin-off can list / get /
+  reference the **root** conversation's artifacts; it cannot create,
+  delete, or own any. Storage and the tree stay on the root conversation.
+
+## Resulting data model (FINAL)
+
+`projects`
+: `id`, `name`, `created_at`, `archived_at` NULLable,
+  `default_main_service`, `default_sidekick_service`,
+  `default_system_prompt`, `default_mcp_servers` (project-level defaults
+  new conversations inherit; all NULLable).
+
+`conversations`
+: + `project_id` **NULLable** FK. Spin-offs inherit their parent's
+  `project_id` (enforced equal: a spin-off is in the same project — or
+  same loose state — as its parent).
+
+`artifacts`
+: `id`, `owner_project_id` NULLable, `owner_conversation_id` NULLable
+  (**exactly one set** — CHECK/invariant), `name`, `mime_type`,
+  `size_bytes`, `sha256`, `source` ∈ {`upload`,`model`,`render`},
+  `origin_message_id` NULLable (set for `model`/`render`), `title`,
+  `language` (carried for render outputs), `created_at`,
+  `deleted_at` NULLable.
+
+`artifact_blobs`
+: `artifact_id` (PK/FK), `bytes` BLOB. One row per artifact; kept off the
+  hot conversation/message rows.
+
+### Scope resolver (the one rule that replaces root-only/read-only)
+
+```
+resolve_artifact_owner(conversation):
+    c = walk_to_root(conversation)          # spin-off -> its root
+    if c.project_id is not None:  return ("project", c.project_id)
+    else:                         return ("conversation", c.id)
+```
+
+- In-project conversations (root + spin-offs) **share** the project's
+  artifacts. Loose conversations + their spin-offs share the **root
+  conversation's** artifacts. Create writes to the resolved owner;
+  list/get/reference read the resolved owner. No special spin-off rule —
+  spin-offs simply resolve to their lineage's scope (read+reference;
+  create allowed since it lands on the shared owner).
+
+## Migration (UNIFY + Project — one-way, in `_migrate()`)
+
+1. **Projects**: create one auto-named project per existing **root**
+   conversation that you want grouped — DEFAULT: leave existing
+   conversations **loose** (`project_id = NULL`) to preserve today's
+   behavior; projects are opt-in going forward. (Alt., if you'd rather
+   auto-wrap each root conv in a 1-conv project, say so — affects only the
+   migration step.)
+2. **Render outputs → artifacts**: for each existing `artifacts` row
+   (`message_id, artifact_type, content, title, language`): resolve the
+   message's conversation owner via the resolver above; insert an
+   `artifacts` row with `source='render'`,
+   `origin_message_id = message_id`, mime from artifact_type/language,
+   name synthesized; write `content` (utf-8) into `artifact_blobs`.
+   `ArtifactRenderer` keeps rendering inline by `origin_message_id`. Old
+   table kept read-only during transition, then dropped. **Back-compat
+   preserved.**
+
+## Proposed defaults (apply unless overridden)
+
+- **Deletion**: soft delete (`deleted_at`). A message that referenced a
+  now-deleted artifact (incl. a render output) shows a "deleted"
+  placeholder; history preserved. **User-only — the model has no delete
+  tool.**
+- **Model tools** (new built-in group `conversation-artifacts`):
+  `list_artifacts()`, `get_artifact(id)`, `create_artifact(name, mime,
+  content_b64)`. Scoped server-side to the active conversation's root
+  (model cannot pass an arbitrary conversation id); spin-off callers get
+  read-only (list/get) against the root, `create` denied.
+- **Referencing UX**: composer picker (paperclip → "from this
+  conversation"). Images inlined as multimodal blocks; small text inlined;
+  large/binary exposed by id for `get_artifact` to fetch on demand
+  (bounded context).
+- **Generation/render flow**: model `create_artifact` → metadata + blob
+  written → appears in the tree (Generated) and as a chip in the producing
+  message. Render outputs additionally keep their existing inline render.
+
+## Out of scope (for now, note in issue)
+
+Versioning / update-in-place, cross-conversation sharing, artifact diff,
+external object storage. Capture as "future" so the first cut stays small.

--- a/design/chat-redesign/mock.html
+++ b/design/chat-redesign/mock.html
@@ -1,0 +1,818 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Drydock — LLM-Dock chat redesign mock</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:ital,opsz,wght@0,16..72,400;0,16..72,500;1,16..72,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+<style>
+  :root{
+    --ink-900:#07090a; --ink-850:#0a0f10; --ink-800:#0c1213;
+    --ink-750:#0e1517; --ink-700:#111a1c; --ink-650:#16201f;
+    --line:rgba(140,170,175,.09); --line-strong:rgba(140,170,175,.17);
+    --text-hi:#eef3f4; --text:#9fb0b3; --text-dim:#67767a; --text-faint:#3f4d4e;
+    --amber:#ff9d00; --amber-soft:#ffc061; --amber-bd:rgba(255,157,0,.34);
+    --cyan:#2fd6c2; --cyan-soft:#67e6d6; --cyan-bd:rgba(47,214,194,.32);
+    --coral:#ff6f5e; --coral-bd:rgba(255,111,94,.34);
+    --green:#57d98a;
+    --f-disp:'Archivo',sans-serif;
+    --f-mono:'IBM Plex Mono',ui-monospace,monospace;
+    --f-read:'Newsreader',Georgia,serif;
+    --r:3px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{height:100%}
+  body{
+    background:var(--ink-900); color:var(--text);
+    font-family:var(--f-mono); font-size:13px; line-height:1.5;
+    -webkit-font-smoothing:antialiased; overflow:hidden;
+  }
+  /* ---- atmosphere ---- */
+  .atmos{position:fixed;inset:0;z-index:0;pointer-events:none}
+  .atmos::before{ /* engineering grid */
+    content:"";position:absolute;inset:0;
+    background-image:
+      linear-gradient(rgba(140,170,175,.035) 1px,transparent 1px),
+      linear-gradient(90deg,rgba(140,170,175,.035) 1px,transparent 1px);
+    background-size:34px 34px;
+    -webkit-mask-image:radial-gradient(ellipse at 50% 40%,#000 35%,transparent 85%);
+            mask-image:radial-gradient(ellipse at 50% 40%,#000 35%,transparent 85%);
+  }
+  .atmos::after{ /* harbour-light blooms + vignette */
+    content:"";position:absolute;inset:0;
+    background:
+      radial-gradient(620px 420px at 8% -6%,rgba(255,157,0,.10),transparent 60%),
+      radial-gradient(680px 520px at 102% 108%,rgba(47,214,194,.09),transparent 60%),
+      radial-gradient(ellipse at 50% 50%,transparent 55%,rgba(0,0,0,.55) 100%);
+  }
+  .grain{position:fixed;inset:0;z-index:1;pointer-events:none;opacity:.035;mix-blend-mode:overlay;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2'/></filter><rect width='140' height='140' filter='url(%23n)'/></svg>");}
+
+  /* ---- shell ---- */
+  .shell{position:relative;z-index:2;display:grid;
+    grid-template-columns:54px 296px 1fr 372px;height:100vh}
+  .col{min-width:0;min-height:0;display:flex;flex-direction:column}
+  .scroll{overflow:auto;scrollbar-width:thin;scrollbar-color:var(--line-strong) transparent}
+  .scroll::-webkit-scrollbar{width:9px;height:9px}
+  .scroll::-webkit-scrollbar-thumb{background:var(--line-strong);border-radius:9px}
+
+  /* ---- shared atoms ---- */
+  .led{display:inline-block;width:7px;height:7px;border-radius:50%;
+    background:var(--c,var(--text-faint));
+    box-shadow:0 0 0 1px rgba(0,0,0,.5),0 0 7px var(--c,transparent);flex:none}
+  .led.pulse{animation:led 2.4s ease-in-out infinite}
+  @keyframes led{0%,100%{opacity:1}50%{opacity:.32}}
+  .meta{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.16em;
+    text-transform:uppercase;color:var(--text-dim)}
+  .kbd{font-family:var(--f-mono);font-size:10px;color:var(--text-dim);
+    border:1px solid var(--line);border-bottom-width:2px;border-radius:3px;
+    padding:1px 5px;background:var(--ink-750)}
+  .tick{position:absolute;width:7px;height:7px;border-color:var(--line-strong);pointer-events:none}
+  .tick.tl{top:-1px;left:-1px;border-top:1px solid;border-left:1px solid}
+  .tick.tr{top:-1px;right:-1px;border-top:1px solid;border-right:1px solid}
+  .tick.bl{bottom:-1px;left:-1px;border-bottom:1px solid;border-left:1px solid}
+  .tick.br{bottom:-1px;right:-1px;border-bottom:1px solid;border-right:1px solid}
+
+  .panel{position:relative;background:var(--ink-800)}
+  .hdr{height:52px;display:flex;align-items:center;gap:12px;
+    padding:0 16px;border-bottom:1px solid var(--line);flex:none}
+
+  /* ---- 1. icon rail ---- */
+  .rail{background:var(--ink-850);border-right:1px solid var(--line);
+    align-items:center;padding:14px 0;gap:6px}
+  .mark{width:30px;height:30px;border:1px solid var(--amber-bd);border-radius:6px;
+    display:grid;place-items:center;color:var(--amber-soft);font-size:14px;
+    box-shadow:0 0 14px rgba(255,157,0,.16) inset;margin-bottom:14px}
+  .rail a{width:36px;height:36px;display:grid;place-items:center;color:var(--text-faint);
+    border-radius:7px;font-size:15px;text-decoration:none;transition:.15s}
+  .rail a:hover{color:var(--text);background:var(--ink-700)}
+  .rail a.on{color:var(--amber-soft);background:rgba(255,157,0,.08);
+    box-shadow:inset 0 0 0 1px var(--amber-bd)}
+  .rail .sp{flex:1}
+
+  /* ---- 2. berths rail ---- */
+  .berths{background:var(--ink-850);border-right:1px solid var(--line)}
+  .berths .top{padding:15px 15px 12px;border-bottom:1px solid var(--line)}
+  .wordmark{display:flex;align-items:center;gap:9px;margin-bottom:14px}
+  .wordmark b{font-family:var(--f-disp);font-weight:800;font-size:15px;
+    letter-spacing:.26em;color:var(--text-hi)}
+  .wordmark span{font-family:var(--f-mono);font-size:9px;letter-spacing:.22em;
+    color:var(--text-faint);margin-left:auto}
+  .btn{font-family:var(--f-mono);font-size:11px;letter-spacing:.13em;
+    text-transform:uppercase;cursor:pointer;border-radius:var(--r);
+    display:inline-flex;align-items:center;justify-content:center;gap:8px;
+    padding:9px 12px;transition:.15s;border:1px solid transparent;background:none;color:inherit}
+  .btn-primary{width:100%;color:var(--amber-soft);border-color:var(--amber-bd);
+    background:linear-gradient(180deg,rgba(255,157,0,.10),rgba(255,157,0,.03))}
+  .btn-primary:hover{background:linear-gradient(180deg,rgba(255,157,0,.18),rgba(255,157,0,.06));
+    box-shadow:0 0 18px rgba(255,157,0,.14)}
+  .subbar{height:34px;display:flex;align-items:center;justify-content:space-between;
+    padding:0 15px;border-bottom:1px solid var(--line)}
+  .subbar.sel{background:rgba(47,214,194,.05)}
+  .link{font-size:10.5px;letter-spacing:.08em;color:var(--text-dim);cursor:pointer;background:none;border:0}
+  .link:hover{color:var(--text)}
+  .berth-list{padding:6px 0}
+  .berth{position:relative;display:flex;align-items:flex-start;gap:11px;
+    padding:11px 15px;cursor:pointer;border-left:2px solid transparent}
+  .berth:hover{background:var(--ink-800)}
+  .berth.active{background:var(--ink-800);border-left-color:var(--amber)}
+  .berth.picked{background:rgba(47,214,194,.06);border-left-color:var(--cyan)}
+  .berth .body{flex:1;min-width:0}
+  .berth .ttl{font-family:var(--f-disp);font-weight:600;font-size:13px;
+    color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .berth.active .ttl{color:var(--text-hi)}
+  .berth .m{display:flex;gap:8px;margin-top:4px;font-family:var(--f-mono);
+    font-size:9.5px;color:var(--text-faint);letter-spacing:.04em}
+  .berth .m b{color:var(--text-dim);font-weight:500}
+  .berth .del{opacity:0;color:var(--text-faint);background:none;border:0;cursor:pointer;
+    padding:3px;transition:.15s;font-size:11px}
+  .berth:hover .del{opacity:1}
+  .berth .del:hover{color:var(--coral)}
+  .tender{position:relative;margin-left:15px;padding-left:18px}
+  .tender::before{content:"";position:absolute;left:0;top:-11px;bottom:50%;
+    width:13px;border-left:1px solid var(--line-strong);
+    border-bottom:1px solid var(--line-strong);border-bottom-left-radius:6px}
+  .pick{width:13px;height:13px;border:1px solid var(--line-strong);border-radius:3px;
+    margin-top:2px;flex:none;display:grid;place-items:center;color:var(--cyan);font-size:8px}
+  .pick.on{border-color:var(--cyan-bd);background:rgba(47,214,194,.12)}
+
+  /* ---- 3. console ---- */
+  .console{background:linear-gradient(180deg,var(--ink-800),var(--ink-850))}
+  .strip{flex:none;border-bottom:1px solid var(--line);position:relative;background:var(--ink-800)}
+  .strip-row{display:flex;align-items:center;gap:14px;padding:11px 18px}
+  .crumb{display:flex;align-items:baseline;gap:10px;min-width:0}
+  .crumb .b{font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;color:var(--amber-soft)}
+  .crumb .t{font-family:var(--f-disp);font-weight:700;font-size:15px;color:var(--text-hi);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .sep{width:1px;align-self:stretch;background:var(--line);margin:2px 0}
+  .group{display:flex;align-items:center;gap:9px}
+  .readout{display:flex;flex-direction:column;gap:2px;padding:5px 11px;border-radius:var(--r);
+    border:1px solid var(--line);background:var(--ink-750);cursor:pointer;transition:.15s}
+  .readout:hover{border-color:var(--line-strong);background:var(--ink-700)}
+  .readout .l{font-family:var(--f-mono);font-size:8.5px;letter-spacing:.18em;color:var(--text-faint)}
+  .readout .v{font-family:var(--f-mono);font-size:11.5px;color:var(--text-hi);display:flex;align-items:center;gap:7px}
+  .readout .v i{color:var(--text-faint);font-size:8px}
+  .readout.main .v{color:var(--amber-soft)} .readout.kick .v{color:var(--cyan-soft)}
+  .switches{display:flex;gap:7px}
+  .sw{display:flex;align-items:center;gap:7px;padding:6px 9px;border-radius:var(--r);
+    border:1px solid var(--line);background:var(--ink-750);cursor:pointer;font-size:10px;
+    letter-spacing:.06em;color:var(--text-dim);transition:.15s;user-select:none}
+  .sw i.ic{font-size:10px;width:12px;text-align:center}
+  .track{width:24px;height:13px;border-radius:8px;background:var(--ink-650);
+    border:1px solid var(--line-strong);position:relative;transition:.18s}
+  .track::after{content:"";position:absolute;top:1px;left:1px;width:9px;height:9px;
+    border-radius:50%;background:var(--text-faint);transition:.18s}
+  .sw.on{color:var(--green);border-color:rgba(87,217,138,.32);background:rgba(87,217,138,.06)}
+  .sw.on .track{background:rgba(87,217,138,.22);border-color:rgba(87,217,138,.4)}
+  .sw.on .track::after{left:12px;background:var(--green);box-shadow:0 0 7px var(--green)}
+  .telemetry{display:flex;gap:16px;align-items:center;margin-left:auto}
+  .tele{display:flex;flex-direction:column;gap:3px;align-items:flex-end}
+  .tele .l{font-family:var(--f-mono);font-size:8px;letter-spacing:.16em;color:var(--text-faint)}
+  .tele .n{font-family:var(--f-mono);font-size:13px;color:var(--text-hi);font-variant-numeric:tabular-nums}
+  .tele .n small{font-size:8.5px;color:var(--text-faint);letter-spacing:.05em}
+  .bar{width:46px;height:3px;border-radius:2px;background:var(--ink-650);overflow:hidden}
+  .bar i{display:block;height:100%}
+  .stop{display:flex;align-items:center;gap:7px;padding:7px 13px;border-radius:var(--r);
+    font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--coral);border:1px solid var(--coral-bd);background:rgba(255,111,94,.07);cursor:pointer}
+  .stop:hover{background:rgba(255,111,94,.14)}
+  .prompts{display:flex;align-items:center;gap:10px;padding:8px 18px;
+    border-bottom:1px solid var(--line);color:var(--text-dim);font-size:10.5px;
+    letter-spacing:.14em;text-transform:uppercase;cursor:pointer;background:var(--ink-850)}
+  .prompts:hover{color:var(--text)}
+  .prompts .ed{margin-left:auto;font-size:9px;color:var(--text-faint);letter-spacing:.1em}
+  .sweep{position:absolute;left:0;right:0;bottom:-1px;height:2px;overflow:hidden}
+  .sweep::after{content:"";position:absolute;top:0;height:100%;width:42%;
+    background:linear-gradient(90deg,transparent,var(--amber),var(--cyan),transparent);
+    animation:sweep 2.6s linear infinite;filter:blur(.4px)}
+  @keyframes sweep{0%{left:-42%}100%{left:100%}}
+
+  /* ---- transcript ---- */
+  .log{flex:1;padding:26px 0}
+  .log-inner{max-width:900px;margin:0 auto;padding:0 30px;position:relative}
+  .spine{position:absolute;left:14px;top:6px;bottom:30px;width:1px;
+    background:linear-gradient(180deg,transparent,var(--line-strong) 6%,var(--line-strong) 94%,transparent)}
+  .turn{position:relative;padding-left:30px;margin-bottom:30px}
+  .node{position:absolute;left:-16.5px;top:3px;width:9px;height:9px;border-radius:50%;
+    background:var(--ink-850);border:1px solid var(--line-strong)}
+  .turn.op .node{border-color:var(--amber-bd);box-shadow:0 0 8px rgba(255,157,0,.3)}
+  .turn.ai .node{border-color:var(--cyan-bd);box-shadow:0 0 8px rgba(47,214,194,.3)}
+  .turn-meta{display:flex;align-items:center;gap:10px;margin-bottom:9px}
+  .turn-meta .who{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.2em;
+    text-transform:uppercase}
+  .op .who{color:var(--amber-soft)} .ai .who{color:var(--cyan-soft)}
+  .turn-meta .dot{width:3px;height:3px;border-radius:50%;background:var(--text-faint)}
+  .turn-meta .x{font-family:var(--f-mono);font-size:9.5px;color:var(--text-faint);letter-spacing:.05em}
+  .turn-meta .act{margin-left:auto;display:flex;gap:14px;opacity:0;transition:.15s}
+  .turn:hover .turn-meta .act{opacity:1}
+  .act button{background:none;border:0;color:var(--text-faint);cursor:pointer;
+    font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase}
+  .act button:hover{color:var(--text)}
+  .block{border:1px solid var(--line);border-left:2px solid var(--lc,var(--line-strong));
+    border-radius:var(--r);background:var(--ink-800)}
+  .op .block{--lc:var(--amber-bd)} .ai .block{--lc:var(--cyan-bd)}
+  .op-text{padding:14px 16px;font-family:var(--f-mono);font-size:12.5px;color:var(--text-hi);
+    display:flex;gap:12px;align-items:flex-start;line-height:1.65}
+  .op-text .pr{color:var(--amber);flex:none;user-select:none}
+  .thumb{width:78px;height:78px;border:1px solid var(--line-strong);border-radius:3px;
+    object-fit:cover;flex:none}
+  .imgrow{display:flex;gap:9px;padding:0 16px 14px 40px}
+
+  .ai-prose{padding:16px 20px;font-family:var(--f-read);font-size:16px;line-height:1.72;
+    color:#dfe7e7}
+  .ai-prose p{margin:0 0 13px} .ai-prose p:last-child{margin-bottom:0}
+  .ai-prose strong{color:var(--text-hi);font-weight:600}
+  .ai-prose .math{font-style:italic;color:var(--cyan-soft)}
+  .ai-prose code.inl{font-family:var(--f-mono);font-size:13px;background:var(--ink-700);
+    padding:1px 6px;border-radius:3px;color:var(--amber-soft);border:1px solid var(--line)}
+  .codeblk{margin:14px 0;border:1px solid var(--line);border-radius:var(--r);
+    background:var(--ink-900);overflow:hidden}
+  .codeblk .cap{display:flex;align-items:center;gap:8px;padding:7px 12px;
+    border-bottom:1px solid var(--line);background:var(--ink-850)}
+  .codeblk .cap .l{font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;
+    color:var(--text-faint);text-transform:uppercase}
+  .codeblk .cap .cp{margin-left:auto;font-family:var(--f-mono);font-size:9px;
+    color:var(--text-faint);cursor:pointer;letter-spacing:.1em}
+  .codeblk .cap .cp:hover{color:var(--cyan-soft)}
+  .codeblk pre{padding:13px 14px;font-family:var(--f-mono);font-size:12px;color:#cdd8d8;
+    overflow:auto;line-height:1.7}
+  .codeblk .k{color:var(--cyan-soft)} .codeblk .s{color:var(--amber-soft)}
+  .codeblk .c{color:var(--text-faint)}
+
+  .tape{margin-bottom:10px}
+  .tape-btn{display:flex;align-items:center;gap:9px;background:none;border:0;cursor:pointer;
+    color:var(--text-dim);font-family:var(--f-mono);font-size:10px;letter-spacing:.13em;
+    text-transform:uppercase;padding:3px 0}
+  .tape-btn:hover{color:var(--text)}
+  .tape-btn i.cv{font-size:8px;width:8px;transition:.18s}
+  .tape-body{margin-top:8px;border:1px solid var(--line);border-radius:var(--r);
+    padding:13px 15px;font-family:var(--f-mono);font-size:11.5px;color:var(--text-dim);
+    line-height:1.7;max-height:230px;overflow:auto;
+    background:
+      repeating-linear-gradient(180deg,transparent 0 3px,rgba(47,214,194,.022) 3px 4px),
+      var(--ink-850)}
+  .tape-body em{color:var(--cyan-soft);font-style:normal}
+
+  .tool{margin-bottom:10px;border:1px solid var(--line);border-radius:var(--r);
+    background:var(--ink-850);font-family:var(--f-mono)}
+  .tool .h{display:flex;align-items:center;gap:9px;padding:9px 13px;border-bottom:1px solid var(--line)}
+  .tool .h .nm{font-size:11.5px;color:var(--amber-soft);letter-spacing:.03em}
+  .tool .h .st{margin-left:auto;font-size:8.5px;letter-spacing:.18em;text-transform:uppercase}
+  .tool .h .st.ok{color:var(--green)}
+  .tool .args{padding:9px 13px 11px;font-size:11px;color:var(--text-dim);line-height:1.85}
+  .tool .args .a{color:var(--text-faint)} .tool .args .v{color:var(--text)}
+  .tool .res{margin:0 13px 13px;border:1px solid var(--line);border-left:2px solid rgba(87,217,138,.4);
+    border-radius:3px;background:var(--ink-900);padding:9px 12px;font-size:11.5px;color:#cdd8d8}
+  .tool .res .rl{font-size:8px;letter-spacing:.2em;color:var(--text-faint);
+    text-transform:uppercase;margin-bottom:5px}
+
+  .chip{display:inline-flex;align-items:center;gap:9px;padding:8px 12px;border-radius:var(--r);
+    font-family:var(--f-mono);font-size:11px;border:1px solid var(--line);
+    background:var(--ink-850);margin-bottom:10px}
+  .chip.art{color:var(--cyan-soft);border-color:var(--cyan-bd);background:rgba(47,214,194,.05)}
+  .chip.art .go{margin-left:6px;color:var(--text-faint);cursor:pointer;letter-spacing:.1em;font-size:9px}
+  .chip.art .go:hover{color:var(--cyan-soft)}
+  .chip.drift{color:var(--coral);border-color:var(--coral-bd);background:rgba(255,111,94,.06);
+    display:flex;width:100%;line-height:1.55}
+  .chip.drift .x{color:var(--text-dim)}
+
+  .stream .block{background:linear-gradient(180deg,rgba(47,214,194,.05),transparent)}
+  .stream{position:relative}
+  .caret{display:inline-block;width:8px;height:17px;background:var(--cyan);
+    vertical-align:-3px;margin-left:3px;box-shadow:0 0 9px var(--cyan);animation:cb .9s steps(1) infinite}
+  @keyframes cb{50%{opacity:0}}
+  .hb{display:flex;align-items:center;gap:9px;margin-top:10px;font-family:var(--f-mono);
+    font-size:10px;letter-spacing:.1em;color:var(--text-dim)}
+
+  /* ---- composer ---- */
+  .composer{flex:none;border-top:1px solid var(--line);background:var(--ink-800);padding:14px 0 16px}
+  .composer-in{max-width:900px;margin:0 auto;padding:0 30px}
+  .flags{display:flex;flex-direction:column;gap:7px;margin-bottom:11px}
+  .flag{display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:var(--r);
+    border:1px solid var(--cyan-bd);background:rgba(47,214,194,.05);font-family:var(--f-mono);font-size:11px}
+  .flag .tag{color:var(--cyan-soft);font-size:9px;letter-spacing:.16em;text-transform:uppercase}
+  .flag .tx{color:var(--text);flex:1;min-width:0}
+  .flag .rm{color:var(--text-faint);cursor:pointer}.flag .rm:hover{color:var(--coral)}
+  .att{display:flex;gap:9px;margin-bottom:11px}
+  .att .t{position:relative;width:54px;height:54px}
+  .att img{width:100%;height:100%;object-fit:cover;border:1px solid var(--line-strong);border-radius:3px}
+  .att .rm{position:absolute;top:-6px;right:-6px;width:17px;height:17px;border-radius:50%;
+    background:var(--coral);color:#1a0a08;display:grid;place-items:center;font-size:8px;cursor:pointer}
+  .cmd{position:relative;border:1px solid var(--line-strong);border-radius:5px;
+    background:var(--ink-750);display:flex;align-items:flex-end;gap:12px;padding:13px 14px;
+    transition:.15s}
+  .cmd:focus-within{border-color:var(--amber-bd);box-shadow:0 0 0 1px var(--amber-bd),0 0 22px rgba(255,157,0,.08)}
+  .cmd .glyph{color:var(--amber);font-family:var(--f-mono);font-size:14px;padding-bottom:1px;user-select:none}
+  .cmd .ta{flex:1;font-family:var(--f-mono);font-size:13px;color:var(--text-hi);min-height:22px;
+    padding-top:1px;outline:none}
+  .cmd .ta:empty::before{content:"Type a command — the operator speaks here…";color:var(--text-faint)}
+  .cmd .tools{display:flex;gap:5px;align-items:center}
+  .icbtn{width:30px;height:30px;border-radius:4px;border:1px solid transparent;background:none;
+    color:var(--text-faint);cursor:pointer;display:grid;place-items:center;font-size:13px;transition:.15s}
+  .icbtn:hover{color:var(--text);background:var(--ink-700);border-color:var(--line)}
+  .send{width:34px;height:30px;border-radius:4px;border:1px solid var(--amber-bd);cursor:pointer;
+    background:linear-gradient(180deg,rgba(255,157,0,.22),rgba(255,157,0,.08));
+    color:var(--amber-soft);display:grid;place-items:center;font-size:12px;transition:.15s}
+  .send:hover{background:linear-gradient(180deg,rgba(255,157,0,.34),rgba(255,157,0,.14));
+    box-shadow:0 0 16px rgba(255,157,0,.2)}
+  .hint{display:flex;gap:16px;margin-top:9px;font-family:var(--f-mono);font-size:9.5px;
+    color:var(--text-faint);letter-spacing:.06em;align-items:center}
+  .hint .g{display:flex;gap:6px;align-items:center}
+
+  /* ---- 4. inspector ---- */
+  .inspector{background:var(--ink-850);border-left:1px solid var(--line)}
+  .inspector .hdr{justify-content:space-between}
+  .inspector .hdr .ti{display:flex;align-items:center;gap:9px;font-family:var(--f-disp);
+    font-weight:700;font-size:13px;letter-spacing:.14em;text-transform:uppercase;color:var(--text-hi)}
+  .inspector .hdr .ti i{color:var(--cyan)}
+  .xbtn{background:none;border:0;color:var(--text-faint);cursor:pointer;font-size:14px}
+  .xbtn:hover{color:var(--text)}
+  .insp-form{padding:15px 16px;border-bottom:1px solid var(--line)}
+  .insp-form label{display:block;margin-bottom:8px;font-family:var(--f-mono);font-size:9px;
+    letter-spacing:.16em;text-transform:uppercase;color:var(--text-dim)}
+  .insp-form .ta{border:1px solid var(--line);border-radius:var(--r);background:var(--ink-750);
+    padding:10px 12px;font-family:var(--f-mono);font-size:11.5px;color:var(--text);
+    min-height:54px;line-height:1.6}
+  .insp-form .ta:empty::before{content:"e.g. verify the integration constant, check the algebra…";color:var(--text-faint)}
+  .insp-form .run{margin-top:10px;width:100%;color:var(--cyan-soft);border:1px solid var(--cyan-bd);
+    background:linear-gradient(180deg,rgba(47,214,194,.12),rgba(47,214,194,.03))}
+  .insp-form .run:hover{background:linear-gradient(180deg,rgba(47,214,194,.2),rgba(47,214,194,.06))}
+  .ann{padding:14px 16px;border-bottom:1px solid var(--line)}
+  .ann .top{display:flex;align-items:center;gap:9px;margin-bottom:9px}
+  .ann .sev{font-family:var(--f-mono);font-size:8.5px;letter-spacing:.16em;text-transform:uppercase}
+  .ann .sev.hi{color:var(--coral)} .ann .sev.lo{color:var(--amber-soft)}
+  .ann .ins{margin-left:auto;font-family:var(--f-mono);font-size:9px;letter-spacing:.1em;
+    color:var(--text-faint);cursor:pointer}
+  .ann .ins:hover{color:var(--cyan-soft)}
+  .ann .q{border-left:2px solid var(--line-strong);padding:3px 0 3px 12px;margin-bottom:9px;
+    font-family:var(--f-mono);font-size:11px;color:var(--text-dim);font-style:italic}
+  .ann .cm{font-family:var(--f-read);font-size:14px;line-height:1.6;color:#dbe3e3}
+
+  /* ---- tender (spin-off) ---- */
+  .tenderwin{position:fixed;right:404px;bottom:38px;width:386px;z-index:30;
+    border:1px solid var(--line-strong);border-radius:6px;overflow:hidden;
+    background:var(--ink-800);box-shadow:0 26px 60px -18px rgba(0,0,0,.8),0 0 0 1px rgba(0,0,0,.4)}
+  .tw-bar{display:flex;align-items:center;gap:9px;padding:9px 12px;cursor:grab;
+    background:var(--ink-750);border-bottom:1px solid var(--line)}
+  .tw-bar .br{color:var(--cyan);font-size:10px}
+  .tw-bar .nm{font-family:var(--f-disp);font-weight:600;font-size:11.5px;color:var(--text-hi);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
+  .tw-bar .ctl{display:flex;gap:4px}
+  .tw-bar .ctl b{width:18px;height:18px;border-radius:3px;display:grid;place-items:center;
+    color:var(--text-faint);font-size:8px;cursor:pointer}
+  .tw-bar .ctl b:hover{background:var(--ink-700);color:var(--text)}
+  .tw-ctx{padding:7px 12px;border-bottom:1px solid var(--line);background:rgba(47,214,194,.04);
+    font-family:var(--f-mono);font-size:10px;color:var(--text-dim);font-style:italic}
+  .tw-body{padding:12px;display:flex;flex-direction:column;gap:9px;height:168px;overflow:auto}
+  .tw-msg{max-width:88%;font-size:11.5px;line-height:1.55;padding:8px 11px;border-radius:5px}
+  .tw-msg.u{align-self:flex-end;font-family:var(--f-mono);color:var(--text-hi);
+    border:1px solid var(--amber-bd);background:rgba(255,157,0,.07)}
+  .tw-msg.a{align-self:flex-start;font-family:var(--f-read);font-size:13px;color:#dbe3e3;
+    border:1px solid var(--line);background:var(--ink-850)}
+  .tw-in{display:flex;gap:8px;padding:10px 12px;border-top:1px solid var(--line)}
+  .tw-in .f{flex:1;border:1px solid var(--line-strong);border-radius:4px;background:var(--ink-750);
+    padding:7px 10px;font-family:var(--f-mono);font-size:11px;color:var(--text-faint)}
+  .tw-in .s{width:32px;border-radius:4px;border:1px solid var(--cyan-bd);
+    background:rgba(47,214,194,.12);color:var(--cyan-soft);cursor:pointer;font-size:11px}
+  .tray{position:fixed;left:362px;bottom:14px;z-index:30;display:flex;gap:8px}
+  .tray .t{display:flex;align-items:center;gap:8px;padding:7px 12px;border-radius:6px;
+    border:1px solid var(--line-strong);background:var(--ink-750);
+    font-family:var(--f-mono);font-size:10px;color:var(--text-dim);cursor:pointer;
+    box-shadow:0 10px 26px -10px rgba(0,0,0,.7)}
+  .tray .t:hover{color:var(--text);border-color:var(--cyan-bd)}
+  .tray .t i{color:var(--cyan);font-size:9px}
+
+  .titlecard{position:fixed;left:50%;top:13px;transform:translateX(-50%);z-index:40;
+    display:flex;align-items:center;gap:11px;padding:7px 16px;border-radius:99px;
+    border:1px solid var(--line);background:rgba(10,15,16,.78);backdrop-filter:blur(7px);
+    font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;color:var(--text-dim)}
+  .titlecard b{color:var(--amber-soft);letter-spacing:.24em}
+</style>
+</head>
+<body>
+<div class="atmos"></div>
+<div class="grain"></div>
+
+<div class="titlecard"><b>DRYDOCK</b> · proposed chat redesign · mock</div>
+
+<div class="shell">
+
+  <!-- 1 · icon rail -->
+  <nav class="col rail">
+    <div class="mark"><i class="fa-solid fa-anchor"></i></div>
+    <a href="#" title="Dock"><i class="fa-solid fa-gauge-high"></i></a>
+    <a href="#" title="Services"><i class="fa-solid fa-server"></i></a>
+    <a href="#" title="GPU"><i class="fa-solid fa-microchip"></i></a>
+    <a href="#" class="on" title="Chat"><i class="fa-solid fa-terminal"></i></a>
+    <a href="#" title="Tools"><i class="fa-solid fa-screwdriver-wrench"></i></a>
+    <span class="sp"></span>
+    <a href="#" title="Settings"><i class="fa-solid fa-sliders"></i></a>
+  </nav>
+
+  <!-- 2 · berths -->
+  <aside class="col berths">
+    <div class="top">
+      <div class="wordmark">
+        <b>BERTHS</b><span>14</span>
+      </div>
+      <button class="btn btn-primary"><i class="fa-solid fa-plus"></i> New berth</button>
+    </div>
+    <div class="subbar sel">
+      <span class="meta" style="color:var(--cyan-soft)">2 picked</span>
+      <div style="display:flex;gap:12px">
+        <button class="link" style="color:var(--coral)"><i class="fa-solid fa-trash"></i> delete</button>
+        <button class="link">clear</button>
+      </div>
+    </div>
+    <div class="berth-list scroll" style="flex:1">
+
+      <div class="berth active">
+        <span class="led pulse" style="--c:var(--amber)"></span>
+        <div class="body">
+          <div class="ttl">Quantum decoder — derivation notes</div>
+          <div class="m"><b>qwen3·6-27b</b> · 14:02 · 28 turns</div>
+        </div>
+        <button class="del"><i class="fa-solid fa-trash"></i></button>
+      </div>
+
+      <div class="tender">
+        <div class="berth picked">
+          <span class="pick on"><i class="fa-solid fa-check"></i></span>
+          <div class="body">
+            <div class="ttl" style="display:flex;align-items:center;gap:7px">
+              <i class="fa-solid fa-code-branch" style="color:var(--cyan);font-size:9px"></i>
+              tender · "the matryoshka prefix…"</div>
+            <div class="m"><b>tender</b> · 14:09 · 4 turns</div>
+          </div>
+          <button class="del"><i class="fa-solid fa-trash"></i></button>
+        </div>
+      </div>
+
+      <div class="berth picked">
+        <span class="pick on"><i class="fa-solid fa-check"></i></span>
+        <div class="body">
+          <div class="ttl">vLLM 0.20 arg-surface audit</div>
+          <div class="m"><b>gemma·4-31b</b> · yesterday</div>
+        </div>
+        <button class="del"><i class="fa-solid fa-trash"></i></button>
+      </div>
+
+      <div class="berth">
+        <span class="led" style="--c:var(--text-faint)"></span>
+        <div class="body">
+          <div class="ttl">Blackwell cuTensorMap notes</div>
+          <div class="m"><b>qwen3·5-27b</b> · 2d</div>
+        </div>
+        <button class="del"><i class="fa-solid fa-trash"></i></button>
+      </div>
+
+      <div class="berth">
+        <span class="led" style="--c:var(--text-faint)"></span>
+        <div class="body">
+          <div class="ttl">Embedding service smoke tests</div>
+          <div class="m"><b>nomic-embed</b> · 4d</div>
+        </div>
+        <button class="del"><i class="fa-solid fa-trash"></i></button>
+      </div>
+
+      <div class="berth">
+        <span class="led" style="--c:var(--text-faint)"></span>
+        <div class="body">
+          <div class="ttl">Default-key rotation runbook</div>
+          <div class="m"><b>gemma·4-31b</b> · 6d</div>
+        </div>
+        <button class="del"><i class="fa-solid fa-trash"></i></button>
+      </div>
+
+    </div>
+  </aside>
+
+  <!-- 3 · console -->
+  <main class="col console">
+
+    <div class="strip">
+      <div class="strip-row">
+        <div class="crumb">
+          <span class="b">BERTH&nbsp;07</span>
+          <span class="t">Quantum decoder — derivation notes</span>
+        </div>
+
+        <div class="sep"></div>
+
+        <div class="group">
+          <div class="readout main">
+            <span class="l">MAIN</span>
+            <span class="v">qwen3-6-27b-bf16 <i class="fa-solid fa-chevron-down"></i></span>
+          </div>
+          <div class="readout kick">
+            <span class="l">SIDEKICK</span>
+            <span class="v">qwen3-5-27b-q8 <i class="fa-solid fa-chevron-down"></i></span>
+          </div>
+        </div>
+
+        <div class="sep"></div>
+
+        <div class="switches">
+          <div class="sw on"><i class="fa-solid fa-square-root-variable ic"></i><span class="track"></span>sympy</div>
+          <div class="sw"><i class="fa-solid fa-bezier-curve ic"></i><span class="track"></span>circuits</div>
+          <div class="sw"><i class="fa-solid fa-code ic"></i><span class="track"></span>render-html</div>
+        </div>
+
+        <div class="telemetry">
+          <div class="tele"><span class="l">TOK/S</span><span class="n">63.2</span></div>
+          <div class="tele"><span class="l">CTX</span><span class="n">18.4<small>/32k</small></span></div>
+          <div class="tele">
+            <span class="l">GPU</span>
+            <span class="bar"><i style="width:74%;background:linear-gradient(90deg,var(--amber),var(--coral))"></i></span>
+          </div>
+          <div class="tele"><span class="l">ELAPSED</span><span class="n">6.4<small>s</small></span></div>
+          <button class="stop"><i class="fa-solid fa-stop"></i> halt</button>
+        </div>
+      </div>
+      <div class="sweep"></div>
+    </div>
+
+    <div class="prompts" onclick="this.querySelector('.cv').classList.toggle('fa-chevron-down')">
+      <i class="fa-solid fa-chevron-right cv" style="font-size:8px"></i>
+      <i class="fa-solid fa-sliders"></i>
+      <span>System prompts</span>
+      <span class="ed">main · sidekick — defaults</span>
+    </div>
+
+    <div class="log scroll">
+      <div class="log-inner">
+        <div class="spine"></div>
+
+        <!-- operator turn -->
+        <div class="turn op">
+          <span class="node"></span>
+          <div class="turn-meta">
+            <span class="who">Operator</span><span class="dot"></span>
+            <span class="x">14:02:51 · seq 1</span>
+            <span class="act"><button><i class="fa-solid fa-pen-to-square"></i> edit</button></span>
+          </div>
+          <div class="block">
+            <div class="op-text">
+              <span class="pr">▸</span>
+              <span>Derive the closed form for ∫ sin(x)·e^x dx and sanity-check it
+              symbolically. The whiteboard photo has my by-hand attempt — tell me where it breaks.</span>
+            </div>
+            <div class="imgrow">
+              <div style="width:120px;height:78px;border:1px solid var(--line-strong);border-radius:3px;
+                background:repeating-linear-gradient(135deg,#13201f 0 7px,#0e1719 7px 14px);
+                display:grid;place-items:center;color:var(--text-faint);font-size:9px;letter-spacing:.1em">
+                WHITEBOARD.JPG</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- model turn -->
+        <div class="turn ai">
+          <span class="node"></span>
+          <div class="turn-meta">
+            <span class="who">qwen3-6-27b</span><span class="dot"></span>
+            <span class="x">14:02:58 · seq 2 · 1,204 tok</span>
+            <span class="act"><button><i class="fa-solid fa-magnifying-glass"></i> critique ▸</button></span>
+          </div>
+
+          <div class="tape">
+            <button class="tape-btn" onclick="var b=this.nextElementSibling,o=b.style.display==='none';b.style.display=o?'block':'none';this.querySelector('.cv').className='fa-solid cv '+(o?'fa-chevron-down':'fa-chevron-right')">
+              <i class="fa-solid fa-chevron-down cv"></i><i class="fa-solid fa-wave-square"></i>
+              <span>Reasoning tape · 2,318 chars</span>
+            </button>
+            <div class="tape-body">
+              The integral ∫ sin(x)·eˣ dx is a classic integration-by-parts cycle.
+              Let me set <em>I = ∫ eˣ sin x dx</em>. By parts twice the integral
+              reappears with a sign flip, so <em>I = eˣ(sin x − cos x)/2 + C</em>.
+              The operator's by-hand attempt drops the ½ factor — that's the break.
+              I'll confirm with the sympy tool before stating it, then flag the
+              missing constant explicitly so the sidekick has something to check…
+            </div>
+          </div>
+
+          <div class="tool">
+            <div class="h">
+              <span class="led" style="--c:var(--green)"></span>
+              <span class="nm">sympy-math.integrate</span>
+              <span class="st ok">✓ ok · 41 ms</span>
+            </div>
+            <div class="args">
+              <span class="a">expr:</span> <span class="v">"exp(x)*sin(x)"</span><br>
+              <span class="a">var:</span> <span class="v">"x"</span>
+            </div>
+            <div class="res">
+              <div class="rl">result</div>
+              exp(x)*sin(x)/2 − exp(x)*cos(x)/2
+            </div>
+          </div>
+
+          <div class="chip art">
+            <i class="fa-solid fa-bezier-curve"></i> derivation-steps.svg · rendered
+            <span class="go">open ▸</span>
+          </div>
+
+          <div class="block">
+            <div class="ai-prose">
+              <p>Your by-hand work is right up until the last line — you lost the
+              <strong>½</strong> factor that integration-by-parts produces. The
+              closed form is:</p>
+              <p class="math">∫ eˣ·sin(x) dx&nbsp;=&nbsp;½·eˣ·( sin x − cos x ) + C</p>
+              <p>The symbolic check agrees (see the tool trace above). The reason
+              the ½ appears: applying parts twice returns <code class="inl">I</code>
+              on the right-hand side, so you solve <code class="inl">2I = …</code>.
+              Skipping that algebra is exactly where the whiteboard derivation
+              diverges. Quick numerical guard:</p>
+              <div class="codeblk">
+                <div class="cap"><span class="l">python · verify</span>
+                  <span class="cp"><i class="fa-regular fa-copy"></i> copy</span></div>
+                <pre><span class="k">from</span> sympy <span class="k">import</span> *
+x = symbols(<span class="s">'x'</span>)
+<span class="c"># closed form vs. direct integration</span>
+assert simplify(diff(exp(x)*(sin(x)-cos(x))/<span class="s">2</span>, x)
+                 - exp(x)*sin(x)) == <span class="s">0</span></pre>
+              </div>
+              <p>So: drop nothing, keep the ½, and the constant of integration —
+              your sidekick flagged that next.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- drift-warning block -->
+        <div class="turn ai">
+          <span class="node"></span>
+          <div class="turn-meta">
+            <span class="who">qwen3-6-27b</span><span class="dot"></span>
+            <span class="x">14:03:40 · seq 3</span>
+          </div>
+          <div class="chip drift">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            <span><strong style="color:var(--coral)">Format drift</strong> —
+            tool-call JSON leaked into the content stream
+            <span class="x">· raw preserved · click to inspect</span></span>
+          </div>
+          <div class="block">
+            <div class="ai-prose"><p>Re-issuing the call through the proper
+            channel — one moment.</p></div>
+          </div>
+        </div>
+
+        <!-- streaming block -->
+        <div class="turn ai stream">
+          <span class="node"></span>
+          <div class="turn-meta">
+            <span class="who">qwen3-6-27b</span><span class="dot"></span>
+            <span class="x">live · seq 4</span>
+          </div>
+          <div class="block">
+            <div class="ai-prose">
+              <p>To extend this to the matryoshka-prefixed embedding case, note
+              that the same by-parts structure shows up when you differentiate the
+              cosine-similarity kernel<span class="caret"></span></p>
+            </div>
+          </div>
+          <div class="hb">
+            <span class="led pulse" style="--c:var(--cyan)"></span>
+            awaiting model · 6.4s · 63 tok/s
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- composer -->
+    <div class="composer">
+      <div class="composer-in">
+        <div class="flags">
+          <div class="flag">
+            <span class="tag">Reviewer flag · factual</span>
+            <span class="tx">Check the integration constant — the answer omits “+ C” in the boxed line.</span>
+            <span class="rm"><i class="fa-solid fa-xmark"></i></span>
+          </div>
+        </div>
+        <div class="att">
+          <div class="t">
+            <div style="width:54px;height:54px;border:1px solid var(--line-strong);border-radius:3px;
+              background:repeating-linear-gradient(135deg,#13201f 0 6px,#0e1719 6px 12px)"></div>
+            <span class="rm"><i class="fa-solid fa-xmark"></i></span>
+          </div>
+        </div>
+        <div class="cmd">
+          <span class="glyph">▸</span>
+          <div class="ta" contenteditable="true" spellcheck="false">Now redo it for ∫ x²·ln(x) dx and keep the constant this time.</div>
+          <div class="tools">
+            <button class="icbtn" title="Attach"><i class="fa-solid fa-paperclip"></i></button>
+            <button class="icbtn" title="Tools"><i class="fa-solid fa-screwdriver-wrench"></i></button>
+            <button class="send" title="Send"><i class="fa-solid fa-paper-plane"></i></button>
+          </div>
+        </div>
+        <div class="hint">
+          <span class="g"><span class="kbd">↵</span> send</span>
+          <span class="g"><span class="kbd">⇧ ↵</span> newline</span>
+          <span class="g"><span class="kbd">⌘ K</span> commands</span>
+          <span class="g" style="margin-left:auto;color:var(--text-faint)">main · qwen3-6-27b · sympy on</span>
+        </div>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- 4 · inspector -->
+  <aside class="col inspector">
+    <div class="hdr">
+      <div class="ti"><i class="fa-solid fa-magnifying-glass"></i> Inspector</div>
+      <button class="xbtn"><i class="fa-solid fa-xmark"></i></button>
+    </div>
+    <div class="insp-form">
+      <label>Sidekick directive · qwen3-5-27b</label>
+      <div class="ta" contenteditable="true" spellcheck="false">Verify the integration constant and the ½ factor; check the algebra step by step.</div>
+      <button class="btn run"><i class="fa-solid fa-rotate"></i> Re-run critique</button>
+    </div>
+
+    <div class="scroll" style="flex:1">
+      <div class="ann">
+        <div class="top">
+          <span class="led" style="--c:var(--coral)"></span>
+          <span class="sev hi">High · factual</span>
+          <span class="ins">insert ▸</span>
+        </div>
+        <div class="q">"= ½·eˣ·( sin x − cos x ) + C"</div>
+        <div class="cm">The boxed result is correct, but the inline restatement
+        two lines below drops the <strong>+ C</strong>. Flag it so the operator
+        doesn't copy the constant-free version.</div>
+      </div>
+
+      <div class="ann">
+        <div class="top">
+          <span class="led" style="--c:var(--amber)"></span>
+          <span class="sev lo">Low · style</span>
+          <span class="ins">insert ▸</span>
+        </div>
+        <div class="q">"applying parts twice returns I…"</div>
+        <div class="cm">Solid explanation. Could show the intermediate
+        <em>2I = eˣ(sin x − cos x)</em> line explicitly — the operator asked
+        specifically where their derivation breaks.</div>
+      </div>
+
+      <div class="ann">
+        <div class="top">
+          <span class="led" style="--c:var(--green)"></span>
+          <span class="sev lo" style="color:var(--green)">Verified</span>
+        </div>
+        <div class="cm">Symbolic check via <code class="inl" style="font-size:11px">sympy-math.integrate</code>
+        independently reproduces the closed form. No numerical discrepancy.</div>
+      </div>
+    </div>
+  </aside>
+
+</div>
+
+<!-- floating tender (spin-off) -->
+<div class="tenderwin" id="tw">
+  <div class="tw-bar" id="twbar">
+    <i class="fa-solid fa-code-branch br"></i>
+    <span class="nm">the matryoshka prefix…</span>
+    <div class="ctl"><b><i class="fa-solid fa-minus"></i></b><b><i class="fa-solid fa-xmark"></i></b></div>
+  </div>
+  <div class="tw-ctx">“…use search_document: on stored text and search_query: on queries”</div>
+  <div class="tw-body scroll">
+    <div class="tw-msg u">▸ Does the ½ trick generalise to the matryoshka kernel?</div>
+    <div class="tw-msg a">Yes — the recurrence is identical once you treat the
+    truncated dimension as a fixed scalar. The prefix only changes the constant,
+    not the by-parts structure.</div>
+    <div class="tw-msg u">▸ Show the kernel derivative.</div>
+  </div>
+  <div class="tw-in">
+    <div class="f">Ask about this…</div>
+    <button class="s"><i class="fa-solid fa-paper-plane"></i></button>
+  </div>
+</div>
+
+<!-- dock tray (minimised tenders) -->
+<div class="tray">
+  <div class="t"><i class="fa-solid fa-code-branch"></i> tender · cuTensorMap repro <i class="fa-solid fa-up-right-and-down-left-from-center" style="color:var(--text-faint)"></i></div>
+</div>
+
+<script>
+  // lightweight drag for the tender window — makes the mock feel real
+  (function(){
+    var w=document.getElementById('tw'),bar=document.getElementById('twbar');
+    var dx=0,dy=0,drag=false;
+    bar.addEventListener('mousedown',function(e){
+      drag=true;var r=w.getBoundingClientRect();
+      dx=e.clientX-r.left;dy=e.clientY-r.top;
+      w.style.right='auto';w.style.bottom='auto';bar.style.cursor='grabbing';
+      e.preventDefault();
+    });
+    window.addEventListener('mousemove',function(e){
+      if(!drag)return;
+      w.style.left=Math.max(8,e.clientX-dx)+'px';
+      w.style.top=Math.max(8,e.clientY-dy)+'px';
+    });
+    window.addEventListener('mouseup',function(){drag=false;bar.style.cursor='grab'});
+  })();
+</script>
+</body>
+</html>

--- a/docs/plan-resizable-chat-sidebar.md
+++ b/docs/plan-resizable-chat-sidebar.md
@@ -1,0 +1,186 @@
+# Plan: Resizable ChatSidebar
+
+## Context
+
+The ChatSidebar (`ChatSidebar.jsx`) currently has a fixed `w-72` (288px) width with a
+collapsed `w-10` (40px) toggle. The file-explorer strip inside `ProjectChatSplit.jsx`
+already has a proven custom resize pattern using a drag divider. The goal is to make the
+conversation panel resizable so users can widen/narrow it to fit longer conversation
+titles or compact it to give more room to the chat area.
+
+## Approach: Extract shared resize logic, apply to ChatSidebar
+
+The `ProjectChatSplit` resize logic is self-contained and follows a clear pattern:
+localStorage persistence, `ResizeObserver` for window resizing, clamped drag with
+`mousedown`/`mousemove`/`mouseup` on a thin divider element. Rather than duplicating
+it, we extract the shared pieces into a reusable hook, then apply it in both places.
+
+### 1. New shared hook: `useResizableWidth`
+
+**File:** `dashboard/frontend/src/hooks/useResizableWidth.js`
+
+Encapsulates the resize state machine:
+
+| Parameter | Type | Purpose |
+|-----------|------|---------|
+| `storageKey` | `string` | localStorage key for persisted width |
+| `minWidth` | `number` | Minimum allowed width (px), default `160` |
+| `maxFraction` | `number` | Maximum fraction of container width, default `0.45` |
+| `defaultWidthPx` | `number` | Default pixel width before first drag (replaces `defaultPercent`) |
+
+Returns:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `containerRef` | `RefObject<HTMLDivElement>` | Ref to attach to the parent flex container |
+| `currentWidth` | `number` | Current width in px (hook resolves default internally, never null) |
+| `dragging` | `boolean` | Active drag state |
+| `startDrag` | `() => void` | Call on divider `mousedown` to begin drag |
+
+The hook handles:
+- Reading/writing `width` to localStorage under `storageKey`
+- `useLayoutEffect` + `ResizeObserver` on the container to compute `maxWidth`
+  (fraction of container). `useLayoutEffect` used over `useEffect` to avoid layout
+  flash when the container is first measured (matching existing `ProjectChatSplit`
+  behavior at line 84).
+- Clamping stored width against `maxWidth` on every render
+- Window-level `mousemove`/`mouseup` listeners during drag
+- `e.stopPropagation()` in `startDrag` to prevent event bubbling into parent
+  resizable containers (critical for nested splits)
+- Cursor style changes (`cursor-col-resize`) on the document body during drag
+
+### 2. Modify `ChatSidebar.jsx`
+
+**Changes:**
+- Accept controlled `collapsed` and `onCollapse`/`onExpand` props
+- Remove internal `collapsed` state management (the `useState(readCollapsed)` and
+  accompanying `useEffect` that writes to localStorage)
+- No longer imports or uses `useResizableWidth` directly — that belongs in `SidebarSplit`
+
+**Scope note:** `ChatSidebar` is only imported by `ChatPage.jsx` and
+`ChatSidebar.test.jsx`. The controlled-component change affects only these two files,
+not a broader set of consumers.
+
+### 3. New component: `SidebarSplit`
+
+**File:** `dashboard/frontend/src/components/chat/SidebarSplit.jsx`
+
+Thin wrapper component, structurally identical to the resize portion of
+`ProjectChatSplit` but without the file-editor overlay logic:
+
+```
+<SidebarSplit>
+  <ChatSidebar ... />    {/* left, resizable */}
+  {children}             {/* right, flex-1 */}
+</SidebarSplit>
+```
+
+Props:
+- (No props needed; both `collapsed` and `width` state are internal)
+
+Internal state:
+- `collapsed` — migrated from ChatSidebar, persisted under `llmdock.chatSidebar.collapsed`
+- `width` — from `useResizableWidth` hook, key `llmdock.chatSidebar.width`,
+  `defaultWidthPx: 288`, `minWidth: 200`, `maxFraction: 0.35`
+- `dragging` (from hook)
+
+Layout:
+```
+<div ref={containerRef} className="flex-1 flex overflow-hidden">
+  {collapsed && <collapsed-rail />}
+  <div style={{ display: collapsed ? 'none' : undefined, width: `${currentWidth}px`, minWidth: `${minWidth}px` }}>
+    <ChatSidebar collapsed={collapsed} onCollapse={...} onExpand={...} ... />
+  </div>
+  {!collapsed && <divider onMouseDown={startDrag} />}
+  <div className="flex-1 flex min-w-0 relative">
+    {children}
+    {dragging && <transparent-overlay z-40 />}
+  </div>
+</div>
+```
+
+The collapsed rail geometry mirrors the existing ChatSidebar collapsed rail (h-16
+bordered header, w-8 h-8 toggle, text-sm icon) so the expander chevrons of all
+collapsed panels align.
+
+The divider is conditionally rendered (`{!collapsed && ...}`), fully removed from the
+DOM when collapsed — no hidden-but-present element intercepting clicks.
+
+Transparent overlay uses `z-40` to match the existing `ProjectChatSplit` overlay
+precedent (line 216).
+
+### 4. Modify `ChatPage.jsx`
+
+Replace the flat flex layout with `SidebarSplit`:
+
+Before:
+```jsx
+<div className="flex-1 flex overflow-hidden">
+  <ChatSidebar ... />
+  {projectId ? <ProjectPage ... /> : <ProjectChatSplit ...>{children}</ProjectChatSplit>}
+</div>
+```
+
+After:
+```jsx
+<SidebarSplit>
+  <ChatSidebar ... />
+  {projectId ? <ProjectPage ... /> : <ProjectChatSplit ...>{children}</ProjectChatSplit>}
+</SidebarSplit>
+```
+
+### 5. Refactor `ProjectChatSplit.jsx`
+
+Extract the resize logic into the shared `useResizableWidth` hook to avoid duplication.
+`ProjectChatSplit` continues to manage its own width (key `llmdock.chatExplorer.width`,
+`defaultWidthPx: null` — keeping the existing 20% percentage default behavior) but
+delegates to the hook. The file-editor overlay logic stays in `ProjectChatSplit`.
+
+## Implementation Order
+
+1. **Create `useResizableWidth` hook** — extract logic from `ProjectChatSplit`
+2. **Create `SidebarSplit` component** — uses the hook, wraps sidebar + content
+3. **Smoke-test `SidebarSplit` with a dummy sidebar** — verify resize, divider,
+   overlay, and collapse work before touching real components
+4. **Modify `ChatSidebar`** — accept controlled `collapsed` prop, remove internal
+   collapse state management
+5. **Refactor `ProjectChatSplit`** — use the shared hook for resize logic
+6. **Modify `ChatPage`** — wrap layout in `SidebarSplit`
+7. **Update `ChatSidebar.test.jsx`** — adapt tests for controlled `collapsed` prop
+8. **Test** — verify resize, collapse, localStorage persistence, window resize,
+   nested splits (SidebarSplit + ProjectChatSplit), keyboard shortcuts
+
+## Risks & Considerations
+
+- **Backward compatibility:** Existing `llmdock.chatSidebar.collapsed` localStorage key
+  is reused. New `llmdock.chatSidebar.width` key starts as `null` (default 288px).
+- **No initial jump:** `defaultWidthPx: 288` matches the current `w-72` fixed width,
+  so existing users see no visual change on first load.
+- **Minimum width:** `200px` for the sidebar (vs `160px` for the file explorer).
+  Conversation titles need more room than file names.
+- **Maximum width:** `35%` fraction for the sidebar (vs `45%` for the file explorer).
+  Conversation lists don't need to be extremely wide.
+- **Nested resizable splits:** When the conversation belongs to a project, we'll have
+  `SidebarSplit` (sidebar) -> `ProjectChatSplit` (explorer strip) -> Chat. Two resizable
+  splits nested. Each has its own container ref and independently computes max width.
+  The `startDrag` calls `e.stopPropagation()` to prevent the inner divider's drag from
+  bubbling to the outer split. Transparent overlays won't conflict because they're in
+  different subtrees.
+- **Text truncation already handled:** `ConversationItem` already uses `truncate` class
+  (line 137), so rapid reflow during drag won't cause vertical layout shifts.
+- **Layout thrashing:** The existing `ProjectChatSplit` already uses `useState` updated
+  on every `mousemove` without reported issues. The hook follows the same pattern.
+- **Keyboard accessibility:** Add `Cmd/Ctrl + [` and `Cmd/Ctrl + ]` shortcuts on
+  `ChatPage` to increment/decrement sidebar width (e.g. by 20px steps) and toggle
+  collapse. Draggable dividers are inaccessible to keyboard-only users.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `hooks/useResizableWidth.js` | **New** — shared resize hook |
+| `components/chat/SidebarSplit.jsx` | **New** — resizable sidebar wrapper |
+| `components/chat/ChatSidebar.jsx` | Accept controlled `collapsed` prop |
+| `components/chat/ProjectChatSplit.jsx` | Use shared hook |
+| `components/chat/ChatPage.jsx` | Wrap in `SidebarSplit`, add keyboard shortcuts |
+| `components/chat/ChatSidebar.test.jsx` | Adapt for controlled `collapsed` prop |


### PR DESCRIPTION
## Summary

- Extract resize logic from ProjectChatSplit into a reusable `useResizableWidth` hook
- Add `SidebarSplit` wrapper component for the main chat sidebar with collapse, drag-resize, and keyboard shortcuts (Cmd/Ctrl+[ ] B)
- Add matching "Conversations" title bar to align with the file explorer panel
- Show vertical titles on collapsed rails (clickable to expand)
- Consistent expand/collapse icon size across all states
- Supports nested resizable splits via `e.stopPropagation()` in startDrag

## Files Changed

- `hooks/useResizableWidth.js` — new shared resize hook
- `components/chat/SidebarSplit.jsx` — new wrapper component
- `components/chat/ChatSidebar.jsx` — controlled collapse, title bar
- `components/chat/ProjectChatSplit.jsx` — delegates to shared hook
- `components/chat/ProjectExplorerPane.jsx` — icon size fix
- `components/chat/ChatPage.jsx` — SidebarSplit integration, keyboard shortcuts
- `components/chat/ChatSidebar.test.jsx` — updated for controlled props