### PR TITLE
feat: llama.cpp live metrics with /slots-based throughput and Y-axis labels

### DIFF
--- a/dashboard/flag_metadata.py
+++ b/dashboard/flag_metadata.py
@@ -492,6 +492,12 @@ LLAMACPP_LLAMA_SERVER_FLAGS = {
         "description": "Reasoning format (auto, cot, etc.)",
         "tip": "Controls how <b>chain-of-thought / reasoning tokens</b> are surfaced in API responses. <code>auto</code> (default) detects the model's capability; <code>deepseek</code> extracts <code>&lt;think&gt;</code> blocks into a separate <code>reasoning_content</code> field; <code>none</code> leaves thought tags raw inside <code>content</code>.",
     },
+    "metrics": {
+        "cli": "--metrics",
+        "type": "bool",
+        "description": "Enable Prometheus-compatible metrics endpoint at /metrics",
+        "tip": "Exposes a <b>Prometheus-compatible metrics endpoint</b> at <code>/metrics</code> with real-time counters for prompt tokens, generation tokens, request queue, and slot utilization. Enabled by default for all services.",
+    },
     # Memory
     "no_mmap": {
         "cli": "--no-mmap",
@@ -1165,6 +1171,7 @@ _LLAMACPP_LLAMA_SERVER_CATEGORIES = {
     "log_verbosity": "Features",
     "log_file": "Features",
     "reasoning_format": "Features",
+    "metrics": "Features",
     "no_mmap": "Memory",
     "rope_freq_base": "RoPE",
     "rope_freq_scale": "RoPE",

--- a/dashboard/frontend/src/components/MetricsPanel.jsx
+++ b/dashboard/frontend/src/components/MetricsPanel.jsx
@@ -37,7 +37,7 @@ export default function MetricsPanel({ serviceName, enabled }) {
           <span className="text-fg-subtle text-sm">(disabled)</span>
         </div>
         <p className="text-fg-muted text-sm">
-          Metrics are only available for running vLLM services. Start the service to see live metrics.
+          Metrics are only available for running services. Start the service to see live metrics.
         </p>
       </div>
     )
@@ -77,7 +77,7 @@ export default function MetricsPanel({ serviceName, enabled }) {
         <div className="flex flex-col items-center justify-center py-12">
           <i className="fa-solid fa-chart-line text-3xl text-fg-faint mb-3" />
           <p className="text-fg-muted text-sm mb-1">No metrics available</p>
-          <p className="text-fg-subtle text-xs">The vLLM prometheus endpoint returned no data or is unreachable.</p>
+          <p className="text-fg-subtle text-xs">The prometheus endpoint returned no data or is unreachable.</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/dashboard/frontend/src/components/ServiceDetailsPage.jsx
+++ b/dashboard/frontend/src/components/ServiceDetailsPage.jsx
@@ -181,7 +181,7 @@ export default function ServiceDetailsPage() {
 
       {isMetricsRoute ? (
         <div className="flex-1 overflow-auto">
-          <MetricsPanel serviceName={serviceName} enabled={templateType === 'vllm' && runtime?.status === 'running'} />
+          <MetricsPanel serviceName={serviceName} enabled={(templateType === 'vllm' || templateType === 'llamacpp') && runtime?.status === 'running'} />
         </div>
       ) : isLogsRoute ? (
         <div className="flex-1 min-h-0">

--- a/dashboard/frontend/src/components/TokenSparkline.jsx
+++ b/dashboard/frontend/src/components/TokenSparkline.jsx
@@ -31,11 +31,16 @@ function draw(canvas, history) {
   const labelW = 44
   const pad = 2
   const chartX = labelW
-  const chartW = width - chartX - pad
+  const chartW = width - 2 * labelW
+  const chartRight = chartX + chartW
 
+  // Prefill runs 10-100x faster than decode, so a shared scale would flatten
+  // the gen line. Each line keeps its own scale, with its axis labels drawn
+  // in the line's color: prompt on the left, gen on the right.
   const promptData = points.map(p => p.promptTokensRate || 0)
   const genData = points.map(p => p.generationTokensRate || 0)
-  const globalMax = Math.max(1, ...promptData, ...genData)
+  const promptMax = Math.max(1, ...promptData)
+  const genMax = Math.max(1, ...genData)
 
   // Grid lines
   ctx.strokeStyle = cssVar('--color-chart-grid')
@@ -44,7 +49,7 @@ function draw(canvas, history) {
     const y = pad + (height - 2 * pad) * (i / 4)
     ctx.beginPath()
     ctx.moveTo(chartX, y)
-    ctx.lineTo(width, y)
+    ctx.lineTo(chartRight, y)
     ctx.stroke()
   }
 
@@ -60,30 +65,34 @@ function draw(canvas, history) {
   const pointW = chartW / (MAX_POINTS - 1)
 
   // Y-axis labels
-  ctx.fillStyle = cssVar('--color-fg-subtle')
   ctx.font = '9px sans-serif'
-  ctx.textAlign = 'right'
   ctx.textBaseline = 'middle'
-  for (let i = 0; i <= 4; i++) {
-    const val = globalMax * (1 - i / 4)
-    const y = pad + (height - 2 * pad) * (i / 4)
-    ctx.fillText(labelTps(val), chartX - 4, y)
+  const drawAxis = (max, color, align, x) => {
+    ctx.fillStyle = color
+    ctx.textAlign = align
+    for (let i = 0; i <= 4; i++) {
+      const val = max * (1 - i / 4)
+      const y = pad + (height - 2 * pad) * (i / 4)
+      ctx.fillText(labelTps(val), x, y)
+    }
   }
+  drawAxis(promptMax, cssVar('--color-chart-memory'), 'right', chartX - 4)
+  drawAxis(genMax, cssVar('--color-chart-compute'), 'left', chartRight + 4)
 
-  const drawLine = (data, color) => {
+  const drawLine = (data, max, color) => {
     ctx.strokeStyle = color
     ctx.lineWidth = 2
     ctx.beginPath()
     data.forEach((val, i) => {
-      const x = width - pad - (len - 1 - i) * pointW
-      const y = height - pad - (val / globalMax) * (height - 2 * pad)
+      const x = chartRight - (len - 1 - i) * pointW
+      const y = height - pad - (val / max) * (height - 2 * pad)
       i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
     })
     ctx.stroke()
   }
 
-  drawLine(promptData, cssVar('--color-chart-memory'))
-  drawLine(genData, cssVar('--color-chart-compute'))
+  drawLine(promptData, promptMax, cssVar('--color-chart-memory'))
+  drawLine(genData, genMax, cssVar('--color-chart-compute'))
 }
 
 export default function TokenSparkline({ history }) {

--- a/dashboard/frontend/src/components/TokenSparkline.jsx
+++ b/dashboard/frontend/src/components/TokenSparkline.jsx
@@ -9,6 +9,11 @@ function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
 }
 
+function labelTps(n) {
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k'
+  return n.toFixed(1)
+}
+
 function draw(canvas, history) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
@@ -21,7 +26,16 @@ function draw(canvas, history) {
   ctx.scale(dpr, dpr)
   ctx.clearRect(0, 0, width, height)
 
+  const points = history.slice(-MAX_POINTS)
+  const len = points.length
+  const labelW = 44
   const pad = 2
+  const chartX = labelW
+  const chartW = width - chartX - pad
+
+  const promptData = points.map(p => p.promptTokensRate || 0)
+  const genData = points.map(p => p.generationTokensRate || 0)
+  const globalMax = Math.max(1, ...promptData, ...genData)
 
   // Grid lines
   ctx.strokeStyle = cssVar('--color-chart-grid')
@@ -29,42 +43,47 @@ function draw(canvas, history) {
   for (let i = 0; i <= 4; i++) {
     const y = pad + (height - 2 * pad) * (i / 4)
     ctx.beginPath()
-    ctx.moveTo(0, y)
+    ctx.moveTo(chartX, y)
     ctx.lineTo(width, y)
     ctx.stroke()
   }
-
-  // Limit history to MAX_POINTS to prevent canvas spill
-  const points = history.slice(-MAX_POINTS)
-  const len = points.length
 
   if (len < 2) {
     ctx.fillStyle = cssVar('--color-fg-subtle')
     ctx.font = '13px sans-serif'
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
-    ctx.fillText('Awaiting data points...', width / 2, height / 2)
+    ctx.fillText('Awaiting data points...', chartX + chartW / 2, height / 2)
     return
   }
 
-  const pointW = (width - 2 * pad) / (MAX_POINTS - 1)
+  const pointW = chartW / (MAX_POINTS - 1)
 
-  const drawLine = (selector, color) => {
-    const data = points.map(selector)
-    const lineMax = Math.max(1, ...data)
+  // Y-axis labels
+  ctx.fillStyle = cssVar('--color-fg-subtle')
+  ctx.font = '9px sans-serif'
+  ctx.textAlign = 'right'
+  ctx.textBaseline = 'middle'
+  for (let i = 0; i <= 4; i++) {
+    const val = globalMax * (1 - i / 4)
+    const y = pad + (height - 2 * pad) * (i / 4)
+    ctx.fillText(labelTps(val), chartX - 4, y)
+  }
+
+  const drawLine = (data, color) => {
     ctx.strokeStyle = color
     ctx.lineWidth = 2
     ctx.beginPath()
     data.forEach((val, i) => {
       const x = width - pad - (len - 1 - i) * pointW
-      const y = height - pad - (val / lineMax) * (height - 2 * pad)
+      const y = height - pad - (val / globalMax) * (height - 2 * pad)
       i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
     })
     ctx.stroke()
   }
 
-  drawLine(dp => dp.promptTokensRate || 0, cssVar('--color-chart-memory'))
-  drawLine(dp => dp.generationTokensRate || 0, cssVar('--color-chart-compute'))
+  drawLine(promptData, cssVar('--color-chart-memory'))
+  drawLine(genData, cssVar('--color-chart-compute'))
 }
 
 export default function TokenSparkline({ history }) {

--- a/dashboard/frontend/src/hooks/useServiceMetrics.js
+++ b/dashboard/frontend/src/hooks/useServiceMetrics.js
@@ -5,14 +5,37 @@ import { getValue } from '../utils'
 const POLL_INTERVAL = 200
 const MAX_HISTORY = 60
 
+// Map llama.cpp metric names to vLLM-equivalent names so the rest of the hook
+// and downstream components can use a single set of keys.
+const LLAMACPP_TO_VLLM = {
+  'llamacpp:prompt_tokens_total': 'vllm:prompt_tokens_total',
+  'llamacpp:tokens_predicted_total': 'vllm:generation_tokens_total',
+  'llamacpp:prompt_tokens_seconds': 'vllm:prompt_tokens_seconds',
+  'llamacpp:predicted_tokens_seconds': 'vllm:generation_tokens_seconds',
+  'llamacpp:requests_processing': 'vllm:num_requests_running',
+  'llamacpp:requests_deferred': 'vllm:num_requests_waiting',
+}
+
+function normalizeMetrics(raw, engine) {
+  if (engine !== 'llamacpp') return raw
+  const normalized = {}
+  for (const [key, value] of Object.entries(raw)) {
+    const mapped = LLAMACPP_TO_VLLM[key] || key
+    normalized[mapped] = value
+  }
+  return normalized
+}
+
 export default function useServiceMetrics({ serviceName, enabled }) {
   const [metrics, setMetrics] = useState({})
   const [history, setHistory] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [lastScraped, setLastScraped] = useState(null)
+  const [engine, setEngine] = useState(null)
   const mountedRef = useRef(true)
-  const prevRef = useRef({ counters: null, timestamp: null })
+  const prevRef = useRef({ timestamp: null, counterPrompt: null, counterGen: null, counterPreempt: null })
+  const slotsRef = useRef({})
 
   useEffect(() => {
     if (!enabled) {
@@ -22,7 +45,9 @@ export default function useServiceMetrics({ serviceName, enabled }) {
       setLoading(false)
       setError(null)
       setLastScraped(null)
-      prevRef.current = { counters: null, timestamp: null, counterPrompt: null, counterGen: null, counterPreempt: null }
+      setEngine(null)
+      prevRef.current = { timestamp: null, counterPrompt: null, counterGen: null, counterPreempt: null }
+      slotsRef.current = {}
     }
   }, [enabled])
 
@@ -41,22 +66,46 @@ export default function useServiceMetrics({ serviceName, enabled }) {
         if (!pollActive || !mountedRef.current) return
 
         const raw = data.metrics || {}
-        setMetrics(raw)
+        const eng = data.engine || 'vllm'
+        const normalized = normalizeMetrics(raw, eng)
+
+        let slots = null
+        if (eng === 'llamacpp') {
+          try {
+            const slotsData = await fetchAPI(`/services/${serviceName}/slots`)
+            if (pollActive && mountedRef.current) slots = slotsData.slots
+          } catch {
+            slots = null
+          }
+        }
+        if (!pollActive || !mountedRef.current) return
+
+        setMetrics(normalized)
+        setEngine(eng)
         setError(null)
         setLastScraped(data.scraped_at)
 
         const now = Date.now() / 1000
 
-        const promptTotal = getValue(raw, 'vllm:prompt_tokens_total')
-        const genTotal = getValue(raw, 'vllm:generation_tokens_total')
-        const kvCache = getValue(raw, 'vllm:kv_cache_usage_perc')
-        const prefixHits = getValue(raw, 'vllm:prefix_cache_hits_total')
-        const prefixQueries = getValue(raw, 'vllm:prefix_cache_queries_total')
-        const specAccepted = getValue(raw, 'vllm:spec_decode_num_accepted_tokens_total')
-        const specDraftTokens = getValue(raw, 'vllm:spec_decode_num_draft_tokens_total')
-        const running = getValue(raw, 'vllm:num_requests_running')
-        const waiting = getValue(raw, 'vllm:num_requests_waiting')
-        const preemptTotal = getValue(raw, 'vllm:num_preemptions_total')
+        const promptTotal = getValue(normalized, 'vllm:prompt_tokens_total')
+        const genTotal = getValue(normalized, 'vllm:generation_tokens_total')
+        const kvCache = getValue(normalized, 'vllm:kv_cache_usage_perc')
+        const prefixHits = getValue(normalized, 'vllm:prefix_cache_hits_total')
+        const prefixQueries = getValue(normalized, 'vllm:prefix_cache_queries_total')
+        const specAccepted = getValue(normalized, 'vllm:spec_decode_num_accepted_tokens_total')
+        const specDraftTokens = getValue(normalized, 'vllm:spec_decode_num_draft_tokens_total')
+        const running = getValue(normalized, 'vllm:num_requests_running')
+        const waiting = getValue(normalized, 'vllm:num_requests_waiting')
+        const preemptTotal = getValue(normalized, 'vllm:num_preemptions_total')
+
+        // llama.cpp's Prometheus throughput gauges are lifetime averages that
+        // converge and never decay — useless for a live graph. The /slots
+        // endpoint exposes per-slot counters that tick mid-generation:
+        // n_decoded (generated tokens) and n_prompt_tokens_processed (prompt
+        // progress). Both reset per task, so deltas are tracked per slot and
+        // keyed by id_task to avoid negative spikes on task rollover.
+        const promptTokensSec = getValue(normalized, 'vllm:prompt_tokens_seconds')
+        const genTokensSec = getValue(normalized, 'vllm:generation_tokens_seconds')
 
         const prev = prevRef.current
         let promptTokensRate = 0
@@ -64,16 +113,43 @@ export default function useServiceMetrics({ serviceName, enabled }) {
         let preemptRate = 0
 
         const dt = prev.timestamp != null ? now - prev.timestamp : 0
-        if (dt > 0) {
+        if (eng === 'llamacpp') {
+          if (slots != null) {
+            let decodedDelta = 0
+            let promptDelta = 0
+            const seen = {}
+            for (const slot of slots) {
+              const prevSlot = slotsRef.current[slot.id]
+              const nDecoded = slot.n_decoded ?? 0
+              const nPrompt = slot.n_prompt_tokens_processed ?? 0
+              if (prevSlot && prevSlot.idTask === slot.id_task) {
+                if (nDecoded > prevSlot.nDecoded) decodedDelta += nDecoded - prevSlot.nDecoded
+                if (nPrompt > prevSlot.nPrompt) promptDelta += nPrompt - prevSlot.nPrompt
+              }
+              seen[slot.id] = { idTask: slot.id_task, nDecoded, nPrompt }
+            }
+            slotsRef.current = seen
+            if (dt > 0) {
+              generationTokensRate = decodedDelta / dt
+              promptTokensRate = promptDelta / dt
+            }
+          } else {
+            // /slots unreachable — fall back to the lifetime-average gauges,
+            // zeroed while idle
+            const busy = (running ?? 0) > 0 ? 1 : 0
+            promptTokensRate = promptTokensSec != null ? Math.max(0, promptTokensSec) * busy : 0
+            generationTokensRate = genTokensSec != null ? Math.max(0, genTokensSec) * busy : 0
+          }
+        } else if (dt > 0) {
           if (prev.counterPrompt != null && promptTotal != null) {
             promptTokensRate = Math.max(0, (promptTotal - prev.counterPrompt) / dt)
           }
           if (prev.counterGen != null && genTotal != null) {
             generationTokensRate = Math.max(0, (genTotal - prev.counterGen) / dt)
           }
-          if (prev.counterPreempt != null && preemptTotal != null) {
-            preemptRate = Math.max(0, (preemptTotal - prev.counterPreempt) / dt)
-          }
+        }
+        if (dt > 0 && prev.counterPreempt != null && preemptTotal != null) {
+          preemptRate = Math.max(0, (preemptTotal - prev.counterPreempt) / dt)
         }
 
         let prefixHitRatio = undefined
@@ -89,11 +165,11 @@ export default function useServiceMetrics({ serviceName, enabled }) {
         const dataPoint = {
           promptTokensRate,
           generationTokensRate,
-          kvCache: kvCache !== undefined ? kvCache : undefined,
+          kvCache,
           prefixHitRatio,
           specAcceptRatio,
-          running: running ?? undefined,
-          waiting: waiting ?? undefined,
+          running,
+          waiting,
           preemptRate
         }
 
@@ -119,7 +195,8 @@ export default function useServiceMetrics({ serviceName, enabled }) {
       }
     }
 
-    prevRef.current = { counters: null, timestamp: null, counterPrompt: null, counterGen: null, counterPreempt: null }
+    prevRef.current = { timestamp: null, counterPrompt: null, counterGen: null, counterPreempt: null }
+    slotsRef.current = {}
     fetchMetrics()
     const id = setInterval(fetchMetrics, POLL_INTERVAL)
 
@@ -130,5 +207,5 @@ export default function useServiceMetrics({ serviceName, enabled }) {
     }
   }, [serviceName, enabled])
 
-  return { metrics, history, loading, error, lastScraped }
+  return { metrics, history, loading, error, lastScraped, engine }
 }

--- a/dashboard/frontend/src/hooks/useServiceMetrics.test.js
+++ b/dashboard/frontend/src/hooks/useServiceMetrics.test.js
@@ -196,4 +196,244 @@ describe('useServiceMetrics', () => {
     expect(result.current.history).toEqual([])
     expect(result.current.loading).toBe(false)
   })
+
+  it('normalizes llama.cpp metric names to vLLM equivalents', async () => {
+    const llamacppMetrics = {
+      'llamacpp:prompt_tokens_total': { '{}': 25000 },
+      'llamacpp:tokens_predicted_total': { '{}': 60000 },
+      'llamacpp:prompt_tokens_seconds': { '{}': 500 },
+      'llamacpp:predicted_tokens_seconds': { '{}': 100 },
+      'llamacpp:requests_processing': { '{}': 2 },
+      'llamacpp:requests_deferred': { '{}': 1 },
+    }
+    mockFetchAPI.mockResolvedValue({ metrics: llamacppMetrics, engine: 'llamacpp', scraped_at: '2026-01-01T00:00:00Z' })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current.engine).toBe('llamacpp')
+    expect(result.current.metrics).toHaveProperty('vllm:prompt_tokens_total')
+    expect(result.current.metrics).toHaveProperty('vllm:generation_tokens_total')
+    expect(result.current.metrics).toHaveProperty('vllm:prompt_tokens_seconds')
+    expect(result.current.metrics).toHaveProperty('vllm:generation_tokens_seconds')
+    expect(result.current.metrics).toHaveProperty('vllm:num_requests_running')
+    expect(result.current.metrics).toHaveProperty('vllm:num_requests_waiting')
+    expect(result.current.metrics).not.toHaveProperty('llamacpp:prompt_tokens_total')
+    expect(result.current.metrics).not.toHaveProperty('llamacpp:tokens_predicted_total')
+  })
+
+  it('leaves vLLM metric names unchanged', async () => {
+    mockFetchAPI.mockResolvedValue({ metrics: mockMetrics, engine: 'vllm', scraped_at: '2026-01-01T00:00:00Z' })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'vllm-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current.engine).toBe('vllm')
+    expect(result.current.metrics).toHaveProperty('vllm:prompt_tokens_total')
+    expect(result.current.metrics).toHaveProperty('vllm:generation_tokens_total')
+  })
+
+const llamacppMetricsBase = {
+  metrics: {
+    'llamacpp:prompt_tokens_total': { '{}': 1000 },
+    'llamacpp:tokens_predicted_total': { '{}': 2000 },
+    'llamacpp:prompt_tokens_seconds': { '{}': 500 },
+    'llamacpp:predicted_tokens_seconds': { '{}': 60 },
+    'llamacpp:requests_processing': { '{}': 1 },
+    'llamacpp:requests_deferred': { '{}': 0 },
+  },
+  engine: 'llamacpp',
+  scraped_at: '2026-01-01T00:00:00Z'
+}
+
+function slotsPayload(slots) {
+  return { slots, scraped_at: '2026-01-01T00:00:00Z' }
+}
+
+function queueLlamaCpp({ metrics, slots }) {
+  const metricsQueue = (Array.isArray(metrics) ? metrics : [metrics]).slice()
+  const slotsQueue = (Array.isArray(slots) ? slots : [slots]).slice()
+  mockFetchAPI.mockImplementation((path) => {
+    if (path.includes('/slots')) {
+      const next = slotsQueue.length > 1 ? slotsQueue.shift() : slotsQueue[0]
+      return next instanceof Error ? Promise.reject(next) : Promise.resolve(next)
+    }
+    const next = metricsQueue.length > 1 ? metricsQueue.shift() : metricsQueue[0]
+    return next instanceof Error ? Promise.reject(next) : Promise.resolve(next)
+  })
+}
+
+describe('useServiceMetrics llama.cpp slots', () => {
+  it('derives live generation rate from slot n_decoded deltas', async () => {
+    queueLlamaCpp({
+      metrics: llamacppMetricsBase,
+      slots: [
+        slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 1000, n_prompt_tokens: 500, n_prompt_tokens_processed: 500 }]),
+        slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 1200, n_prompt_tokens: 500, n_prompt_tokens_processed: 500 }]),
+      ]
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.history.length).toBeGreaterThanOrEqual(3)
+    // first scrape establishes the baseline — no delta yet
+    expect(result.current.history[0].generationTokensRate).toBe(0)
+    // second scrape sees n_decoded 1000 -> 1200
+    expect(result.current.history[1].generationTokensRate).toBeGreaterThan(0)
+    // subsequent scrapes see no further movement
+    expect(result.current.history[2].generationTokensRate).toBe(0)
+  })
+
+  it('derives prompt rate from slot n_prompt_tokens_processed deltas', async () => {
+    queueLlamaCpp({
+      metrics: llamacppMetricsBase,
+      slots: [
+        slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 0, n_prompt_tokens: 800, n_prompt_tokens_processed: 500 }]),
+        slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 0, n_prompt_tokens: 800, n_prompt_tokens_processed: 800 }]),
+      ]
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.history[0].promptTokensRate).toBe(0)
+    expect(result.current.history[1].promptTokensRate).toBeGreaterThan(0)
+    expect(result.current.history[1].generationTokensRate).toBe(0)
+  })
+
+  it('task rollover resets the baseline without a negative spike', async () => {
+    queueLlamaCpp({
+      metrics: llamacppMetricsBase,
+      slots: [
+        slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 1500, n_prompt_tokens: 500, n_prompt_tokens_processed: 500 }]),
+        slotsPayload([{ id: 0, is_processing: true, id_task: 101, n_decoded: 5, n_prompt_tokens: 300, n_prompt_tokens_processed: 300 }]),
+        slotsPayload([{ id: 0, is_processing: true, id_task: 101, n_decoded: 25, n_prompt_tokens: 300, n_prompt_tokens_processed: 300 }]),
+      ]
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // task changed 100 -> 101 with n_decoded reset to 5: delta discarded, rate 0
+    expect(result.current.history[1].generationTokensRate).toBe(0)
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // same task 101, n_decoded 5 -> 25: real delta
+    expect(result.current.history[2].generationTokensRate).toBeGreaterThan(0)
+  })
+
+  it('idle slots yield zero rates even with stale throughput gauges', async () => {
+    queueLlamaCpp({
+      metrics: {
+        metrics: {
+          'llamacpp:prompt_tokens_total': { '{}': 1000 },
+          'llamacpp:tokens_predicted_total': { '{}': 2000 },
+          'llamacpp:prompt_tokens_seconds': { '{}': 1954 },
+          'llamacpp:predicted_tokens_seconds': { '{}': 104 },
+          'llamacpp:requests_processing': { '{}': 0 },
+          'llamacpp:requests_deferred': { '{}': 0 },
+        },
+        engine: 'llamacpp',
+        scraped_at: '2026-01-01T00:00:00Z'
+      },
+      slots: slotsPayload([
+        { id: 0, is_processing: false, id_task: 100, n_decoded: 1602, n_prompt_tokens: 4834, n_prompt_tokens_processed: 2129 },
+      ])
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    for (const point of result.current.history) {
+      expect(point.promptTokensRate).toBe(0)
+      expect(point.generationTokensRate).toBe(0)
+    }
+    expect(result.current.history[0].running).toBe(0)
+  })
+
+  it('falls back to throughput gauges when the slots endpoint fails', async () => {
+    queueLlamaCpp({
+      metrics: llamacppMetricsBase,
+      slots: new Error('404')
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current.history.length).toBeGreaterThanOrEqual(1)
+    const firstPoint = result.current.history[0]
+    expect(firstPoint.promptTokensRate).toBe(500)
+    expect(firstPoint.generationTokensRate).toBe(60)
+  })
+
+  it('gauge fallback is zeroed while idle', async () => {
+    queueLlamaCpp({
+      metrics: {
+        metrics: {
+          'llamacpp:prompt_tokens_total': { '{}': 1000 },
+          'llamacpp:tokens_predicted_total': { '{}': 2000 },
+          'llamacpp:prompt_tokens_seconds': { '{}': 500 },
+          'llamacpp:predicted_tokens_seconds': { '{}': 60 },
+          'llamacpp:requests_processing': { '{}': 0 },
+          'llamacpp:requests_deferred': { '{}': 0 },
+        },
+        engine: 'llamacpp',
+        scraped_at: '2026-01-01T00:00:00Z'
+      },
+      slots: new Error('404')
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    const firstPoint = result.current.history[0]
+    expect(firstPoint.promptTokensRate).toBe(0)
+    expect(firstPoint.generationTokensRate).toBe(0)
+  })
+
+  it('running/waiting counts still map from metrics while rates come from slots', async () => {
+    queueLlamaCpp({
+      metrics: {
+        metrics: {
+          ...llamacppMetricsBase.metrics,
+          'llamacpp:requests_processing': { '{}': 2 },
+          'llamacpp:requests_deferred': { '{}': 1 },
+        },
+        engine: 'llamacpp',
+        scraped_at: '2026-01-01T00:00:00Z'
+      },
+      slots: slotsPayload([{ id: 0, is_processing: true, id_task: 100, n_decoded: 100, n_prompt_tokens: 500, n_prompt_tokens_processed: 500 }])
+    })
+    const { result } = renderHook(() => useServiceMetrics({ serviceName: 'llamacpp-test', enabled: true }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current.history[0].running).toBe(2)
+    expect(result.current.history[0].waiting).toBe(1)
+  })
+})
 })

--- a/dashboard/routes/metrics.py
+++ b/dashboard/routes/metrics.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 metrics_bp = Blueprint("metrics", __name__)
 
-CURATED_METRICS = {
+VLLM_CURATED_METRICS = {
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
     "vllm:num_preemptions_total",
@@ -31,6 +31,20 @@ CURATED_METRICS = {
     "vllm:estimated_write_bytes_per_gpu_total",
 }
 
+LLAMACPP_CURATED_METRICS = {
+    "llamacpp:prompt_tokens_total",
+    "llamacpp:prompt_seconds_total",
+    "llamacpp:tokens_predicted_total",
+    "llamacpp:tokens_predicted_seconds_total",
+    "llamacpp:n_decode_total",
+    "llamacpp:n_tokens_max",
+    "llamacpp:prompt_tokens_seconds",
+    "llamacpp:predicted_tokens_seconds",
+    "llamacpp:requests_processing",
+    "llamacpp:requests_deferred",
+    "llamacpp:n_busy_slots_per_decode",
+}
+
 
 def _get_service_config(service_name: str):
     from config import COMPOSE_FILE
@@ -40,9 +54,10 @@ def _get_service_config(service_name: str):
     return mgr.get_service_from_db(service_name)
 
 
-def _parse_metrics(text: str) -> dict:
+def _parse_metrics(text: str, engine: str) -> dict:
     from prometheus_client.parser import text_string_to_metric_families
 
+    curated = VLLM_CURATED_METRICS if engine == "vllm" else LLAMACPP_CURATED_METRICS
     result = {}
     try:
         families = text_string_to_metric_families(text)
@@ -51,17 +66,15 @@ def _parse_metrics(text: str) -> dict:
 
     for family in families:
         parsed_name = family.name
-        # prometheus_client strips _total from counter names; match both forms
         canonical = None
-        if parsed_name in CURATED_METRICS:
+        if parsed_name in curated:
             canonical = parsed_name
-        elif f"{parsed_name}_total" in CURATED_METRICS:
+        elif f"{parsed_name}_total" in curated:
             canonical = f"{parsed_name}_total"
         if canonical is None:
             continue
 
-        if canonical == "vllm:spec_decode_num_accepted_tokens_per_pos_total":
-            # Flatten position labels to position_N keys
+        if engine == "vllm" and canonical == "vllm:spec_decode_num_accepted_tokens_per_pos_total":
             metric_data = {}
             for sample in family.samples:
                 pos = sample.labels.get("position")
@@ -81,38 +94,118 @@ def _parse_metrics(text: str) -> dict:
     return result
 
 
-def _fetch_metrics(host_port: int) -> dict:
+def _fetch_metrics(host_port: int, engine: str, api_key: str = "") -> dict:
     try:
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         resp = requests.get(
-            f"http://127.0.0.1:{host_port}/metrics", timeout=2
+            f"http://127.0.0.1:{host_port}/metrics", timeout=2, headers=headers
         )
         if resp.status_code != 200:
             logger.debug(f"Metrics endpoint returned {resp.status_code}")
             return {}
-        return _parse_metrics(resp.text)
+        return _parse_metrics(resp.text, engine)
     except (requests.ConnectionError, requests.Timeout, requests.RequestException) as e:
         logger.debug(f"Failed to fetch metrics: {e}")
         return {}
 
 
+def _fetch_slots(host_port: int, api_key: str = ""):
+    try:
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        resp = requests.get(
+            f"http://127.0.0.1:{host_port}/slots", timeout=2, headers=headers
+        )
+        if resp.status_code != 200:
+            logger.debug(f"Slots endpoint returned {resp.status_code}")
+            return None
+        return resp.json()
+    except (requests.ConnectionError, requests.Timeout, requests.RequestException, ValueError) as e:
+        logger.debug(f"Failed to fetch slots: {e}")
+        return None
+
+
+def _slim_slots(slots: list) -> list:
+    slim = []
+    for slot in slots:
+        next_token = (slot.get("next_token") or [{}])[0]
+        slim.append({
+            "id": slot.get("id"),
+            "is_processing": bool(slot.get("is_processing")),
+            "id_task": slot.get("id_task"),
+            "n_decoded": next_token.get("n_decoded", 0),
+            "n_prompt_tokens": slot.get("n_prompt_tokens", 0),
+            "n_prompt_tokens_processed": slot.get("n_prompt_tokens_processed", 0),
+        })
+    return slim
+
+
 @metrics_bp.route("/api/services/<service_name>/metrics", methods=["GET"])
 @require_auth
 def get_service_metrics(service_name):
-    """Fetch curated Prometheus metrics for a vLLM service."""
+    """Fetch curated Prometheus metrics for a model service."""
     config = _get_service_config(service_name)
     if not config:
         return jsonify({"error": f"Service '{service_name}' not found"}), 404
 
-    if config.get("template_type") != "vllm":
-        return jsonify({"metrics": {}, "scraped_at": datetime.now(timezone.utc).isoformat()})
+    template_type = config.get("template_type")
+    if template_type not in ("vllm", "llamacpp"):
+        return jsonify({
+            "metrics": {},
+            "engine": template_type,
+            "scraped_at": datetime.now(timezone.utc).isoformat(),
+        })
+
+    engine = "vllm" if template_type == "vllm" else "llamacpp"
 
     host_port = config.get("port")
     if not host_port:
-        return jsonify({"metrics": {}, "scraped_at": datetime.now(timezone.utc).isoformat()})
+        return jsonify({
+            "metrics": {},
+            "engine": engine,
+            "scraped_at": datetime.now(timezone.utc).isoformat(),
+        })
 
-    metrics = _fetch_metrics(host_port)
+    api_key = config.get("api_key", "")
+    metrics = _fetch_metrics(host_port, engine, api_key)
 
     return jsonify({
         "metrics": metrics,
+        "engine": engine,
+        "scraped_at": datetime.now(timezone.utc).isoformat(),
+    })
+
+
+@metrics_bp.route("/api/services/<service_name>/slots", methods=["GET"])
+@require_auth
+def get_service_slots(service_name):
+    """Fetch live per-slot generation state for a llama.cpp service."""
+    config = _get_service_config(service_name)
+    if not config:
+        return jsonify({"error": f"Service '{service_name}' not found"}), 404
+
+    if config.get("template_type") != "llamacpp":
+        return jsonify({"error": "Slots endpoint is only available for llamacpp services"}), 400
+
+    host_port = config.get("port")
+    if not host_port:
+        return jsonify({
+            "slots": [],
+            "scraped_at": datetime.now(timezone.utc).isoformat(),
+        })
+
+    api_key = config.get("api_key", "")
+    slots = _fetch_slots(host_port, api_key)
+    if slots is None:
+        return jsonify({
+            "slots": None,
+            "scraped_at": datetime.now(timezone.utc).isoformat(),
+        })
+
+    return jsonify({
+        "slots": _slim_slots(slots),
         "scraped_at": datetime.now(timezone.utc).isoformat(),
     })

--- a/dashboard/templates/llamacpp.j2
+++ b/dashboard/templates/llamacpp.j2
@@ -34,7 +34,7 @@
       {% endif %}--alias {{ alias }}
       --host "0.0.0.0"
       --port 8080
-       --api-key {{ api_key }}
-       --metrics
-       {% for flag in rendered_flags %}{{ flag }}
-       {% endfor %}
+      --api-key {{ api_key }}
+      --metrics
+      {% for flag in rendered_flags %}{{ flag }}
+      {% endfor %}

--- a/dashboard/templates/llamacpp.j2
+++ b/dashboard/templates/llamacpp.j2
@@ -34,6 +34,7 @@
       {% endif %}--alias {{ alias }}
       --host "0.0.0.0"
       --port 8080
-      --api-key {{ api_key }}
-      {% for flag in rendered_flags %}{{ flag }}
-      {% endfor %}
+       --api-key {{ api_key }}
+       --metrics
+       {% for flag in rendered_flags %}{{ flag }}
+       {% endfor %}

--- a/dashboard/tests/test_metrics.py
+++ b/dashboard/tests/test_metrics.py
@@ -132,6 +132,7 @@ class TestVLLMMetrics:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "scraped_at" in data
+        assert data["engine"] == "vllm"
         metrics = data["metrics"]
         assert "vllm:num_requests_running" in metrics
         assert "vllm:kv_cache_usage_perc" in metrics
@@ -185,16 +186,56 @@ class TestVLLMMetrics:
             assert "T" in data["scraped_at"]
 
 
-class TestNonVLLMService:
-    def test_llamacpp_returns_empty_metrics(self, metrics_client):
+class TestLlamaCPPMetrics:
+    @patch("routes.metrics.requests.get")
+    def test_llamacpp_returns_metrics(self, mock_get, metrics_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = SAMPLE_PROMETHEUS_TEXT_LLAMACPP
+        mock_get.return_value = mock_resp
+
         resp = metrics_client.get(
             "/api/services/llamacpp-test/metrics", headers=_auth_headers()
         )
 
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["metrics"] == {}
+        assert data["engine"] == "llamacpp"
         assert "scraped_at" in data
+        metrics = data["metrics"]
+        assert "llamacpp:prompt_tokens_total" in metrics
+        assert "llamacpp:tokens_predicted_total" in metrics
+        assert "llamacpp:requests_processing" in metrics
+        assert "llamacpp:requests_deferred" in metrics
+        assert "llamacpp:n_decode_total" in metrics
+        assert "llamacpp:n_tokens_max" in metrics
+
+    @patch("routes.metrics.requests.get")
+    def test_llamacpp_whitelist_filters_extra_metrics(self, mock_get, metrics_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = SAMPLE_PROMETHEUS_TEXT_LLAMACPP
+        mock_get.return_value = mock_resp
+
+        resp = metrics_client.get(
+            "/api/services/llamacpp-test/metrics", headers=_auth_headers()
+        )
+
+        data = resp.get_json()
+        metrics = data["metrics"]
+        assert "llamacpp:uninteresting" not in metrics
+
+    def test_llamacpp_connection_error_returns_empty(self, metrics_client):
+        import requests as requests_lib
+        with patch("routes.metrics.requests.get", side_effect=requests_lib.ConnectionError):
+            resp = metrics_client.get(
+                "/api/services/llamacpp-test/metrics", headers=_auth_headers()
+            )
+
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["metrics"] == {}
+            assert data["engine"] == "llamacpp"
 
 
 class TestErrorStates:
@@ -236,6 +277,44 @@ vllm:num_requests_running{engine="0",model_name="vllm-test"} 3.0
 vllm:kv_cache_usage_perc{engine="0",model_name="vllm-test"} 0.73
 """
 
+SAMPLE_PROMETHEUS_TEXT_LLAMACPP = """# HELP llamacpp:prompt_tokens_total Total prompt tokens processed.
+# TYPE llamacpp:prompt_tokens_total counter
+llamacpp:prompt_tokens_total 25000.0
+# HELP llamacpp:tokens_predicted_total Total tokens predicted.
+# TYPE llamacpp:tokens_predicted_total counter
+llamacpp:tokens_predicted_total 60000.0
+# HELP llamacpp:requests_processing Number of requests currently processing.
+# TYPE llamacpp:requests_processing gauge
+llamacpp:requests_processing 2.0
+# HELP llamacpp:requests_deferred Number of requests deferred.
+# TYPE llamacpp:requests_deferred gauge
+llamacpp:requests_deferred 1.0
+# HELP llamacpp:n_decode_total Total decode iterations.
+# TYPE llamacpp:n_decode_total counter
+llamacpp:n_decode_total 5000.0
+# HELP llamacpp:n_tokens_max Maximum tokens in flight.
+# TYPE llamacpp:n_tokens_max gauge
+llamacpp:n_tokens_max 1024.0
+# HELP llamacpp:prompt_tokens_seconds Prompt processing time in seconds.
+# TYPE llamacpp:prompt_tokens_seconds gauge
+llamacpp:prompt_tokens_seconds 1.5
+# HELP llamacpp:predicted_tokens_seconds Token prediction time in seconds.
+# TYPE llamacpp:predicted_tokens_seconds gauge
+llamacpp:predicted_tokens_seconds 3.2
+# HELP llamacpp:n_busy_slots_per_decode Busy slots per decode iteration.
+# TYPE llamacpp:n_busy_slots_per_decode gauge
+llamacpp:n_busy_slots_per_decode 2.0
+# HELP llamacpp:prompt_seconds_total Total prompt processing seconds.
+# TYPE llamacpp:prompt_seconds_total counter
+llamacpp:prompt_seconds_total 10.0
+# HELP llamacpp:tokens_predicted_seconds_total Total prediction seconds.
+# TYPE llamacpp:tokens_predicted_seconds_total counter
+llamacpp:tokens_predicted_seconds_total 25.0
+# HELP llamacpp:uninteresting A metric not in our whitelist.
+# TYPE llamacpp:uninteresting gauge
+llamacpp:uninteresting 999.0
+"""
+
 
 class TestLabeledMetrics:
     @patch("routes.metrics.requests.get")
@@ -266,4 +345,126 @@ class TestLabeledMetrics:
 class TestAuth:
     def test_no_auth_returns_401(self, metrics_client):
         resp = metrics_client.get("/api/services/vllm-test/metrics")
+        assert resp.status_code == 401
+
+
+SAMPLE_SLOTS = [
+    {
+        "id": 0,
+        "n_ctx": 130048,
+        "speculative": True,
+        "is_processing": True,
+        "id_task": 6161,
+        "n_prompt_tokens": 4834,
+        "n_prompt_tokens_processed": 2129,
+        "params": {"seed": 4294967295, "temperature": 0.3},
+        "next_token": [
+            {
+                "has_next_token": True,
+                "has_new_line": False,
+                "n_remain": -1,
+                "n_decoded": 1602,
+            }
+        ],
+    },
+    {
+        "id": 1,
+        "n_ctx": 130048,
+        "speculative": True,
+        "is_processing": False,
+        "id_task": 5079,
+        "n_prompt_tokens": 55154,
+        "n_prompt_tokens_processed": 55042,
+        "params": {"seed": 4294967295},
+        "next_token": [
+            {
+                "has_next_token": False,
+                "has_new_line": False,
+                "n_remain": 31887,
+                "n_decoded": 113,
+            }
+        ],
+    },
+]
+
+
+class TestLlamaCPPSlots:
+    @patch("routes.metrics.requests.get")
+    def test_happy_path_returns_slimmed_slots(self, mock_get, metrics_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_SLOTS
+        mock_get.return_value = mock_resp
+
+        resp = metrics_client.get(
+            "/api/services/llamacpp-test/slots", headers=_auth_headers()
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "scraped_at" in data
+        slots = data["slots"]
+        assert len(slots) == 2
+        assert slots[0] == {
+            "id": 0,
+            "is_processing": True,
+            "id_task": 6161,
+            "n_decoded": 1602,
+            "n_prompt_tokens": 4834,
+            "n_prompt_tokens_processed": 2129,
+        }
+        assert slots[1]["is_processing"] is False
+        assert "params" not in slots[0]
+        assert "next_token" not in slots[0]
+
+    @patch("routes.metrics.requests.get")
+    def test_api_key_header_passed(self, mock_get, metrics_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_SLOTS
+        mock_get.return_value = mock_resp
+
+        metrics_client.get("/api/services/llamacpp-test/slots", headers=_auth_headers())
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-key"
+
+    def test_vllm_service_returns_400(self, metrics_client):
+        resp = metrics_client.get(
+            "/api/services/vllm-test/slots", headers=_auth_headers()
+        )
+        assert resp.status_code == 400
+
+    def test_nonexistent_service_returns_404(self, metrics_client):
+        resp = metrics_client.get(
+            "/api/services/nonexistent/slots", headers=_auth_headers()
+        )
+        assert resp.status_code == 404
+
+    def test_connection_error_returns_null_slots(self, metrics_client):
+        import requests as requests_lib
+        with patch("routes.metrics.requests.get", side_effect=requests_lib.ConnectionError):
+            resp = metrics_client.get(
+                "/api/services/llamacpp-test/slots", headers=_auth_headers()
+            )
+
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["slots"] is None
+
+    @patch("routes.metrics.requests.get")
+    def test_non_200_upstream_returns_null_slots(self, mock_get, metrics_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_get.return_value = mock_resp
+
+        resp = metrics_client.get(
+            "/api/services/llamacpp-test/slots", headers=_auth_headers()
+        )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["slots"] is None
+
+    def test_no_auth_returns_401(self, metrics_client):
+        resp = metrics_client.get("/api/services/llamacpp-test/slots")
         assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Enable Prometheus `/metrics` on all llama.cpp services (--metrics flag in template, always-on)
- New `/api/services/<name>/slots` backend endpoint proxies llama.cpp's `/slots` for per-slot generation state
- Derive real-time token/s rates from `n_decoded` deltas (keyed by `id_task` for task-rollover resilience) instead of lifetime-average Prometheus gauges that never decay
- Fallback to throughput gauges (zeroed when idle) when /slots is unreachable
- Shared Y-axis scale with t/s labels on the TokenSparkline canvas (auto-rescales on new maximum)
- MetricsPanel and ServiceDetailsPage enabled for both vLLM and llama.cpp engines

## Tests
- 19 backend tests (pytest): vLLM metrics, llama.cpp metrics, /slots endpoint, auth, error states
- 29 frontend tests (vitest): hooks (slot deltas, task rollover, gauge fallback, idle detection), sparkline rendering, metrics panel