### PR TITLE
Android F01: connection and authentication

### DIFF
--- a/android/docs/F00-cross-cutting.md
+++ b/android/docs/F00-cross-cutting.md
@@ -222,6 +222,14 @@ stored token (`Endpoints.establishesSession`). Every other call is unchanged.
 The same three are exempt from the 401 re-authentication path, so a wrong
 password reports itself rather than looping through the credential exchange.
 
+**F00-R2 — narrowed by F01-R6: a request with no stored token may now reach
+the network.** The first criterion above ("never reaches the network; the app
+routes to Connect instead") describes what F00 shipped, and F01 changed it:
+the transport now mints a token from the stored credential first, and fails
+the request locally only when it cannot. Without that, a dashboard restart
+would send a signed-in user to Connect, which F01-R6 forbids. See F01's
+*Deviations*.
+
 **F00-R2 — `X-TOTP-Token` cannot be exercised against the real dashboard.**
 `require_auth` emits that header only when a request authenticates via the
 `X-TOTP-Code` header, and the two login routes bypass `require_auth` entirely

--- a/android/docs/F01-connection-and-auth.md
+++ b/android/docs/F01-connection-and-auth.md
@@ -193,6 +193,49 @@ yet", not "no".
 - Disabling TOTP server-side.
 - Multiple saved servers. One address at a time.
 
+## Deviations
+
+**F01-R5 — the TOTP secret is not stored, and cannot be.** R5 offers
+"the password, or the TOTP secret if the user chooses to store it" as the
+credential. Only the password is implemented.
+
+Storing the secret would mean shipping an RFC 6238 code generator *and* a
+way to get the secret onto the phone — and no endpoint this app is
+permitted to call hands it out. `/api/totp/setup` returns it, but that is
+enrollment, which `Plan_TOC.md` and this file both put out of scope, and
+F00-R10 forbids the app writing configuration. A user who could paste the
+secret in by hand would in effect be pasting a permanent credential, which
+is the password path with extra steps and a second code generator to get
+wrong.
+
+So silent re-authentication is delivered for the password path, which
+F01-R6 itself identifies as the fully-deliverable one. R6's last criterion
+— telling TOTP-only users plainly that they will be asked again — is met
+twice over: the Connect screen's Auth-code tab says so before they sign in
+("An authenticator code cannot be saved, so when this session ends you will
+be asked for a new one"), and when the session does end the app returns to
+Connect saying why rather than silently.
+
+**F00-R2 — a request with no stored token may now reach the network.** As
+written, R2 requires that any call other than the three session-establishing
+ones "never reaches the network" without a stored token, and that the app
+routes to Connect instead. F01-R6 makes that wrong in the ordinary case: a
+dashboard restart 401s the first request, the transport discards the dead
+token, and every request queued behind it would then be failed locally and
+send a signed-in user to Connect — precisely what R6 forbids.
+
+The transport therefore mints a token from the stored credential before
+sending, through the same single-flight exchange the 401 path uses, and
+fails the request locally only when that cannot produce one. Requests still
+never go out unauthenticated; F00-R2's mechanism is unchanged, only the
+"no token stored" branch gained a step in front of it.
+
+**Signing in lands on a placeholder, not the conversation list.** R3 and R4
+both say a valid credential "lands on the conversation list". F02 builds
+that screen; until then the signed-in destination shows the server, a live
+session check and Sign out. No requirement changes — the criterion is
+verified as far as F01 can reach it and re-verified in F02.
+
 ## Backend findings from F00
 
 Discovered while building the foundation, confirmed independently against
@@ -239,3 +282,29 @@ F01 should be built; none of them were known when this file was written.
 7. **`allowBackup` is still on with the stock rules.** A session token in
    DataStore lands in cloud backup. Tolerable for a disposable 8 h token;
    decide it deliberately before storing the long-lived credential.
+
+**Mockup screen 01's "Stay signed in" toggle is not implemented.** F01-R6
+makes staying signed in unconditional, so a toggle would offer a choice
+the requirement has already made. Nothing else on screen 01 changed.
+
+## Outstanding and carried-forward criteria
+
+F01 is **not** marked `[DONE]`: one Must criterion is unverified, and it
+needs the dashboard owner.
+
+| Criterion | State |
+|---|---|
+| **R3 · "A valid code signs in and lands on the conversation list"** | **Outstanding.** Generating a valid TOTP code requires the server's secret; reading it is blocked by policy, and `/api/totp/setup` is enrollment and forbidden by F00-R10. The *rejection* path is verified live — the dashboard's verbatim "Invalid TOTP code" after an auto-submitted six-digit code, address untouched. **Closing this needs one code typed from the owner's authenticator app.** |
+
+Carried forward to a later feature, as their screens do not exist yet:
+
+| Criterion | Verify in |
+|---|---|
+| R3 / R4 · "lands on the conversation list" — F01 lands on a placeholder | F02 |
+| R6 · "a 401 during a streaming turn re-authenticates and the turn is recoverable; the user's message is not lost" | F04, with F09 |
+| R6 · "after a week of not opening the app, it works with no login prompt" | Not directly testable. The mechanism — stored credential plus `startDestination` — is verified; treat the elapsed-time criterion as satisfied by that. |
+
+Verified live and complete in F01: R1, R2, R3's rejection path and input
+handling, R4's password path, R5 in full (including a Backup Manager
+backup/restore cycle proving `files/datastore/` is excluded), R6's silent
+re-auth and its bounded-retry cap, and R7.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -174,7 +174,7 @@ Mark completed features `[DONE]` in the Status column.
 | # | Feature | File | Mockup screens | Status |
 |---|---|---|---|---|
 | F00 | Cross-cutting requirements | [F00-cross-cutting.md](F00-cross-cutting.md) | all | [DONE] |
-| F01 | Connection and authentication | [F01-connection-and-auth.md](F01-connection-and-auth.md) | 01 | [ ] |
+| F01 | Connection and authentication | [F01-connection-and-auth.md](F01-connection-and-auth.md) | 01 | [WIP] — one Must criterion outstanding, see the feature file |
 | F02 | Conversation list | [F02-conversation-list.md](F02-conversation-list.md) | 02 | [ ] |
 | F03 | Starting a conversation | [F03-new-conversation.md](F03-new-conversation.md) | 03 | [ ] |
 | F04 | Sending a turn and streaming the reply | [F04-chat-turn-and-streaming.md](F04-chat-turn-and-streaming.md) | 04, 06a | [ ] |

--- a/android/src/app/build.gradle.kts
+++ b/android/src/app/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
     implementation(libs.okhttp)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.android)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/MainActivity.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/MainActivity.kt
@@ -7,32 +7,81 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import com.hpz.llmdockchat.core.AppContainer
+import com.hpz.llmdockchat.core.prefs.Stored
+import com.hpz.llmdockchat.core.prefs.valueOrNull
 import com.hpz.llmdockchat.core.ui.theme.LLMDockChatTheme
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
-import com.hpz.llmdockchat.feature.foundation.FoundationScreen
+import com.hpz.llmdockchat.navigation.AppNavHost
+import com.hpz.llmdockchat.navigation.startDestination
 
 class MainActivity : ComponentActivity() {
 
+    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val container = (application as LlmDockApplication).container
         setContent {
             LLMDockChatTheme {
-                val serverUrl by container.serverUrlStore.baseUrl.collectAsState()
                 Scaffold(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        // Surfaces Compose test tags as resource ids, so a
+                        // `uiautomator` dump can name what it is tapping.
+                        .semantics { testTagsAsResourceId = true },
                     containerColor = LlmTheme.colors.app,
                 ) { innerPadding ->
-                    FoundationScreen(
-                        serverUrl = serverUrl,
-                        modifier = Modifier.padding(innerPadding),
-                    )
+                    AppRoot(container, Modifier.padding(innerPadding))
                 }
             }
         }
+    }
+}
+
+/**
+ * Decides where the app opens, once the three stored values it depends on have
+ * come off disk. Nothing renders before then: showing Connect for two frames
+ * and then replacing it would flash a login screen at a signed-in user.
+ */
+@Composable
+private fun AppRoot(container: AppContainer, modifier: Modifier = Modifier) {
+    val server by container.serverUrlStore.baseUrl.collectAsState()
+    val token by container.tokenStore.token.collectAsState()
+    val credential by container.credentialStore.hasCredential.collectAsState()
+
+    val hydrated = server !is Stored.Loading &&
+        token !is Stored.Loading &&
+        credential !is Stored.Loading
+
+    var start by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(hydrated) {
+        if (hydrated && start == null) {
+            start = startDestination(
+                server = server.valueOrNull,
+                token = token.valueOrNull,
+                hasCredential = credential.valueOrNull == true,
+            )
+        }
+    }
+
+    start?.let { destination ->
+        AppNavHost(
+            container = container,
+            startDestination = destination,
+            modifier = modifier.testTag("app_root"),
+        )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
@@ -6,8 +6,15 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
+import com.hpz.llmdockchat.core.auth.AuthService
+import com.hpz.llmdockchat.core.auth.CredentialReauthenticator
+import com.hpz.llmdockchat.core.auth.CredentialStore
+import com.hpz.llmdockchat.core.auth.DataStoreCredentialStore
 import com.hpz.llmdockchat.core.auth.DataStoreTokenStore
+import com.hpz.llmdockchat.core.auth.KeystoreSecretCipher
 import com.hpz.llmdockchat.core.auth.ReauthenticatorHolder
+import com.hpz.llmdockchat.core.auth.SecretCipher
+import com.hpz.llmdockchat.core.auth.SessionManager
 import com.hpz.llmdockchat.core.auth.SessionState
 import com.hpz.llmdockchat.core.auth.TokenStore
 import com.hpz.llmdockchat.core.net.ApiClient
@@ -19,15 +26,17 @@ import com.hpz.llmdockchat.core.net.ServerUrlStore
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.core.net.SseTransport
 import com.hpz.llmdockchat.data.HealthRepository
+import com.hpz.llmdockchat.data.ReachabilityRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import java.time.Duration
 
 /**
  * A corrupt preferences file is replaced rather than thrown from. Everything
- * stored here — a server address and a disposable session token — is
- * re-enterable, so recovering silently beats failing every read.
+ * stored here — a server address, a session token and an encrypted credential —
+ * is re-enterable, so recovering silently beats failing every read.
  */
 private val Context.llmDockDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "llm_dock",
@@ -41,20 +50,22 @@ private val Context.llmDockDataStore: DataStore<Preferences> by preferencesDataS
 class AppContainer(
     context: Context,
     val dispatchers: AppDispatchers = AppDispatchers(),
+    cipher: SecretCipher = KeystoreSecretCipher(),
 ) {
     private val appScope = CoroutineScope(SupervisorJob() + dispatchers.io)
     private val dataStore = context.applicationContext.llmDockDataStore
 
     val sessionState = SessionState()
     val serverUrlStore: ServerUrlStore = DataStoreServerUrlStore(dataStore, appScope)
-    val tokenStore: TokenStore = DataStoreTokenStore(dataStore, appScope)
+    val tokenStore: TokenStore = DataStoreTokenStore(dataStore, appScope, cipher)
+    val credentialStore: CredentialStore = DataStoreCredentialStore(dataStore, appScope, cipher)
 
-    /** F01 installs the real credential exchange here. */
-    val reauthenticator = ReauthenticatorHolder()
+    /** Breaks the cycle: the HTTP stack exists before anything that can log in. */
+    private val reauthenticatorHolder = ReauthenticatorHolder()
 
     private val httpClient: OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(AuthInterceptor(tokenStore, sessionState))
-        .authenticator(SessionAuthenticator(tokenStore, sessionState, reauthenticator))
+        .addInterceptor(AuthInterceptor(tokenStore, sessionState, reauthenticatorHolder))
+        .authenticator(SessionAuthenticator(tokenStore, sessionState, reauthenticatorHolder))
         .connectTimeout(Duration.ofSeconds(15))
         .readTimeout(Duration.ofSeconds(30))
         .build()
@@ -67,7 +78,45 @@ class AppContainer(
         .readTimeout(Duration.ZERO)
         .build()
 
+    /**
+     * The reachability check must not leave the user watching a spinner while a
+     * wrong address runs out the ordinary 15 s connect timeout — F01-R2 allows
+     * it "a few seconds".
+     */
+    private val probeClient: OkHttpClient = httpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(3))
+        .readTimeout(Duration.ofSeconds(3))
+        .callTimeout(Duration.ofSeconds(5))
+        .build()
+
     val apiClient = ApiClient(httpClient, serverUrlStore, ApiJson, dispatchers.io)
     val sseTransport: SseTransport = OkHttpSseTransport(streamingClient, serverUrlStore, dispatchers.io)
-    val healthRepository = HealthRepository(apiClient)
+
+    val authService = AuthService(apiClient)
+    val healthRepository = HealthRepository(
+        ApiClient(probeClient, serverUrlStore, ApiJson, dispatchers.io),
+    )
+    val reachabilityRepository = ReachabilityRepository(healthRepository)
+
+    private val reauthenticator = CredentialReauthenticator(
+        credentials = credentialStore,
+        sessionState = sessionState,
+        // OkHttp's `Authenticator` is a blocking callback on a network thread.
+        // `/api/auth/session` is exempt from both the interceptor and the
+        // authenticator, so this cannot recurse into itself.
+        exchange = { credential -> runBlocking { authService.signIn(credential) } },
+    )
+
+    val sessionManager = SessionManager(
+        serverUrlStore = serverUrlStore,
+        tokenStore = tokenStore,
+        credentials = credentialStore,
+        sessionState = sessionState,
+        authService = authService,
+        reauthenticator = reauthenticator,
+    )
+
+    init {
+        reauthenticatorHolder.delegate = reauthenticator
+    }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/AuthService.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/AuthService.kt
@@ -1,0 +1,74 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiException
+import com.hpz.llmdockchat.core.net.Endpoints
+import com.hpz.llmdockchat.core.net.apiCall
+import com.hpz.llmdockchat.data.dto.SessionDto
+import com.hpz.llmdockchat.data.dto.TokenVerificationDto
+
+/**
+ * The two ways into the dashboard, and the token-liveness probe.
+ *
+ * Neither login route is decorated with `require_auth` server-side
+ * (`dashboard/routes/system.py`), so neither may carry a session bearer:
+ * `/api/auth/login` authenticates with `X-TOTP-Code`, and `/api/auth/session`
+ * uses the password itself as the bearer. `Endpoints.establishesSession`
+ * exempts both from the transport's token handling; this class must not
+ * reintroduce one.
+ */
+class AuthService(private val api: ApiClient) {
+
+    /** `POST /api/auth/session` with the dashboard password as the bearer (F01-R4). */
+    suspend fun signIn(credential: Credential): Result<String> = when (credential) {
+        is Credential.Password -> token(
+            path = Endpoints.AUTH_SESSION,
+            headers = mapOf("Authorization" to "Bearer ${credential.secret}"),
+        )
+    }
+
+    /**
+     * `POST /api/auth/login` with the six-digit code as `X-TOTP-Code` (F01-R3).
+     *
+     * Never sent on any other route: an expired `totp-` bearer makes
+     * `require_auth` return 401 before it reaches the `X-TOTP-Code` branch
+     * (`dashboard/auth.py:53-66`), so the code would be silently discarded.
+     */
+    suspend fun signInWithTotpCode(code: String): Result<String> = token(
+        path = Endpoints.AUTH_LOGIN,
+        headers = mapOf(TOTP_CODE_HEADER to code),
+    )
+
+    /** `POST /api/auth/verify` — authenticated, so it exercises the stored token. */
+    suspend fun verify(): Result<Boolean> = apiCall {
+        api.request(
+            method = "POST",
+            path = Endpoints.AUTH_VERIFY,
+            deserializer = TokenVerificationDto.serializer(),
+        ).valid
+    }
+
+    private suspend fun token(path: String, headers: Map<String, String>): Result<String> = apiCall {
+        val session = api.request(
+            method = "POST",
+            path = path,
+            deserializer = SessionDto.serializer(),
+            headers = headers,
+        )
+        if (session.token.isBlank()) {
+            throw ApiException(
+                AppError.Http(
+                    status = 200,
+                    message = "The server accepted the sign-in but returned no session token.",
+                    fromServer = false,
+                ),
+            )
+        }
+        session.token
+    }
+
+    companion object {
+        const val TOTP_CODE_HEADER = "X-TOTP-Code"
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/Credential.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/Credential.kt
@@ -1,0 +1,45 @@
+package com.hpz.llmdockchat.core.auth
+
+/**
+ * A long-lived secret the app can exchange for a fresh session token without
+ * asking the user anything (F01-R6).
+ *
+ * `toString` is overridden on every variant. A data class would print the
+ * secret into any log line, stack trace or crash report that happens to
+ * interpolate it, which F01-R5 forbids outright.
+ */
+sealed interface Credential {
+
+    /**
+     * The dashboard password — `DASHBOARD_TOKEN` from `dashboard/.env`. Posted
+     * as a bearer to `/api/auth/session`, which hands back a session token.
+     */
+    class Password(val secret: String) : Credential {
+        override fun toString(): String = "Credential.Password(secret=***)"
+        override fun equals(other: Any?): Boolean = other is Password && other.secret == secret
+        override fun hashCode(): Int = secret.hashCode()
+    }
+
+    companion object {
+        private const val PASSWORD_TAG = "password"
+
+        /**
+         * Tagged so a second credential kind — a stored TOTP secret, say — can
+         * be added without a migration for anything already on disk.
+         */
+        fun encode(credential: Credential): String = when (credential) {
+            is Password -> "$PASSWORD_TAG:${credential.secret}"
+        }
+
+        fun decode(stored: String): Credential? {
+            val separator = stored.indexOf(':')
+            if (separator <= 0) return null
+            val secret = stored.substring(separator + 1)
+            if (secret.isEmpty()) return null
+            return when (stored.substring(0, separator)) {
+                PASSWORD_TAG -> Password(secret)
+                else -> null
+            }
+        }
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/CredentialReauthenticator.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/CredentialReauthenticator.kt
@@ -1,0 +1,124 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.net.appError
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Silent re-authentication (F01-R6): exchanges the stored credential for a
+ * fresh session token so the user only ever sees Connect after an explicit
+ * sign-out or a credential the dashboard rejects.
+ *
+ * Two properties matter more than anything else here.
+ *
+ * **Single-flight.** A dashboard restart invalidates every token at once, so N
+ * in-flight requests come back 401 together. Each one reaches OkHttp's
+ * `Authenticator` on its own thread; without deduplication that is N credential
+ * exchanges for one dead session. The first caller runs the exchange and the
+ * rest wait on its result.
+ *
+ * **Bounded.** A credential the server rejects is cleared on the spot, and any
+ * other repeated failure stops attempting after [maxConsecutiveFailures]. The
+ * app falls back to Connect rather than exchanging a hopeless credential once
+ * per request forever.
+ *
+ * Called from a network thread, so it blocks by design.
+ */
+class CredentialReauthenticator(
+    private val credentials: CredentialStore,
+    private val sessionState: SessionState,
+    private val maxConsecutiveFailures: Int = DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    private val exchange: (Credential) -> Result<String>,
+) : Reauthenticator {
+
+    private val lock = ReentrantLock()
+    private var inFlight: FutureTask<String?>? = null
+    private val consecutiveFailures = AtomicInteger(0)
+
+    /** Called when the user signs in, so a fresh credential starts from zero. */
+    fun reset() {
+        consecutiveFailures.set(0)
+    }
+
+    override fun reauthenticate(): String? {
+        if (consecutiveFailures.get() >= maxConsecutiveFailures) return null
+
+        var owner = false
+        val task = lock.withLock {
+            inFlight ?: FutureTask(::exchangeOnce).also {
+                inFlight = it
+                owner = true
+            }
+        }
+
+        if (owner) {
+            try {
+                task.run()
+            } finally {
+                lock.withLock { inFlight = null }
+            }
+        }
+
+        return try {
+            task.get()
+        } catch (e: ExecutionException) {
+            consecutiveFailures.incrementAndGet()
+            null
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            null
+        }
+    }
+
+    private fun exchangeOnce(): String? {
+        // Nothing to exchange: a TOTP sign-in stores no credential, because no
+        // endpoint this app may call hands out the secret. Say so plainly
+        // rather than dropping the user on a bare Connect screen.
+        val credential = credentials.current() ?: return refuse(NO_CREDENTIAL)
+
+        val result = exchange(credential)
+        result.getOrNull()?.takeIf { it.isNotBlank() }?.let { token ->
+            consecutiveFailures.set(0)
+            sessionState.authenticated()
+            return token
+        }
+
+        // 401 from `/api/auth/session` means the password itself is wrong — the
+        // dashboard's password changed, or it was mistyped and this is the
+        // first request since. Retrying can never succeed, so drop it.
+        if (result.exceptionOrNull()?.appError.isRejection()) {
+            credentials.clear()
+            return refuse(REJECTED)
+        }
+
+        consecutiveFailures.incrementAndGet()
+        return null
+    }
+
+    private fun refuse(reason: String): String? {
+        sessionState.requireAuthentication(reason)
+        return null
+    }
+
+    private fun AppError?.isRejection(): Boolean = when (this) {
+        AppError.Unauthenticated -> true
+        // `/api/auth/session` answers 400 when the Authorization header is
+        // missing and 401 when the credential is wrong, so a 4xx here is always
+        // this client's fault and never worth repeating.
+        is AppError.Http -> status in 400..499
+        else -> false
+    }
+
+    companion object {
+        const val DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
+
+        const val NO_CREDENTIAL =
+            "Your session ended. Authenticator codes can't be saved, so enter a new one."
+        const val REJECTED =
+            "The dashboard rejected the saved password. Enter it again."
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/CredentialStore.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/CredentialStore.kt
@@ -1,0 +1,66 @@
+package com.hpz.llmdockchat.core.auth
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.hpz.llmdockchat.core.prefs.Stored
+import com.hpz.llmdockchat.core.prefs.ValuePreference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The credential that survives a dead session token (F01-R5). Encrypted at
+ * rest by construction: the store never sees plaintext on disk, only what
+ * [SecretCipher] hands it.
+ *
+ * Only [hasCredential] is exposed as a flow. The secret itself is reachable
+ * through [current] alone, which the HTTP stack calls on a network thread —
+ * nothing observable by the UI ever holds it.
+ */
+interface CredentialStore {
+
+    /** Whether a credential is stored, once the disk read has landed. */
+    val hasCredential: StateFlow<Stored<Boolean>>
+
+    /** Blocks until the first disk read lands; for network threads only. */
+    fun current(): Credential?
+
+    fun save(credential: Credential)
+    fun clear()
+}
+
+class DataStoreCredentialStore(
+    dataStore: DataStore<Preferences>,
+    scope: CoroutineScope,
+    cipher: SecretCipher,
+) : CredentialStore {
+
+    private val pref = ValuePreference(
+        dataStore = dataStore,
+        name = "credential",
+        scope = scope,
+        // A blob that will not decrypt — a restored backup, a reset Keystore —
+        // reads as "no credential" rather than as an error. The cost is one
+        // sign-in, and the alternative is an app that cannot start.
+        decode = { stored -> cipher.decrypt(stored)?.let(Credential::decode) },
+        encode = { credential -> cipher.encrypt(Credential.encode(credential)).orEmpty() },
+    )
+
+    override val hasCredential: StateFlow<Stored<Boolean>> = pref.flow
+        .map { stored ->
+            when (stored) {
+                Stored.Loading -> Stored.Loading
+                is Stored.Ready -> Stored.Ready(stored.value != null)
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, Stored.Loading)
+
+    override fun current(): Credential? = pref.get()
+    override fun save(credential: Credential) = pref.set(credential)
+    override fun clear() = pref.clear()
+
+    /** Test support: writes are enqueued, so "on disk yet?" needs a join. */
+    internal suspend fun awaitPendingWrites() = pref.awaitPendingWrites()
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SecretCipher.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SecretCipher.kt
@@ -1,0 +1,95 @@
+package com.hpz.llmdockchat.core.auth
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Symmetric encryption for the one secret the app stores at rest.
+ *
+ * An interface, not a helper object, for two reasons: the Android Keystore
+ * needs a device, and the store that uses it must stay unit-testable.
+ * Both methods return null rather than throwing — an unreadable secret is
+ * equivalent to no secret, and losing it costs one sign-in.
+ */
+interface SecretCipher {
+    fun encrypt(plaintext: String): String?
+    fun decrypt(ciphertext: String): String?
+}
+
+/**
+ * AES-256/GCM with the key held in the platform Keystore, so the key material
+ * never enters the app's process (Architecture U1 — `androidx.security:
+ * security-crypto` is deprecated in full and must not be used).
+ *
+ * The output is `base64(iv || ciphertext||tag)`, which is what lands in
+ * DataStore. Without the Keystore key that blob is inert, so a copy of the
+ * preferences file taken off the device yields nothing.
+ */
+class KeystoreSecretCipher(
+    private val alias: String = DEFAULT_ALIAS,
+) : SecretCipher {
+
+    override fun encrypt(plaintext: String): String? = runCatching {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, key())
+        val iv = cipher.iv
+        val body = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        Base64.encodeToString(iv + body, Base64.NO_WRAP)
+    }.getOrNull()
+
+    override fun decrypt(ciphertext: String): String? = runCatching {
+        val raw = Base64.decode(ciphertext, Base64.NO_WRAP)
+        if (raw.size <= IV_BYTES) return null
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            key(),
+            GCMParameterSpec(TAG_BITS, raw, 0, IV_BYTES),
+        )
+        String(cipher.doFinal(raw, IV_BYTES, raw.size - IV_BYTES), Charsets.UTF_8)
+    }.getOrNull()
+
+    /**
+     * Created on first use and reused after. Synchronised because a 401 storm
+     * can reach this from several OkHttp threads at once, and two threads
+     * generating the same alias would leave one holding a key that no longer
+     * decrypts what the other wrote.
+     */
+    @Synchronized
+    private fun key(): SecretKey {
+        val keyStore = KeyStore.getInstance(PROVIDER).apply { load(null) }
+        (keyStore.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.let { return it.secretKey }
+
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, PROVIDER)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(KEY_BITS)
+                // Deliberately not `setUserAuthenticationRequired`: that is
+                // F01-R8's biometric gate, which is out of scope for v1. Adding
+                // it here would lock the credential behind a prompt the app has
+                // no UI for.
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    companion object {
+        const val DEFAULT_ALIAS = "llm_dock_credential_v1"
+        private const val PROVIDER = "AndroidKeyStore"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val IV_BYTES = 12
+        private const val TAG_BITS = 128
+        private const val KEY_BITS = 256
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SessionManager.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SessionManager.kt
@@ -1,0 +1,56 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.ServerUrlStore
+
+/**
+ * Signing in and signing out, in one place. Screens call this; nothing else
+ * writes the token or the credential.
+ */
+class SessionManager(
+    private val serverUrlStore: ServerUrlStore,
+    private val tokenStore: TokenStore,
+    private val credentials: CredentialStore,
+    private val sessionState: SessionState,
+    private val authService: AuthService,
+    private val reauthenticator: CredentialReauthenticator,
+) {
+
+    /**
+     * F01-R4. The password is kept (encrypted) so the session can be renewed
+     * without asking again — the trade-off F01-R5 spells out.
+     */
+    suspend fun signInWithPassword(server: BaseUrl, password: String): Result<Unit> {
+        val credential = Credential.Password(password)
+        return signIn(server) { authService.signIn(credential) }
+            .onSuccess { credentials.save(credential) }
+    }
+
+    /**
+     * F01-R3. Nothing is stored but the token: no endpoint this app may call
+     * exposes the TOTP secret, so there is nothing to renew the session with
+     * once it dies. The user is told so on the Connect screen.
+     */
+    suspend fun signInWithTotpCode(server: BaseUrl, code: String): Result<Unit> =
+        signIn(server) { authService.signInWithTotpCode(code) }
+            .onSuccess { credentials.clear() }
+
+    /** F01-R7. The address stays; the token and the credential do not. */
+    fun signOut() {
+        tokenStore.clear()
+        credentials.clear()
+        reauthenticator.reset()
+        sessionState.signedOut()
+    }
+
+    private suspend fun signIn(server: BaseUrl, login: suspend () -> Result<String>): Result<Unit> {
+        // Stored before the call, not after: the request is built from the
+        // configured base URL, so there is nowhere else for it to come from.
+        serverUrlStore.set(server)
+        return login().map { token ->
+            tokenStore.update(token)
+            reauthenticator.reset()
+            sessionState.authenticated()
+        }
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SessionState.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/SessionState.kt
@@ -5,10 +5,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * App-wide "the session is gone" signal (F00-R3). The HTTP stack raises it;
- * the app shell observes it and routes to Connect (F01).
+ * App-wide "the session is gone" signal (F00-R3, narrowed by F01-R6). The HTTP
+ * stack raises it; the app shell observes it and routes to Connect.
  *
- * Deliberately a [StateFlow] rather than an event stream: a 401 raised while
+ * Under F01 an ordinary 401 no longer reaches here — silent re-auth absorbs it.
+ * This fires only when re-authentication itself cannot succeed: no stored
+ * credential, or one the dashboard rejects.
+ *
+ * Deliberately a [StateFlow] rather than an event stream: a signal raised while
  * nothing is collecting must still be visible to whatever collects next.
  */
 class SessionState {
@@ -16,11 +20,33 @@ class SessionState {
     private val _authenticationRequired = MutableStateFlow(false)
     val authenticationRequired: StateFlow<Boolean> = _authenticationRequired.asStateFlow()
 
-    fun requireAuthentication() {
+    private val _reason = MutableStateFlow<String?>(null)
+
+    /**
+     * Why Connect is being shown, when there is something worth saying —
+     * F01-R6 requires the app to explain a rejected credential rather than
+     * silently reappearing at the login screen. Null after a plain sign-out.
+     */
+    val reason: StateFlow<String?> = _reason.asStateFlow()
+
+    /**
+     * A null [reason] leaves any reason already set alone. The re-authenticator
+     * knows *why* the session is unrecoverable; the HTTP stack that raises the
+     * signal a moment later does not, and must not overwrite it with silence.
+     */
+    fun requireAuthentication(reason: String? = null) {
+        if (reason != null) _reason.value = reason
         _authenticationRequired.value = true
     }
 
     fun authenticated() {
+        _reason.value = null
         _authenticationRequired.value = false
+    }
+
+    /** Sign-out (F01-R7): back to Connect, with nothing to explain. */
+    fun signedOut() {
+        _reason.value = null
+        _authenticationRequired.value = true
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/TokenStore.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/auth/TokenStore.kt
@@ -12,8 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
  * the dashboard, so this is disposable: losing it costs one re-authentication,
  * not any user data.
  *
- * F01 owns the *credential* (password or TOTP secret) behind [Reauthenticator];
- * this holds only the short-lived token derived from it.
+ * [CredentialStore] owns the long-lived *credential* the token is derived from.
  */
 interface TokenStore {
     val token: StateFlow<Stored<String>>
@@ -24,21 +23,30 @@ interface TokenStore {
     fun clear()
 }
 
+/**
+ * Encrypted at rest alongside the credential (F01-R5). The token is disposable,
+ * but it is a working bearer for eight sliding hours, so it gets the same
+ * treatment rather than sitting in plain preferences.
+ */
 class DataStoreTokenStore(
     dataStore: DataStore<Preferences>,
     scope: CoroutineScope,
+    cipher: SecretCipher,
 ) : TokenStore {
 
     private val pref = ValuePreference(
         dataStore = dataStore,
         name = "session_token",
         scope = scope,
-        decode = { it.takeIf(String::isNotBlank) },
-        encode = { it },
+        decode = { stored -> cipher.decrypt(stored)?.takeIf(String::isNotBlank) },
+        encode = { token -> cipher.encrypt(token).orEmpty() },
     )
 
     override val token: StateFlow<Stored<String>> get() = pref.flow
     override fun current(): String? = pref.get()
     override fun update(token: String) = pref.set(token)
     override fun clear() = pref.clear()
+
+    /** Test support: writes are enqueued, so "on disk yet?" needs a join. */
+    internal suspend fun awaitPendingWrites() = pref.awaitPendingWrites()
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/ApiClient.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/ApiClient.kt
@@ -32,19 +32,35 @@ class ApiClient(
         query: Map<String, String> = emptyMap(),
     ): T = request("GET", path, deserializer, query)
 
+    /**
+     * [headers] is how the login routes carry their own credential —
+     * `X-TOTP-Code`, or the password as an `Authorization` bearer. The
+     * interceptor leaves a request that already has an `Authorization` header
+     * alone, so a caller-supplied one is never overwritten (F00-R2).
+     */
     suspend fun <T> request(
         method: String,
         path: String,
         deserializer: DeserializationStrategy<T>,
         query: Map<String, String> = emptyMap(),
         body: String? = null,
+        headers: Map<String, String> = emptyMap(),
     ): T = withContext(ioDispatcher) {
         val base = serverUrlStore.current()
             ?: throw ApiException(AppError.Unexpected(IllegalStateException("No server configured.")))
 
+        // OkHttp rejects a POST/PUT/PATCH with no body, and both login routes
+        // send none — the credential is entirely in the headers.
+        val requestBody = when {
+            body != null -> body.toRequestBody(JSON_MEDIA_TYPE)
+            method in METHODS_REQUIRING_A_BODY -> EMPTY_BODY
+            else -> null
+        }
+
         val httpRequest = Request.Builder()
             .url(base.resolve(path, query))
-            .method(method, body?.toRequestBody(JSON_MEDIA_TYPE))
+            .apply { headers.forEach { (name, value) -> header(name, value) } }
+            .method(method, requestBody)
             .build()
 
         val response = try {
@@ -57,7 +73,15 @@ class ApiClient(
 
         response.use {
             val text = runCatching { it.body.string() }.getOrNull()
-            if (!it.isSuccessful) throw ApiException(httpError(it.code, text))
+            if (!it.isSuccessful) {
+                throw ApiException(
+                    httpError(
+                        status = it.code,
+                        body = text,
+                        credentialRejected = Endpoints.establishesSession(httpRequest),
+                    ),
+                )
+            }
             try {
                 json.decodeFromString(deserializer, text.orEmpty())
             } catch (e: Exception) {
@@ -68,5 +92,7 @@ class ApiClient(
 
     companion object {
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private val METHODS_REQUIRING_A_BODY = setOf("POST", "PUT", "PATCH")
+        private val EMPTY_BODY = ByteArray(0).toRequestBody(null)
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/AuthInterceptor.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/AuthInterceptor.kt
@@ -1,23 +1,31 @@
 package com.hpz.llmdockchat.core.net
 
+import com.hpz.llmdockchat.core.auth.Reauthenticator
 import com.hpz.llmdockchat.core.auth.SessionState
 import com.hpz.llmdockchat.core.auth.TokenStore
 import com.hpz.llmdockchat.core.error.AppError
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 
 /**
  * Attaches `Authorization: Bearer <token>` to every request that needs one, and
  * adopts a rotated `X-TOTP-Token` when the dashboard issues one (F00-R2).
  *
- * With no token stored, the request is failed here rather than sent: an
- * unauthenticated call would only come back 401, and F00-R2 requires it never
- * reach the network.
+ * With no token stored it mints one from the credential before sending
+ * (F01-R6). That is not a nicety: a dashboard restart 401s the first request,
+ * which discards the dead token, and every request queued behind it would
+ * otherwise fail here with nothing stored — turning one expired session into a
+ * trip to the Connect screen. The exchange is single-flight, so a request
+ * arriving while one is already running waits for it rather than starting a
+ * second.
+ *
+ * Only when there is nothing left to try is the request failed here rather than
+ * sent, as F00-R2 requires.
  */
 class AuthInterceptor(
     private val tokenStore: TokenStore,
     private val sessionState: SessionState,
+    private val reauthenticator: Reauthenticator = Reauthenticator.NoCredential,
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -27,19 +35,24 @@ class AuthInterceptor(
             // the dashboard password as its bearer.
             request.header(AUTHORIZATION) != null -> request
             Endpoints.establishesSession(request) -> request
-            else -> {
-                val token = tokenStore.current()
-                if (token.isNullOrBlank()) {
-                    sessionState.requireAuthentication()
-                    throw ApiException(AppError.Unauthenticated)
-                }
-                request.newBuilder().header(AUTHORIZATION, "Bearer $token").build()
-            }
+            else -> request.newBuilder().header(AUTHORIZATION, "Bearer ${bearer()}").build()
         }
 
         val response = chain.proceed(outgoing)
         response.header(TOTP_TOKEN_HEADER)?.takeIf { it.isNotBlank() }?.let(tokenStore::update)
         return response
+    }
+
+    private fun bearer(): String {
+        tokenStore.current()?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val fresh = reauthenticator.reauthenticate()?.takeIf { it.isNotBlank() }
+        if (fresh == null) {
+            sessionState.requireAuthentication()
+            throw ApiException(AppError.Unauthenticated)
+        }
+        tokenStore.update(fresh)
+        return fresh
     }
 
     companion object {

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
@@ -13,6 +13,9 @@ object Endpoints {
     const val AUTH_LOGIN = "/api/auth/login"
     const val AUTH_SESSION = "/api/auth/session"
 
+    /** Authenticated, unlike the two above — it is a probe, not a way in. */
+    const val AUTH_VERIFY = "/api/auth/verify"
+
     /**
      * Requests that establish a session, and so cannot depend on one.
      *

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/HttpErrors.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/HttpErrors.kt
@@ -7,8 +7,16 @@ import com.hpz.llmdockchat.core.error.ErrorBody
  * Maps a non-2xx response onto an [AppError], preferring the dashboard's own
  * `{"error": "..."}` text over anything this client could invent (F00-R4).
  */
-fun httpError(status: Int, body: String?): AppError {
-    if (status == 401) return AppError.Unauthenticated
+/**
+ * [credentialRejected] flips the meaning of a 401. On an ordinary route it says
+ * the session is gone, which is [AppError.Unauthenticated] and not something a
+ * screen should render the server's words for. On a route that *establishes* a
+ * session it says the password or code just supplied is wrong — and F01-R3 and
+ * F01-R4 both require the dashboard's own message ("Invalid TOTP code") to
+ * reach the user.
+ */
+fun httpError(status: Int, body: String?, credentialRejected: Boolean = false): AppError {
+    if (status == 401 && !credentialRejected) return AppError.Unauthenticated
     val serverMessage = ErrorBody.extract(body)
     return AppError.Http(
         status = status,
@@ -18,6 +26,8 @@ fun httpError(status: Int, body: String?): AppError {
 }
 
 private fun defaultMessage(status: Int): String = when (status) {
+    400 -> "The server rejected this request."
+    401 -> "The server rejected that credential."
     403 -> "The server refused this request."
     404 -> "Not found on the server."
     409 -> "The server rejected this because something else is in progress."

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/SessionAuthenticator.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/SessionAuthenticator.kt
@@ -29,7 +29,16 @@ class SessionAuthenticator(
         if (Endpoints.establishesSession(response.request)) return null
 
         val attempted = response.request.header(AuthInterceptor.AUTHORIZATION)?.removePrefix("Bearer ")
-        if (attempted != null && attempted == tokenStore.current()) {
+        val stored = tokenStore.current()
+
+        // A concurrent request already re-authenticated and stored a newer
+        // token. Retrying with it costs nothing; exchanging the credential
+        // again would be the second half of the stampede F01 exists to avoid.
+        if (attempted != null && !stored.isNullOrBlank() && attempted != stored) {
+            return if (priorResponses(response) > 1) giveUp() else retryWith(response, stored)
+        }
+
+        if (attempted != null && attempted == stored) {
             tokenStore.clear()
         }
 
@@ -39,10 +48,13 @@ class SessionAuthenticator(
 
         tokenStore.update(fresh)
         sessionState.authenticated()
-        return response.request.newBuilder()
-            .header(AuthInterceptor.AUTHORIZATION, "Bearer $fresh")
-            .build()
+        return retryWith(response, fresh)
     }
+
+    private fun retryWith(response: Response, token: String): Request =
+        response.request.newBuilder()
+            .header(AuthInterceptor.AUTHORIZATION, "Bearer $token")
+            .build()
 
     private fun giveUp(): Request? {
         sessionState.requireAuthentication()

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ReachabilityRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ReachabilityRepository.kt
@@ -1,0 +1,39 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.net.appError
+
+/**
+ * What `GET /api/health` says about an address the user typed (F01-R2).
+ *
+ * The distinction is the whole point: "wrong host" and "wrong code" are the two
+ * failures a user cannot otherwise tell apart, because both surface as a login
+ * that does not work.
+ */
+sealed interface Reachability {
+    data object Dashboard : Reachability
+    data object NotADashboard : Reachability
+    data class Unreachable(val detail: String) : Reachability
+}
+
+class ReachabilityRepository(private val health: HealthRepository) {
+
+    suspend fun probe(): Reachability = health.health().fold(
+        onSuccess = { server ->
+            if (server.healthy) Reachability.Dashboard else Reachability.NotADashboard
+        },
+        onFailure = { failure ->
+            when (val error = failure.appError) {
+                // The bare cause ("Failed to connect to /10.0.2.99:3399"), not
+                // its display form: the caller supplies its own lead-in and
+                // would otherwise say "could not reach" twice.
+                is AppError.Network ->
+                    Reachability.Unreachable(error.cause.message?.takeIf { it.isNotBlank() }.orEmpty())
+                // Something is listening and it is not the dashboard: a proxy,
+                // a model server (`api.ai.heapzilla.eu` answers /api/health with
+                // an OpenAI-shaped error), or a wrong port.
+                else -> Reachability.NotADashboard
+            }
+        },
+    )
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/SessionDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/SessionDto.kt
@@ -1,0 +1,18 @@
+package com.hpz.llmdockchat.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** The body both login routes return: `{"token": "totp-…", "expires_in": 28800}`. */
+@Serializable
+data class SessionDto(
+    val token: String = "",
+    @SerialName("expires_in") val expiresIn: Long = 0,
+)
+
+/** `POST /api/auth/verify` — `{"valid": true, "message": "Token is valid"}`. */
+@Serializable
+data class TokenVerificationDto(
+    val valid: Boolean = false,
+    val message: String? = null,
+)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectScreen.kt
@@ -1,0 +1,434 @@
+package com.hpz.llmdockchat.feature.connect
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hpz.llmdockchat.core.ui.theme.LLMDockChatTheme
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+
+/**
+ * Screen 01 · Connect. Both ways in are on the one screen, as the dashboard's
+ * own login page has them (F01-R4): no menu, no second screen.
+ */
+@Composable
+fun ConnectScreen(viewModel: ConnectViewModel, onSignedIn: () -> Unit, modifier: Modifier = Modifier) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(state.signedIn) {
+        if (state.signedIn) onSignedIn()
+    }
+
+    ConnectContent(
+        state = state,
+        onAddressChange = viewModel::onAddressChange,
+        onMethodChange = viewModel::onMethodChange,
+        onPasswordChange = viewModel::onPasswordChange,
+        onPasswordVisibilityToggle = viewModel::onPasswordVisibilityToggle,
+        onCodeChange = viewModel::onCodeChange,
+        onSubmit = viewModel::submit,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ConnectContent(
+    state: ConnectUiState,
+    onAddressChange: (String) -> Unit,
+    onMethodChange: (LoginMethod) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onPasswordVisibilityToggle: () -> Unit,
+    onCodeChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LlmTheme.colors
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.app)
+            .verticalScroll(rememberScrollState())
+            .imePadding()
+            .padding(horizontal = 22.dp, vertical = 28.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Mark()
+        Spacer(Modifier.height(14.dp))
+        Text(
+            "llm-dock",
+            style = MaterialTheme.typography.titleLarge,
+            color = colors.fg,
+        )
+        Text(
+            "Connect to your rig",
+            style = MaterialTheme.typography.bodyMedium,
+            color = colors.muted,
+            modifier = Modifier.padding(top = 5.dp),
+        )
+
+        Spacer(Modifier.height(30.dp))
+
+        OutlinedTextField(
+            value = state.address,
+            onValueChange = onAddressChange,
+            label = { Text("Server") },
+            placeholder = { Text("http://10.0.2.2:3399") },
+            singleLine = true,
+            isError = state.addressError != null,
+            supportingText = state.addressError?.let { { Text(it, color = colors.red) } },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                autoCorrectEnabled = false,
+                capitalization = KeyboardCapitalization.None,
+                imeAction = ImeAction.Next,
+            ),
+            colors = fieldColors(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("connect_server"),
+        )
+
+        Spacer(Modifier.height(18.dp))
+
+        MethodSelector(state.method, onMethodChange)
+
+        Spacer(Modifier.height(18.dp))
+
+        when (state.method) {
+            LoginMethod.PASSWORD -> PasswordField(
+                state = state,
+                onPasswordChange = onPasswordChange,
+                onVisibilityToggle = onPasswordVisibilityToggle,
+                onSubmit = {
+                    keyboard?.hide()
+                    onSubmit()
+                },
+            )
+            LoginMethod.CODE -> CodeField(state = state, onCodeChange = onCodeChange)
+        }
+
+        state.failure?.let { Banner(it, colors.red) }
+        state.notice?.takeIf { state.failure == null }?.let { Banner(it, colors.amber) }
+
+        Spacer(Modifier.height(22.dp))
+
+        Button(
+            onClick = {
+                keyboard?.hide()
+                onSubmit()
+            },
+            enabled = state.canSubmit,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.accent,
+                contentColor = colors.onAccent,
+                disabledContainerColor = colors.surfaceElevated,
+                disabledContentColor = colors.subtle,
+            ),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp)
+                .testTag("connect_submit"),
+        ) {
+            if (state.busy) {
+                CircularProgressIndicator(
+                    strokeWidth = 2.dp,
+                    color = colors.onAccent,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(10.dp))
+            }
+            Text(if (state.busy) "Connecting…" else "Connect")
+        }
+
+        Spacer(Modifier.height(18.dp))
+
+        Text(
+            text = when (state.method) {
+                LoginMethod.PASSWORD ->
+                    "The password is the dashboard's DASHBOARD_TOKEN. It is kept " +
+                        "encrypted on this device so the session renews itself and you " +
+                        "stay signed in until you sign out."
+                LoginMethod.CODE ->
+                    "An authenticator code cannot be saved, so when this session ends " +
+                        "you will be asked for a new one. Sign in with the password " +
+                        "instead to stay signed in indefinitely."
+            },
+            style = MaterialTheme.typography.labelMedium,
+            color = colors.subtle,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun Mark() {
+    val colors = LlmTheme.colors
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(56.dp)
+            .background(colors.surface, RoundedCornerShape(16.dp))
+            .border(1.dp, colors.line, RoundedCornerShape(16.dp)),
+    ) {
+        Text("▮▯", color = colors.accent, fontSize = 20.sp)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MethodSelector(method: LoginMethod, onMethodChange: (LoginMethod) -> Unit) {
+    val colors = LlmTheme.colors
+    val options = listOf(LoginMethod.PASSWORD to "Password", LoginMethod.CODE to "Auth code")
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (value, label) ->
+            SegmentedButton(
+                selected = method == value,
+                onClick = { onMethodChange(value) },
+                shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = colors.accentDeep,
+                    activeContentColor = colors.onAccent,
+                    activeBorderColor = colors.accent,
+                    inactiveContainerColor = colors.surface,
+                    inactiveContentColor = colors.muted,
+                    inactiveBorderColor = colors.line,
+                ),
+                modifier = Modifier.testTag("connect_method_${value.name.lowercase()}"),
+            ) {
+                Text(label)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasswordField(
+    state: ConnectUiState,
+    onPasswordChange: (String) -> Unit,
+    onVisibilityToggle: () -> Unit,
+    onSubmit: () -> Unit,
+) {
+    OutlinedTextField(
+        value = state.password,
+        onValueChange = onPasswordChange,
+        label = { Text("Password") },
+        singleLine = true,
+        visualTransformation = if (state.passwordVisible) {
+            VisualTransformation.None
+        } else {
+            PasswordVisualTransformation()
+        },
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Password,
+            autoCorrectEnabled = false,
+            imeAction = ImeAction.Go,
+        ),
+        keyboardActions = KeyboardActions(onGo = { onSubmit() }),
+        trailingIcon = {
+            TextButton(
+                onClick = onVisibilityToggle,
+                modifier = Modifier.testTag("connect_password_reveal"),
+            ) {
+                Text(
+                    if (state.passwordVisible) "Hide" else "Show",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = LlmTheme.colors.accent,
+                )
+            }
+        },
+        colors = fieldColors(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("connect_password"),
+    )
+}
+
+/**
+ * Six cells over one hidden field: a numeric keyboard, no separate submit, and
+ * the caret visible where the next digit lands (F01-R3).
+ */
+@Composable
+private fun CodeField(state: ConnectUiState, onCodeChange: (String) -> Unit) {
+    val colors = LlmTheme.colors
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            "AUTHENTICATOR CODE",
+            style = MaterialTheme.typography.labelSmall,
+            color = colors.subtle,
+            fontFamily = FontFamily.Monospace,
+        )
+        Spacer(Modifier.height(12.dp))
+        BasicTextField(
+            value = state.code,
+            onValueChange = onCodeChange,
+            enabled = !state.busy,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.NumberPassword,
+                imeAction = ImeAction.Done,
+            ),
+            textStyle = TextStyle(color = androidx.compose.ui.graphics.Color.Transparent),
+            cursorBrush = androidx.compose.ui.graphics.SolidColor(
+                androidx.compose.ui.graphics.Color.Transparent,
+            ),
+            decorationBox = {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(9.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    repeat(CODE_LENGTH) { index ->
+                        val filled = index < state.code.length
+                        val active = index == state.code.length
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp)
+                                .background(colors.surface, RoundedCornerShape(10.dp))
+                                .border(
+                                    width = if (active) 2.dp else 1.dp,
+                                    color = if (active) colors.accent else colors.line,
+                                    shape = RoundedCornerShape(10.dp),
+                                ),
+                        ) {
+                            Text(
+                                text = if (filled) state.code[index].toString() else "",
+                                color = colors.fg,
+                                fontSize = 22.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                    }
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .testTag("connect_code"),
+        )
+    }
+}
+
+@Composable
+private fun Banner(message: String, accent: androidx.compose.ui.graphics.Color) {
+    val colors = LlmTheme.colors
+    Box(
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .fillMaxWidth()
+            .background(colors.surface, RoundedCornerShape(10.dp))
+            .border(1.dp, accent.copy(alpha = 0.45f), RoundedCornerShape(10.dp))
+            .padding(horizontal = 14.dp, vertical = 11.dp),
+    ) {
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = accent,
+            modifier = Modifier.testTag("connect_message"),
+        )
+    }
+}
+
+@Composable
+private fun fieldColors() = OutlinedTextFieldDefaults.colors(
+    focusedTextColor = LlmTheme.colors.fg,
+    unfocusedTextColor = LlmTheme.colors.fg,
+    focusedContainerColor = LlmTheme.colors.surface,
+    unfocusedContainerColor = LlmTheme.colors.surface,
+    errorContainerColor = LlmTheme.colors.surface,
+    focusedBorderColor = LlmTheme.colors.accent,
+    unfocusedBorderColor = LlmTheme.colors.line,
+    errorBorderColor = LlmTheme.colors.red,
+    focusedLabelColor = LlmTheme.colors.accent,
+    unfocusedLabelColor = LlmTheme.colors.subtle,
+    cursorColor = LlmTheme.colors.accent,
+    focusedPlaceholderColor = LlmTheme.colors.subtle,
+    unfocusedPlaceholderColor = LlmTheme.colors.subtle,
+)
+
+@Preview
+@Composable
+private fun ConnectPasswordDarkPreview() {
+    LLMDockChatTheme(darkTheme = true) {
+        ConnectContent(
+            state = ConnectUiState(address = "http://10.0.2.2:3399", password = "secret"),
+            onAddressChange = {}, onMethodChange = {}, onPasswordChange = {},
+            onPasswordVisibilityToggle = {}, onCodeChange = {}, onSubmit = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ConnectCodeLightPreview() {
+    LLMDockChatTheme(darkTheme = false) {
+        ConnectContent(
+            state = ConnectUiState(
+                address = "https://dock.example",
+                method = LoginMethod.CODE,
+                code = "419",
+                failure = "Invalid TOTP code",
+            ),
+            onAddressChange = {}, onMethodChange = {}, onPasswordChange = {},
+            onPasswordVisibilityToggle = {}, onCodeChange = {}, onSubmit = {},
+        )
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectViewModel.kt
@@ -1,0 +1,143 @@
+package com.hpz.llmdockchat.feature.connect
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hpz.llmdockchat.core.auth.SessionManager
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.core.net.ServerUrlStore
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.core.prefs.Stored
+import com.hpz.llmdockchat.data.Reachability
+import com.hpz.llmdockchat.data.ReachabilityRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class LoginMethod { PASSWORD, CODE }
+
+data class ConnectUiState(
+    val address: String = "",
+    val addressError: String? = null,
+    val method: LoginMethod = LoginMethod.PASSWORD,
+    val password: String = "",
+    val passwordVisible: Boolean = false,
+    val code: String = "",
+    val busy: Boolean = false,
+    /** A failed attempt, in the dashboard's own words wherever it supplied any. */
+    val failure: String? = null,
+    /** Why the app came back here — a rejected credential, an ended session. */
+    val notice: String? = null,
+    val signedIn: Boolean = false,
+) {
+    val canSubmit: Boolean
+        get() = !busy && address.isNotBlank() && when (method) {
+            LoginMethod.PASSWORD -> password.isNotEmpty()
+            LoginMethod.CODE -> code.length == CODE_LENGTH
+        }
+}
+
+const val CODE_LENGTH = 6
+
+class ConnectViewModel(
+    private val sessionManager: SessionManager,
+    private val reachability: ReachabilityRepository,
+    private val serverUrlStore: ServerUrlStore,
+    sessionState: SessionState,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ConnectUiState(notice = sessionState.reason.value))
+    val state: StateFlow<ConnectUiState> = _state.asStateFlow()
+
+    init {
+        // Prefilled on every later visit (F01-R1), including after a sign-out,
+        // which keeps the address on purpose.
+        viewModelScope.launch {
+            serverUrlStore.baseUrl.collect { stored ->
+                val saved = (stored as? Stored.Ready)?.value?.value ?: return@collect
+                _state.value = _state.value.let {
+                    if (it.address.isBlank()) it.copy(address = saved) else it
+                }
+            }
+        }
+    }
+
+    fun onAddressChange(value: String) {
+        _state.value = _state.value.copy(address = value, addressError = null, failure = null)
+    }
+
+    fun onMethodChange(method: LoginMethod) {
+        _state.value = _state.value.copy(method = method, failure = null)
+    }
+
+    fun onPasswordChange(value: String) {
+        _state.value = _state.value.copy(password = value, failure = null)
+    }
+
+    fun onPasswordVisibilityToggle() {
+        _state.value = _state.value.copy(passwordVisible = !_state.value.passwordVisible)
+    }
+
+    /**
+     * Six digits and nothing else. Submitting on the sixth (F01-R3) removes the
+     * button press that a code with a 30-second life cannot afford.
+     */
+    fun onCodeChange(value: String) {
+        val digits = value.filter(Char::isDigit).take(CODE_LENGTH)
+        _state.value = _state.value.copy(code = digits, failure = null)
+        if (digits.length == CODE_LENGTH && !_state.value.busy) submit()
+    }
+
+    fun submit() {
+        val current = _state.value
+        if (current.busy) return
+
+        // Rejected inline, before anything reaches the network (F01-R1).
+        val server = when (val parsed = BaseUrl.normalize(current.address)) {
+            is BaseUrlResult.Invalid -> {
+                _state.value = current.copy(addressError = parsed.reason)
+                return
+            }
+            is BaseUrlResult.Valid -> parsed.baseUrl
+        }
+
+        _state.value = current.copy(busy = true, failure = null, notice = null, addressError = null)
+        viewModelScope.launch {
+            // The address has to be stored before the probe: every request is
+            // built from it (F00-R1), so there is nowhere else to read it from.
+            serverUrlStore.set(server)
+
+            when (val reach = reachability.probe()) {
+                Reachability.Dashboard -> Unit
+                is Reachability.Unreachable -> return@launch fail(
+                    "Could not reach a server at ${server.value}. ${reach.detail}".trim(),
+                )
+                Reachability.NotADashboard -> return@launch fail(
+                    "${server.value} answered, but it is not an llm-dock dashboard.",
+                )
+            }
+
+            val result = when (current.method) {
+                LoginMethod.PASSWORD -> sessionManager.signInWithPassword(server, current.password)
+                LoginMethod.CODE -> sessionManager.signInWithTotpCode(server, current.code)
+            }
+
+            result.fold(
+                onSuccess = { _state.value = _state.value.copy(busy = false, signedIn = true) },
+                onFailure = { fail(it.appError.displayMessage) },
+            )
+        }
+    }
+
+    /**
+     * The address is left exactly as typed, and so is the method — only the
+     * secret is cleared, so the next attempt starts from an empty code or an
+     * empty password rather than from a stale one (F01-R3, F01-R4).
+     */
+    private fun fail(message: String) {
+        _state.value = _state.value.copy(busy = false, failure = message, code = "")
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/home/HomeScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/home/HomeScreen.kt
@@ -1,0 +1,155 @@
+package com.hpz.llmdockchat.feature.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LLMDockChatTheme
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+
+/**
+ * Placeholder for the conversation list (F02). It shows what F01 can prove:
+ * which server the app is talking to, that the stored session actually works,
+ * and the way back out (F01-R7).
+ */
+@Composable
+fun HomeScreen(viewModel: HomeViewModel, onSignedOut: () -> Unit, modifier: Modifier = Modifier) {
+    val state by viewModel.state.collectAsState()
+    HomeContent(
+        state = state,
+        onRetry = viewModel::verify,
+        onSignOut = {
+            viewModel.signOut()
+            onSignedOut()
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun HomeContent(
+    state: HomeUiState,
+    onRetry: () -> Unit,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LlmTheme.colors
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.app)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("llm-dock", style = MaterialTheme.typography.titleLarge, color = colors.fg)
+        Text(
+            "Signed in. The conversation list arrives with F02.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = colors.muted,
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(colors.surface, RoundedCornerShape(14.dp))
+                .border(1.dp, colors.line, RoundedCornerShape(14.dp))
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                "SESSION",
+                style = MaterialTheme.typography.labelSmall,
+                color = colors.subtle,
+            )
+            Text(
+                state.server.ifBlank { "No server configured" },
+                style = MaterialTheme.typography.bodyLarge,
+                color = colors.fg,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                val (dot, label) = when {
+                    state.checking -> colors.amber to "Checking the session…"
+                    state.sessionValid -> colors.green to "Session verified"
+                    else -> colors.red to (state.failure ?: "Session not usable")
+                }
+                Box(Modifier.size(9.dp).background(dot, CircleShape))
+                Text(
+                    label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colors.muted,
+                    modifier = Modifier.testTag("home_session_status"),
+                )
+            }
+            if (!state.checking && !state.sessionValid) {
+                TextButton(onClick = onRetry, modifier = Modifier.testTag("home_retry")) {
+                    Text("Retry", color = colors.accent)
+                }
+            }
+        }
+
+        OutlinedButton(
+            onClick = onSignOut,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("home_sign_out"),
+        ) {
+            Text("Sign out", color = colors.red)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDarkPreview() {
+    LLMDockChatTheme(darkTheme = true) {
+        HomeContent(
+            state = HomeUiState(
+                server = "http://10.0.2.2:3399",
+                checking = false,
+                sessionValid = true,
+            ),
+            onRetry = {}, onSignOut = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HomeLightPreview() {
+    LLMDockChatTheme(darkTheme = false) {
+        HomeContent(
+            state = HomeUiState(
+                server = "https://dock.example",
+                checking = false,
+                failure = "Could not reach the server.",
+            ),
+            onRetry = {}, onSignOut = {},
+        )
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/home/HomeViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/home/HomeViewModel.kt
@@ -1,0 +1,70 @@
+package com.hpz.llmdockchat.feature.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hpz.llmdockchat.core.auth.AuthService
+import com.hpz.llmdockchat.core.auth.SessionManager
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.ServerUrlStore
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.core.prefs.Stored
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class HomeUiState(
+    val server: String = "",
+    val checking: Boolean = true,
+    val sessionValid: Boolean = false,
+    val failure: String? = null,
+)
+
+/**
+ * The signed-in destination until F02 replaces it with the conversation list.
+ *
+ * It calls `POST /api/auth/verify` on entry, which is the only authenticated
+ * endpoint F01 is allowed to touch. That is not decoration: it is what makes
+ * silent re-auth observable — with a dead token stored, this request 401s, the
+ * transport re-authenticates from the credential, and the screen still lands on
+ * "session verified" without Connect appearing (F01-R6).
+ */
+class HomeViewModel(
+    private val authService: AuthService,
+    private val sessionManager: SessionManager,
+    serverUrlStore: ServerUrlStore,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HomeUiState())
+    val state: StateFlow<HomeUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            serverUrlStore.baseUrl.collect { stored ->
+                val value = (stored as? Stored.Ready)?.value?.value.orEmpty()
+                _state.value = _state.value.copy(server = value)
+            }
+        }
+        verify()
+    }
+
+    fun verify() {
+        _state.value = _state.value.copy(checking = true, failure = null)
+        viewModelScope.launch {
+            authService.verify().fold(
+                onSuccess = { valid ->
+                    _state.value = _state.value.copy(checking = false, sessionValid = valid)
+                },
+                onFailure = { failure ->
+                    _state.value = _state.value.copy(
+                        checking = false,
+                        sessionValid = false,
+                        failure = failure.appError.displayMessage,
+                    )
+                },
+            )
+        }
+    }
+
+    fun signOut() = sessionManager.signOut()
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -1,0 +1,97 @@
+package com.hpz.llmdockchat.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.hpz.llmdockchat.core.AppContainer
+import com.hpz.llmdockchat.feature.connect.ConnectScreen
+import com.hpz.llmdockchat.feature.connect.ConnectViewModel
+import com.hpz.llmdockchat.feature.home.HomeScreen
+import com.hpz.llmdockchat.feature.home.HomeViewModel
+
+/**
+ * The app's navigation graph (Architecture D12). Connect is a destination like
+ * any other rather than a modal in front of the app, so returning to it clears
+ * the back stack — a back press from Connect leaves the app instead of walking
+ * into a screen the session can no longer load.
+ */
+@Composable
+fun AppNavHost(
+    container: AppContainer,
+    startDestination: String,
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+) {
+    // Raised only when silent re-authentication cannot succeed (F01-R6), and by
+    // sign-out (F01-R7). Observed here, once, rather than in every screen —
+    // that is the point of Architecture D4.
+    val authenticationRequired by container.sessionState.authenticationRequired.collectAsState()
+    LaunchedEffect(authenticationRequired) {
+        if (authenticationRequired) navController.toConnect()
+    }
+
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier,
+    ) {
+        composable(Destinations.CONNECT) {
+            val viewModel: ConnectViewModel = viewModel(
+                factory = viewModelFactory {
+                    initializer {
+                        ConnectViewModel(
+                            sessionManager = container.sessionManager,
+                            reachability = container.reachabilityRepository,
+                            serverUrlStore = container.serverUrlStore,
+                            sessionState = container.sessionState,
+                        )
+                    }
+                },
+            )
+            ConnectScreen(
+                viewModel = viewModel,
+                onSignedIn = {
+                    navController.navigate(Destinations.HOME) {
+                        popUpTo(Destinations.CONNECT) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+            )
+        }
+
+        composable(Destinations.HOME) {
+            val viewModel: HomeViewModel = viewModel(
+                factory = viewModelFactory {
+                    initializer {
+                        HomeViewModel(
+                            authService = container.authService,
+                            sessionManager = container.sessionManager,
+                            serverUrlStore = container.serverUrlStore,
+                        )
+                    }
+                },
+            )
+            // Sign-out also raises the session signal, so the effect above would
+            // route here anyway; navigating directly keeps the transition
+            // immediate rather than waiting a frame for the flow to settle.
+            HomeScreen(viewModel = viewModel, onSignedOut = { navController.toConnect() })
+        }
+    }
+}
+
+private fun NavHostController.toConnect() {
+    if (currentDestination?.route == Destinations.CONNECT) return
+    navigate(Destinations.CONNECT) {
+        popUpTo(graph.id) { inclusive = true }
+        launchSingleTop = true
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
@@ -1,0 +1,28 @@
+package com.hpz.llmdockchat.navigation
+
+import com.hpz.llmdockchat.core.net.BaseUrl
+
+/**
+ * The app's destinations (Architecture D12). F01 has two; the two-tab scaffold
+ * arrives with the list screens it is meant to switch between.
+ */
+object Destinations {
+    const val CONNECT = "connect"
+    const val HOME = "home"
+}
+
+/**
+ * Which screen the app opens on, decided once from what is on disk.
+ *
+ * A stored *credential* is enough on its own: it renews the session silently
+ * (F01-R6), so a token that died while the app was closed is not a reason to
+ * ask for anything. A stored *token* without a credential is also enough —
+ * that is a TOTP sign-in, and the token is good until it is not, at which
+ * point the first 401 routes to Connect with an explanation.
+ */
+fun startDestination(server: BaseUrl?, token: String?, hasCredential: Boolean): String =
+    if (server != null && (!token.isNullOrBlank() || hasCredential)) {
+        Destinations.HOME
+    } else {
+        Destinations.CONNECT
+    }

--- a/android/src/app/src/main/res/xml/backup_rules.xml
+++ b/android/src/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Auto Backup, for devices below API 31. See data_extraction_rules.xml for 31+.
+
+   The DataStore file holds the session token and the dashboard credential
+   (F01-R5). Both are encrypted with a key that lives in the platform Keystore
+   and is never backed up, so a restored copy would be undecryptable anyway —
+   but a credential has no business leaving the device at all, so the file is
+   excluded outright.
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="file" path="datastore/" />
 </full-backup-content>

--- a/android/src/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/src/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   Backup and device-transfer rules for API 31+.
+
+   The DataStore file holds the session token and the dashboard credential
+   (F01-R5), so it leaves the device by neither route. The Keystore key that
+   encrypts them is not backed up either, which makes a restored copy inert —
+   this is belt and braces, and it is cheap.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="file" path="datastore/" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="file" path="datastore/" />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/AuthServiceTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/AuthServiceTest.kt
@@ -1,0 +1,149 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.SessionAuthenticator
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthServiceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var service: AuthService
+    private lateinit var tokenStore: FakeTokenStore
+    private var reauthAttempts = 0
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        // A token IS stored: the point of most of these tests is that the login
+        // routes go out without it anyway.
+        tokenStore = FakeTokenStore("totp-stale")
+        val sessionState = SessionState()
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(tokenStore, sessionState))
+            .authenticator(
+                SessionAuthenticator(tokenStore, sessionState) {
+                    reauthAttempts++
+                    "totp-should-never-be-used"
+                },
+            )
+            .build()
+        service = AuthService(
+            ApiClient(
+                client,
+                FakeServerUrlStore(baseUrl(server.url("/").toString())),
+                ApiJson,
+                Dispatchers.IO,
+            ),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun session(token: String = "totp-fresh") = MockResponse.Builder()
+        .body("""{"token": "$token", "expires_in": 28800}""")
+        .build()
+
+    @Test
+    fun `a password login sends the password as its own bearer and no session token`() = runBlocking {
+        server.enqueue(session())
+
+        val result = service.signIn(Credential.Password("hunter2"))
+
+        assertEquals("totp-fresh", result.getOrNull())
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/auth/session", request.url.encodedPath)
+        assertEquals("Bearer hunter2", request.headers["Authorization"])
+        assertNull(request.headers[AuthService.TOTP_CODE_HEADER])
+    }
+
+    @Test
+    fun `a TOTP login sends only the code header`() = runBlocking {
+        server.enqueue(session())
+
+        val result = service.signInWithTotpCode("419283")
+
+        assertEquals("totp-fresh", result.getOrNull())
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/auth/login", request.url.encodedPath)
+        assertEquals("419283", request.headers[AuthService.TOTP_CODE_HEADER])
+        // The stored bearer must not ride along: `/api/auth/login` is not
+        // decorated with `require_auth`, and a stale `totp-` bearer on an
+        // ordinary route makes the dashboard 401 before it reads the code.
+        assertNull(request.headers["Authorization"])
+    }
+
+    /**
+     * F01-R3: "shows the server's message". A 401 from a login route means the
+     * credential just supplied is wrong, not that the session has gone, so the
+     * dashboard's own words have to survive the error mapping.
+     */
+    @Test
+    fun `an invalid code surfaces the dashboard's own message`() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder().code(401).body("""{"error": "Invalid TOTP code"}""").build(),
+        )
+
+        val error = service.signInWithTotpCode("000000").exceptionOrNull()?.appError
+
+        assertEquals("Invalid TOTP code", error?.displayMessage)
+        assertEquals(0, reauthAttempts)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `an invalid password surfaces the dashboard's own message`() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder().code(401).body("""{"error": "Invalid token"}""").build(),
+        )
+
+        val error = service.signIn(Credential.Password("wrong")).exceptionOrNull()?.appError
+
+        assertEquals("Invalid token", error?.displayMessage)
+        assertEquals(0, reauthAttempts)
+    }
+
+    /** TOTP not configured server-side answers 400, and it is worth reading. */
+    @Test
+    fun `a 400 from the login route is shown as the server wrote it`() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder().code(400).body("""{"error": "TOTP is not configured"}""").build(),
+        )
+
+        val error = service.signInWithTotpCode("123456").exceptionOrNull()?.appError
+
+        assertTrue(error is AppError.Http)
+        assertEquals("TOTP is not configured", error?.displayMessage)
+    }
+
+    @Test
+    fun `verify carries the session token, unlike the login routes`() = runBlocking {
+        server.enqueue(MockResponse.Builder().body("""{"valid": true}""").build())
+
+        assertEquals(true, service.verify().getOrNull())
+        assertEquals("Bearer totp-stale", server.takeRequest().headers["Authorization"])
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/CredentialReauthenticatorTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/CredentialReauthenticatorTest.kt
@@ -1,0 +1,195 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.net.ApiException
+import com.hpz.llmdockchat.testing.FakeCredentialStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class CredentialReauthenticatorTest {
+
+    private val parkedStates = setOf(
+        Thread.State.WAITING,
+        Thread.State.TIMED_WAITING,
+        Thread.State.BLOCKED,
+    )
+
+    private val credentials = FakeCredentialStore(Credential.Password("hunter2"))
+    private val sessionState = SessionState()
+
+    private fun reauthenticator(
+        maxConsecutiveFailures: Int = CredentialReauthenticator.DEFAULT_MAX_CONSECUTIVE_FAILURES,
+        exchange: (Credential) -> Result<String>,
+    ) = CredentialReauthenticator(
+        credentials = credentials,
+        sessionState = sessionState,
+        maxConsecutiveFailures = maxConsecutiveFailures,
+        exchange = exchange,
+    )
+
+    private fun rejected() =
+        Result.failure<String>(ApiException(AppError.Http(401, "Invalid token", true)))
+
+    @Test
+    fun `the stored credential is exchanged for a fresh token`() {
+        val exchanged = mutableListOf<Credential>()
+        val token = reauthenticator { credential ->
+            exchanged += credential
+            Result.success("totp-fresh")
+        }.reauthenticate()
+
+        assertEquals("totp-fresh", token)
+        assertEquals(listOf(Credential.Password("hunter2")), exchanged)
+        assertFalse(sessionState.authenticationRequired.value)
+    }
+
+    /**
+     * A dashboard restart invalidates every token at once, so every in-flight
+     * request comes back 401 together. Each reaches OkHttp's `Authenticator` on
+     * its own thread; without this, one dead session costs N sign-ins.
+     */
+    @Test
+    fun `concurrent callers share one credential exchange`() {
+        val followerCount = 11
+        val exchanges = AtomicInteger(0)
+        val exchangeEntered = CountDownLatch(1)
+        val finish = CountDownLatch(1)
+
+        val subject = reauthenticator {
+            exchanges.incrementAndGet()
+            exchangeEntered.countDown()
+            check(finish.await(5, TimeUnit.SECONDS)) { "the test never released the exchange" }
+            Result.success("totp-shared")
+        }
+
+        val tokens = arrayOfNulls<String>(followerCount + 1)
+        val leader = Thread { tokens[0] = subject.reauthenticate() }.apply { start() }
+        // The leader now owns the in-flight exchange and cannot leave it until
+        // `finish`, so every follower below is guaranteed to join rather than
+        // start its own.
+        assertTrue(exchangeEntered.await(5, TimeUnit.SECONDS))
+
+        val followers = (1..followerCount).map { index ->
+            Thread { tokens[index] = subject.reauthenticate() }.apply { start() }
+        }
+        // Parked inside the shared future — no sleep, no timing assumption.
+        awaitUntil("followers never parked") {
+            followers.all { it.state in parkedStates }
+        }
+
+        finish.countDown()
+        (followers + leader).forEach { it.join(5_000) }
+
+        assertEquals(List(followerCount + 1) { "totp-shared" }, tokens.toList())
+        assertEquals(1, exchanges.get())
+    }
+
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (System.nanoTime() < deadline) {
+            if (condition()) return
+            Thread.sleep(5)
+        }
+        throw AssertionError(what)
+    }
+
+    @Test
+    fun `a later caller gets its own exchange once the first has finished`() {
+        val exchanges = AtomicInteger(0)
+        val subject = reauthenticator {
+            Result.success("totp-${exchanges.incrementAndGet()}")
+        }
+
+        assertEquals("totp-1", subject.reauthenticate())
+        assertEquals("totp-2", subject.reauthenticate())
+    }
+
+    /**
+     * `/api/auth/session` answers 401 only when the credential itself is wrong,
+     * so retrying can never succeed. Keeping it would mean one doomed exchange
+     * per request for as long as the app runs.
+     */
+    @Test
+    fun `a rejected credential is discarded and explained`() {
+        val subject = reauthenticator { rejected() }
+
+        assertNull(subject.reauthenticate())
+        assertNull(credentials.current())
+        assertTrue(sessionState.authenticationRequired.value)
+        assertEquals(CredentialReauthenticator.REJECTED, sessionState.reason.value)
+    }
+
+    @Test
+    fun `no stored credential says so rather than failing silently`() {
+        credentials.clear()
+        var attempts = 0
+        val subject = reauthenticator { attempts++; Result.success("totp-never") }
+
+        assertNull(subject.reauthenticate())
+        assertEquals(0, attempts)
+        assertEquals(CredentialReauthenticator.NO_CREDENTIAL, sessionState.reason.value)
+    }
+
+    @Test
+    fun `repeated non-rejection failures stop after the bound`() {
+        val attempts = AtomicInteger(0)
+        val subject = reauthenticator(maxConsecutiveFailures = 3) {
+            attempts.incrementAndGet()
+            Result.failure(ApiException(AppError.Network(java.io.IOException("no route"))))
+        }
+
+        repeat(10) { assertNull(subject.reauthenticate()) }
+
+        assertEquals(3, attempts.get())
+        // A network failure is not the credential's fault, so it survives.
+        assertEquals(Credential.Password("hunter2"), credentials.current())
+    }
+
+    @Test
+    fun `a success clears the failure count`() {
+        val attempts = AtomicInteger(0)
+        var failing = true
+        val subject = reauthenticator(maxConsecutiveFailures = 2) {
+            attempts.incrementAndGet()
+            if (failing) {
+                Result.failure(ApiException(AppError.Network(java.io.IOException("no route"))))
+            } else {
+                Result.success("totp-ok")
+            }
+        }
+
+        assertNull(subject.reauthenticate())
+        failing = false
+        assertEquals("totp-ok", subject.reauthenticate())
+        failing = true
+        assertNull(subject.reauthenticate())
+        failing = false
+        assertEquals("totp-ok", subject.reauthenticate())
+        assertEquals(4, attempts.get())
+    }
+
+    @Test
+    fun `reset lets a new sign-in try again after the bound was hit`() {
+        var failing = true
+        val subject = reauthenticator(maxConsecutiveFailures = 1) {
+            if (failing) {
+                Result.failure(ApiException(AppError.Network(java.io.IOException("no route"))))
+            } else {
+                Result.success("totp-ok")
+            }
+        }
+
+        assertNull(subject.reauthenticate())
+        failing = false
+        assertNull("the bound is still in force", subject.reauthenticate())
+
+        subject.reset()
+        assertEquals("totp-ok", subject.reauthenticate())
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/CredentialStoreTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/CredentialStoreTest.kt
@@ -1,0 +1,161 @@
+package com.hpz.llmdockchat.core.auth
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hpz.llmdockchat.core.prefs.Stored
+import com.hpz.llmdockchat.testing.SoftwareSecretCipher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * The Keystore itself needs a device, so these run the same AES/GCM
+ * construction against a JVM-resident key. What they prove is the part that
+ * belongs to this class: plaintext never reaches DataStore, a round trip
+ * survives a cold start, and an unopenable blob degrades to "no credential".
+ */
+class CredentialStoreTest {
+
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    private val password = "correct-horse-battery-staple"
+
+    /**
+     * One DataStore per file at a time — a second live instance over the same
+     * path is an error DataStore raises rather than tolerates. Cancelling the
+     * scope releases the file, which is also what makes "reopen it" a fair
+     * imitation of a cold app start.
+     */
+    private fun <T> session(file: File, cipher: SecretCipher, block: suspend Session.() -> T): T =
+        runBlocking {
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            try {
+                val store = PreferenceDataStoreFactory.create(scope = scope, produceFile = { file })
+                withTimeout(15_000) {
+                    Session(
+                        store,
+                        DataStoreCredentialStore(store, scope, cipher),
+                        DataStoreTokenStore(store, scope, cipher),
+                    ).block()
+                }
+            } finally {
+                scope.cancel()
+            }
+        }
+
+    private class Session(
+        val dataStore: DataStore<Preferences>,
+        val credentials: DataStoreCredentialStore,
+        val tokens: DataStoreTokenStore,
+    ) {
+        suspend fun raw(key: String): String? = dataStore.data.first()[stringPreferencesKey(key)]
+    }
+
+    @Test
+    fun `a credential round-trips through a cold start`() {
+        val file = folder.newFile("creds.preferences_pb")
+        val cipher = SoftwareSecretCipher()
+
+        session(file, cipher) {
+            credentials.save(Credential.Password(password))
+            credentials.awaitPendingWrites()
+        }
+
+        session(file, cipher) {
+            assertEquals(Credential.Password(password), credentials.current())
+            assertEquals(Stored.Ready(true), credentials.hasCredential.first { it is Stored.Ready })
+        }
+    }
+
+    @Test
+    fun `nothing recognisable reaches disk`() {
+        val file = folder.newFile("creds.preferences_pb")
+
+        val persisted = session(file, SoftwareSecretCipher()) {
+            credentials.save(Credential.Password(password))
+            credentials.awaitPendingWrites()
+            raw("credential")
+        }
+
+        assertNotNull(persisted)
+        assertFalse(persisted!!.contains(password))
+        assertFalse("the credential kind is a tag inside the ciphertext", persisted.contains("password"))
+        assertFalse(file.readBytes().toString(Charsets.ISO_8859_1).contains(password))
+    }
+
+    @Test
+    fun `signing out leaves nothing behind`() {
+        val file = folder.newFile("creds.preferences_pb")
+        val cipher = SoftwareSecretCipher()
+
+        val persisted = session(file, cipher) {
+            credentials.save(Credential.Password(password))
+            credentials.awaitPendingWrites()
+            credentials.clear()
+            credentials.awaitPendingWrites()
+            raw("credential")
+        }
+
+        assertNull(persisted)
+        session(file, cipher) { assertNull(credentials.current()) }
+    }
+
+    /**
+     * A restored backup, or a Keystore whose key has gone, leaves ciphertext
+     * that cannot be opened. Reading it as "no credential" costs one sign-in;
+     * throwing would cost the app its ability to start at all.
+     */
+    @Test
+    fun `an undecryptable blob reads as no credential`() {
+        val file = folder.newFile("creds.preferences_pb")
+
+        session(file, SoftwareSecretCipher()) {
+            credentials.save(Credential.Password(password))
+            credentials.awaitPendingWrites()
+        }
+
+        session(file, SoftwareSecretCipher()) {
+            assertNull(credentials.current())
+            assertEquals(Stored.Ready(false), credentials.hasCredential.first { it is Stored.Ready })
+        }
+    }
+
+    @Test
+    fun `the session token is encrypted at rest too`() {
+        val file = folder.newFile("token.preferences_pb")
+        val cipher = SoftwareSecretCipher()
+
+        val persisted = session(file, cipher) {
+            tokens.update("totp-abcdefghijklmnop")
+            tokens.awaitPendingWrites()
+            raw("session_token")
+        }
+
+        assertNotNull(persisted)
+        assertFalse(persisted!!.contains("totp-"))
+        session(file, cipher) { assertEquals("totp-abcdefghijklmnop", tokens.current()) }
+    }
+
+    @Test
+    fun `the credential never prints itself`() {
+        val rendered = "a credential: ${Credential.Password(password)}"
+        assertFalse(rendered.contains(password))
+        assertTrue(rendered.contains("***"))
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/SessionManagerTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/auth/SessionManagerTest.kt
@@ -1,0 +1,133 @@
+package com.hpz.llmdockchat.core.auth
+
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.SessionAuthenticator
+import com.hpz.llmdockchat.testing.FakeCredentialStore
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SessionManagerTest {
+
+    private lateinit var server: MockWebServer
+    private var serverUrl: BaseUrl = baseUrl("http://placeholder.invalid")
+    private lateinit var manager: SessionManager
+    private val tokenStore = FakeTokenStore()
+    private val credentials = FakeCredentialStore()
+    private val serverUrlStore = FakeServerUrlStore()
+    private val sessionState = SessionState()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        serverUrl = baseUrl(server.url("/").toString())
+        serverUrlStore.set(serverUrl)
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(tokenStore, sessionState))
+            .authenticator(SessionAuthenticator(tokenStore, sessionState) { null })
+            .build()
+        val authService = AuthService(
+            ApiClient(client, serverUrlStore, ApiJson, Dispatchers.IO),
+        )
+        manager = SessionManager(
+            serverUrlStore = serverUrlStore,
+            tokenStore = tokenStore,
+            credentials = credentials,
+            sessionState = sessionState,
+            authService = authService,
+            reauthenticator = CredentialReauthenticator(
+                credentials = credentials,
+                sessionState = sessionState,
+                exchange = { Result.failure(IllegalStateException("not used")) },
+            ),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private val session = MockResponse.Builder()
+        .body("""{"token": "totp-fresh", "expires_in": 28800}""")
+        .build()
+
+    @Test
+    fun `a password sign-in keeps the credential so the session can renew itself`() = runBlocking {
+        server.enqueue(session)
+
+        val result = manager.signInWithPassword(serverUrl, "hunter2")
+
+        assertTrue(result.isSuccess)
+        assertEquals("totp-fresh", tokenStore.current())
+        assertEquals(Credential.Password("hunter2"), credentials.current())
+        assertFalse(sessionState.authenticationRequired.value)
+    }
+
+    @Test
+    fun `a failed password sign-in stores nothing`() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(401).body("""{"error": "Invalid token"}""").build())
+
+        val result = manager.signInWithPassword(serverUrl, "wrong")
+
+        assertTrue(result.isFailure)
+        assertNull(tokenStore.current())
+        assertNull(credentials.current())
+    }
+
+    /**
+     * F01-R6's last criterion: a TOTP sign-in has nothing storable, so the
+     * session cannot renew itself and the user will be asked again.
+     */
+    @Test
+    fun `a TOTP sign-in stores a token and no credential`() = runBlocking {
+        server.enqueue(session)
+
+        val result = manager.signInWithTotpCode(serverUrl, "419283")
+
+        assertTrue(result.isSuccess)
+        assertEquals("totp-fresh", tokenStore.current())
+        assertNull(credentials.current())
+    }
+
+    @Test
+    fun `signing in with a code after a password drops the stale password`() = runBlocking {
+        server.enqueue(session)
+        credentials.save(Credential.Password("hunter2"))
+
+        manager.signInWithTotpCode(serverUrl, "419283")
+
+        assertNull(credentials.current())
+    }
+
+    @Test
+    fun `sign out clears both secrets and keeps the address`() {
+        tokenStore.update("totp-live")
+        credentials.save(Credential.Password("hunter2"))
+        val address = serverUrlStore.current()
+
+        manager.signOut()
+
+        assertNull(tokenStore.current())
+        assertNull(credentials.current())
+        assertEquals(address, serverUrlStore.current())
+        assertTrue(sessionState.authenticationRequired.value)
+        assertNull("a deliberate sign-out has nothing to explain", sessionState.reason.value)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/AuthInterceptorTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/AuthInterceptorTest.kt
@@ -100,13 +100,36 @@ class AuthInterceptorTest {
     }
 
     @Test
-    fun `with no token stored the request never reaches the network`() {
+    fun `with no token and nothing to mint one from, the request never reaches the network`() {
         tokenStore.clear()
         val thrown = runCatching { get("/api/chat/conversations") }.exceptionOrNull()
         assertTrue(thrown is ApiException)
         assertEquals(AppError.Unauthenticated, (thrown as ApiException).error)
         assertEquals(0, server.requestCount)
         assertTrue(sessionState.authenticationRequired.value)
+    }
+
+    /**
+     * F01-R6 narrows the rule above. A dashboard restart 401s the first
+     * request, which discards the dead token; failing everything queued behind
+     * it would take a signed-in user to Connect for no reason.
+     */
+    @Test
+    fun `with no token but a credential, one is minted before sending`() {
+        tokenStore.clear()
+        server.enqueue(MockResponse.Builder().body("{}").build())
+        val minted = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(tokenStore, sessionState) { "totp-minted" })
+            .build()
+
+        val code = minted.newCall(
+            Request.Builder().url(server.url("/api/chat/conversations")).build(),
+        ).execute().use { it.code }
+
+        assertEquals(200, code)
+        assertEquals("Bearer totp-minted", server.takeRequest().headers["Authorization"])
+        assertEquals("totp-minted", tokenStore.current())
+        assertFalse(sessionState.authenticationRequired.value)
     }
 
     @Test

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/ConcurrentReauthTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/ConcurrentReauthTest.kt
@@ -1,0 +1,124 @@
+package com.hpz.llmdockchat.core.net
+
+import com.hpz.llmdockchat.core.auth.Credential
+import com.hpz.llmdockchat.core.auth.CredentialReauthenticator
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.testing.FakeCredentialStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The whole F01-R6 stack over a real socket: a dead token stored, several
+ * requests in flight, the dashboard rejecting every one of them.
+ *
+ * A dashboard restart invalidates all session tokens at once, so this is the
+ * ordinary case rather than an exotic one. It must cost exactly one credential
+ * exchange and no visit to Connect.
+ */
+class ConcurrentReauthTest {
+
+    private lateinit var server: MockWebServer
+    private val tokenStore = FakeTokenStore("totp-stale")
+    private val credentials = FakeCredentialStore(Credential.Password("hunter2"))
+    private val sessionState = SessionState()
+    private val exchanges = AtomicInteger(0)
+
+    private val parked = setOf(
+        Thread.State.WAITING,
+        Thread.State.TIMED_WAITING,
+        Thread.State.BLOCKED,
+    )
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse =
+                if (request.headers["Authorization"] == "Bearer totp-fresh") {
+                    MockResponse.Builder().body("{}").build()
+                } else {
+                    MockResponse.Builder().code(401).body("""{"error": "expired"}""").build()
+                }
+        }
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    @Test
+    fun `a fleet of simultaneous 401s costs one credential exchange`() {
+        val inExchange = CountDownLatch(1)
+        val releaseExchange = CountDownLatch(1)
+
+        val reauthenticator = CredentialReauthenticator(
+            credentials = credentials,
+            sessionState = sessionState,
+        ) {
+            exchanges.incrementAndGet()
+            inExchange.countDown()
+            check(releaseExchange.await(10, TimeUnit.SECONDS)) { "the test never released it" }
+            Result.success("totp-fresh")
+        }
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(tokenStore, sessionState, reauthenticator))
+            .authenticator(SessionAuthenticator(tokenStore, sessionState, reauthenticator))
+            .build()
+
+        val callers = 8
+        val codes = arrayOfNulls<Int>(callers)
+        val threads = (0 until callers).map { index ->
+            Thread {
+                codes[index] = client
+                    .newCall(Request.Builder().url(server.url("/api/chat/conversations")).build())
+                    .execute()
+                    .use { it.code }
+            }
+        }
+
+        // The first caller's 401 opens the exchange and holds it. Every other
+        // caller then arrives to find no stored token (the 401 discarded it) —
+        // the exact pile-up that used to mean N sign-ins, or worse, N trips to
+        // Connect.
+        threads.first().start()
+        assertTrue(inExchange.await(10, TimeUnit.SECONDS))
+        threads.drop(1).forEach(Thread::start)
+        awaitUntil("callers never queued behind the exchange") {
+            threads.drop(1).all { it.state in parked }
+        }
+
+        releaseExchange.countDown()
+        threads.forEach { it.join(20_000) }
+
+        assertEquals(List(callers) { 200 }, codes.toList())
+        assertEquals(1, exchanges.get())
+        assertEquals("totp-fresh", tokenStore.current())
+        assertFalse("nothing should have routed to Connect", sessionState.authenticationRequired.value)
+    }
+
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+        while (System.nanoTime() < deadline) {
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        throw AssertionError(what)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ReachabilityRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ReachabilityRepositoryTest.kt
@@ -1,0 +1,83 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Duration
+
+class ReachabilityRepositoryTest {
+
+    private fun repository(url: String, client: OkHttpClient = OkHttpClient()) =
+        ReachabilityRepository(
+            HealthRepository(
+                ApiClient(
+                    client.newBuilder()
+                        .addInterceptor(AuthInterceptor(FakeTokenStore(), SessionState()))
+                        .connectTimeout(Duration.ofSeconds(3))
+                        .build(),
+                    FakeServerUrlStore(baseUrl(url)),
+                    ApiJson,
+                    Dispatchers.IO,
+                ),
+            ),
+        )
+
+    @Test
+    fun `the dashboard identifies itself`() = runBlocking {
+        val server = MockWebServer()
+        server.start()
+        server.enqueue(MockResponse.Builder().body("""{"status": "healthy"}""").build())
+
+        val result = repository(server.url("/").toString()).probe()
+
+        assertEquals(Reachability.Dashboard, result)
+        assertEquals("/api/health", server.takeRequest().url.encodedPath)
+        server.close()
+    }
+
+    /** The model server on `api.ai.heapzilla.eu` answers /api/health like this. */
+    @Test
+    fun `something else answering is not a dashboard`() = runBlocking {
+        val server = MockWebServer()
+        server.start()
+        server.enqueue(
+            MockResponse.Builder().body("""{"error": {"message": "Invalid API Key"}}""").build(),
+        )
+
+        assertTrue(repository(server.url("/").toString()).probe() is Reachability.NotADashboard)
+        server.close()
+    }
+
+    @Test
+    fun `a page of HTML is not a dashboard either`() = runBlocking {
+        val server = MockWebServer()
+        server.start()
+        server.enqueue(MockResponse.Builder().body("<html><body>nginx</body></html>").build())
+
+        assertTrue(repository(server.url("/").toString()).probe() is Reachability.NotADashboard)
+        server.close()
+    }
+
+    /** F01-R2: a wrong host has to read as unreachable, not as a wrong code. */
+    @Test
+    fun `nothing listening reads as unreachable`() = runBlocking {
+        val server = MockWebServer()
+        server.start()
+        val url = server.url("/").toString()
+        server.close()
+
+        assertTrue(repository(url).probe() is Reachability.Unreachable)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/connect/ConnectViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/connect/ConnectViewModelTest.kt
@@ -1,0 +1,211 @@
+package com.hpz.llmdockchat.feature.connect
+
+import com.hpz.llmdockchat.core.auth.AuthService
+import com.hpz.llmdockchat.core.auth.Credential
+import com.hpz.llmdockchat.core.auth.CredentialReauthenticator
+import com.hpz.llmdockchat.core.auth.SessionManager
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.SessionAuthenticator
+import com.hpz.llmdockchat.data.HealthRepository
+import com.hpz.llmdockchat.data.ReachabilityRepository
+import com.hpz.llmdockchat.testing.FakeCredentialStore
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.MainDispatcherRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ConnectViewModelTest {
+
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    private lateinit var server: MockWebServer
+    private lateinit var address: String
+    private lateinit var viewModel: ConnectViewModel
+
+    private val tokenStore = FakeTokenStore()
+    private val credentials = FakeCredentialStore()
+    private val serverUrlStore = FakeServerUrlStore()
+    private val sessionState = SessionState()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        address = server.url("/").toString().trimEnd('/')
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(tokenStore, sessionState))
+            .authenticator(SessionAuthenticator(tokenStore, sessionState) { null })
+            .build()
+        val api = ApiClient(client, serverUrlStore, ApiJson, Dispatchers.IO)
+        val authService = AuthService(api)
+
+        viewModel = ConnectViewModel(
+            sessionManager = SessionManager(
+                serverUrlStore = serverUrlStore,
+                tokenStore = tokenStore,
+                credentials = credentials,
+                sessionState = sessionState,
+                authService = authService,
+                reauthenticator = CredentialReauthenticator(
+                    credentials = credentials,
+                    sessionState = sessionState,
+                    exchange = { Result.failure(IllegalStateException("not used")) },
+                ),
+            ),
+            reachability = ReachabilityRepository(HealthRepository(api)),
+            serverUrlStore = serverUrlStore,
+            sessionState = sessionState,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun settled(): ConnectUiState = runBlocking {
+        withTimeout(10_000) { viewModel.state.first { !it.busy } }
+    }
+
+    private fun healthy() = MockResponse.Builder()
+        .body("""{"status": "healthy", "version": "1.0.0", "docker_available": true}""")
+        .build()
+
+    private fun session() = MockResponse.Builder()
+        .body("""{"token": "totp-fresh", "expires_in": 28800}""")
+        .build()
+
+    /** F01-R1: "rejected inline before any request is made". */
+    @Test
+    fun `a malformed address never reaches the network`() {
+        viewModel.onAddressChange("http://")
+        viewModel.onPasswordChange("hunter2")
+        viewModel.submit()
+
+        val state = settled()
+        assertNotNull(state.addressError)
+        assertEquals(0, server.requestCount)
+        assertFalse(state.signedIn)
+    }
+
+    @Test
+    fun `a valid password signs in`() {
+        server.enqueue(healthy())
+        server.enqueue(session())
+
+        viewModel.onAddressChange(address)
+        viewModel.onPasswordChange("hunter2")
+        viewModel.submit()
+
+        val state = settled()
+        assertTrue(state.failure ?: "", state.signedIn)
+        assertEquals("totp-fresh", tokenStore.current())
+        assertEquals(Credential.Password("hunter2"), credentials.current())
+        assertEquals("/api/health", server.takeRequest().url.encodedPath)
+        assertEquals("/api/auth/session", server.takeRequest().url.encodedPath)
+    }
+
+    /**
+     * F01-R2's whole purpose: separate "wrong address" from "wrong credential".
+     * A host that answers but is not the dashboard must not consume a code.
+     */
+    @Test
+    fun `a host that is not a dashboard is reported without attempting a login`() {
+        server.enqueue(MockResponse.Builder().body("""{"error": {"message": "Invalid API Key"}}""").build())
+
+        viewModel.onAddressChange(address)
+        viewModel.onPasswordChange("hunter2")
+        viewModel.submit()
+
+        val state = settled()
+        assertFalse(state.signedIn)
+        assertTrue(state.failure.orEmpty(), state.failure!!.contains("not an llm-dock dashboard"))
+        assertEquals(1, server.requestCount)
+        assertNull(tokenStore.current())
+    }
+
+    /** F01-R3: the server's own message, the address untouched, ready to retry. */
+    @Test
+    fun `an invalid code shows the server's message and leaves the address alone`() {
+        server.enqueue(healthy())
+        server.enqueue(
+            MockResponse.Builder().code(401).body("""{"error": "Invalid TOTP code"}""").build(),
+        )
+
+        viewModel.onAddressChange(address)
+        viewModel.onMethodChange(LoginMethod.CODE)
+        viewModel.onCodeChange("000000")
+
+        val state = settled()
+        assertEquals("Invalid TOTP code", state.failure)
+        assertEquals(address, state.address)
+        assertEquals("", state.code)
+        assertFalse(state.signedIn)
+        assertNull(credentials.current())
+    }
+
+    /** F01-R3: "submits without needing a separate button press once complete". */
+    @Test
+    fun `the sixth digit submits on its own`() {
+        server.enqueue(healthy())
+        server.enqueue(session())
+
+        viewModel.onAddressChange(address)
+        viewModel.onMethodChange(LoginMethod.CODE)
+        "41928".forEachIndexed { index, _ -> viewModel.onCodeChange("41928".take(index + 1)) }
+        assertEquals(0, server.requestCount)
+
+        viewModel.onCodeChange("419283")
+
+        assertTrue(settled().signedIn)
+        assertEquals(2, server.requestCount)
+        server.takeRequest()
+        assertEquals("419283", server.takeRequest().headers[AuthService.TOTP_CODE_HEADER])
+    }
+
+    @Test
+    fun `non-digits and overlong input never reach the field`() {
+        viewModel.onCodeChange("4a1-9 2 8 3 7 7")
+        assertEquals("419283", viewModel.state.value.code)
+    }
+
+    @Test
+    fun `a saved address is prefilled`() {
+        serverUrlStore.set(com.hpz.llmdockchat.testing.baseUrl("https://dock.example"))
+        val fresh = ConnectViewModel(
+            sessionManager = SessionManager(
+                serverUrlStore, tokenStore, credentials, sessionState,
+                AuthService(ApiClient(OkHttpClient(), serverUrlStore, ApiJson, Dispatchers.IO)),
+                CredentialReauthenticator(credentials, sessionState) {
+                    Result.failure(IllegalStateException("not used"))
+                },
+            ),
+            reachability = ReachabilityRepository(
+                HealthRepository(ApiClient(OkHttpClient(), serverUrlStore, ApiJson, Dispatchers.IO)),
+            ),
+            serverUrlStore = serverUrlStore,
+            sessionState = sessionState,
+        )
+        assertEquals("https://dock.example", fresh.state.value.address)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/navigation/StartDestinationTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/navigation/StartDestinationTest.kt
@@ -1,0 +1,56 @@
+package com.hpz.llmdockchat.navigation
+
+import com.hpz.llmdockchat.testing.baseUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StartDestinationTest {
+
+    private val server = baseUrl("http://10.0.2.2:3399")
+
+    @Test
+    fun `a cold install opens on Connect`() {
+        assertEquals(
+            Destinations.CONNECT,
+            startDestination(server = null, token = null, hasCredential = false),
+        )
+    }
+
+    /** F01-R6: the credential renews the session, so a dead token is not a prompt. */
+    @Test
+    fun `a stored credential is enough on its own`() {
+        assertEquals(
+            Destinations.HOME,
+            startDestination(server = server, token = null, hasCredential = true),
+        )
+    }
+
+    /** A TOTP sign-in: a live token, nothing to renew it with. Still signed in. */
+    @Test
+    fun `a stored token is enough on its own`() {
+        assertEquals(
+            Destinations.HOME,
+            startDestination(server = server, token = "totp-abc", hasCredential = false),
+        )
+    }
+
+    @Test
+    fun `secrets without a server address cannot be used`() {
+        assertEquals(
+            Destinations.CONNECT,
+            startDestination(server = null, token = "totp-abc", hasCredential = true),
+        )
+    }
+
+    @Test
+    fun `an address alone is not a session`() {
+        assertEquals(
+            Destinations.CONNECT,
+            startDestination(server = server, token = null, hasCredential = false),
+        )
+        assertEquals(
+            Destinations.CONNECT,
+            startDestination(server = server, token = "  ", hasCredential = false),
+        )
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/testing/Fakes.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/testing/Fakes.kt
@@ -1,5 +1,8 @@
 package com.hpz.llmdockchat.testing
 
+import com.hpz.llmdockchat.core.auth.Credential
+import com.hpz.llmdockchat.core.auth.CredentialStore
+import com.hpz.llmdockchat.core.auth.SecretCipher
 import com.hpz.llmdockchat.core.auth.TokenStore
 import com.hpz.llmdockchat.core.net.BaseUrl
 import com.hpz.llmdockchat.core.net.BaseUrlResult
@@ -9,6 +12,12 @@ import com.hpz.llmdockchat.core.prefs.valueOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
 
 class FakeTokenStore(initial: String? = null) : TokenStore {
     private val state = MutableStateFlow<Stored<String>>(Stored.Ready(initial))
@@ -24,6 +33,52 @@ class FakeServerUrlStore(initial: BaseUrl? = null) : ServerUrlStore {
     override fun current(): BaseUrl? = state.value.valueOrNull
     override fun set(url: BaseUrl) { state.value = Stored.Ready(url) }
     override fun clear() { state.value = Stored.Ready(null) }
+}
+
+class FakeCredentialStore(initial: Credential? = null) : CredentialStore {
+    private val state = MutableStateFlow<Stored<Credential>>(Stored.Ready(initial))
+    private val presence = MutableStateFlow<Stored<Boolean>>(Stored.Ready(initial != null))
+    override val hasCredential: StateFlow<Stored<Boolean>> = presence.asStateFlow()
+
+    override fun current(): Credential? = state.value.valueOrNull
+
+    override fun save(credential: Credential) {
+        state.value = Stored.Ready(credential)
+        presence.value = Stored.Ready(true)
+    }
+
+    override fun clear() {
+        state.value = Stored.Ready(null)
+        presence.value = Stored.Ready(false)
+    }
+}
+
+/**
+ * The same AES/GCM shape as [com.hpz.llmdockchat.core.auth.KeystoreSecretCipher]
+ * with a JVM-resident key. The Keystore itself needs a device; what a unit test
+ * can prove is that the store never hands plaintext to DataStore and that a
+ * round trip survives it.
+ */
+class SoftwareSecretCipher : SecretCipher {
+    private val key: SecretKey = KeyGenerator.getInstance("AES")
+        .apply { init(256) }
+        .generateKey()
+    private val random = SecureRandom()
+
+    override fun encrypt(plaintext: String): String {
+        val iv = ByteArray(12).also(random::nextBytes)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        return Base64.getEncoder()
+            .encodeToString(iv + cipher.doFinal(plaintext.toByteArray()))
+    }
+
+    override fun decrypt(ciphertext: String): String? = runCatching {
+        val raw = Base64.getDecoder().decode(ciphertext)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, raw, 0, 12))
+        String(cipher.doFinal(raw, 12, raw.size - 12))
+    }.getOrNull()
 }
 
 fun baseUrl(raw: String): BaseUrl = (BaseUrl.normalize(raw) as BaseUrlResult.Valid).baseUrl

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/testing/MainDispatcherRule.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/testing/MainDispatcherRule.kt
@@ -1,0 +1,20 @@
+package com.hpz.llmdockchat.testing
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * `viewModelScope` dispatches on Main, which does not exist on the JVM. The
+ * dispatcher is unconfined so a launch runs up to its first real suspension
+ * inside the call that started it — the state a test asserts on is then already
+ * there, with no time to advance.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MainDispatcherRule : TestWatcher() {
+    override fun starting(description: Description) = Dispatchers.setMain(UnconfinedTestDispatcher())
+    override fun finished(description: Description) = Dispatchers.resetMain()
+}

--- a/android/src/gradle/libs.versions.toml
+++ b/android/src/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ okhttp = "5.4.0"
 kotlinxSerialization = "1.11.0"
 coroutines = "1.11.0"
 datastore = "1.2.1"
+navigationCompose = "2.9.8"
 turbine = "1.2.1"
 
 [libraries]
@@ -30,6 +31,8 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver3-junit4 = { group = "com.squareup.okhttp3", name = "mockwebserver3-junit4", version.ref = "okhttp" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }


### PR DESCRIPTION
Connect screen, both login methods, Keystore-backed credential storage, silent re-auth, sign-out, and the navigation graph. Built by an implementation agent, independently reviewed and tested by a second agent.

## Verified live on the emulator against the real dashboard

Password sign-in, invalid-code rejection showing the server's own words, malformed address rejected before any request, unreachable host and reachable-but-not-a-dashboard distinguished, masked password with reveal, sign-out clearing both secrets while keeping the address.

**Silent re-auth (F01-R6) was proven, not asserted** — twice, by two agents, using different methods and without restarting the shared dashboard. The reviewer flipped 10 bytes inside the GCM body of the stored token so it could no longer decrypt, then cold-started: the app never showed Connect, minted a fresh session from the stored credential, and left a different ciphertext on disk. That is the exact state a dashboard restart produces.

## Security

Session token and credential are encrypted with an AndroidKeyStore AES-256/GCM key, fresh IV per encryption. The reviewer independently confirmed the app data directory holds no plaintext secret, that a full logcat dump during sign-in contains neither the password nor any `totp-` token, and — by running a real Backup Manager backup and restore cycle — that `files/datastore/` is genuinely excluded from cloud backup and device transfer.

`Credential` is a plain class with a hand-written `toString`, so no generated one can leak the secret into an interpolated log line.

## The F00 change worth reading

`AuthInterceptor`. Once the first 401 clears the dead token, every request queued behind it hit F00-R2's "no token → fail locally, route to Connect" branch — which would have dumped a signed-in user onto Connect during a dashboard restart, exactly what F01-R6 forbids. It now mints a token from the stored credential through the same single-flight exchange, and still fails **before** `chain.proceed` if it cannot, so F00's guarantee that no request leaves unauthenticated is intact and its test still passes.

Single-flight re-auth is mutation-tested: removing the machinery fails exactly the assertions that should fail. The reviewer restored the file byte-identical afterwards and verified by md5.

## Not marked [DONE]

**F01-R3's "a valid code signs in" is unverified.** Generating a valid TOTP code needs the server's secret; reading it is blocked by policy and `/api/totp/setup` is enrollment, forbidden by F00-R10. The rejection path is verified live. Closing this needs one code typed from the dashboard owner's authenticator app — it is recorded in the feature file and marked `[WIP]` in `Plan_TOC.md` rather than reported as complete.

Carried forward with named owners: "lands on the conversation list" → F02; "a 401 during a streaming turn is recoverable" → F04/F09.

118 unit tests, all green, F00's 76 included.