### PR TITLE
Android F05: rendering assistant output

### DIFF
--- a/android/WORK_INSTRUCTIONS.md
+++ b/android/WORK_INSTRUCTIONS.md
@@ -95,6 +95,19 @@ State these in the brief; do not assume they are inferred:
 - **Never** start or stop LLM containers, or fire test traffic at them.
 - **Never** wipe, factory-reset or kill the emulator. `dev.sh clear`
   (this app's data only) is fine.
+- **Target a device explicitly whenever more than one is attached.** The
+  owner's physical phone is sometimes plugged in alongside the emulator.
+  `./gradlew installDebug` installs to **every** connected device, and
+  `dev.sh` and bare `adb` target whatever adb happens to pick — an agent
+  hit this and pushed a build to the owner's phone mid-session, under
+  another agent that was using it. Use
+  `adb -s <serial> install -r app/build/outputs/apk/debug/app-debug.apk`,
+  and `adb -s <serial>` for every shell, screencap and dump.
+  Check with `adb devices -l` first.
+- **The owner's phone is not a test device.** If a brief does not
+  explicitly assign it to you, do not install to it, do not clear its app
+  data (that destroys their stored credential and signs them out), and do
+  not touch their real conversations.
 - **Never** call the dashboard's configuration endpoints — see F00-R10.
 - **Never** edit a requirements file except to add to its *Deviations*
   section, and only with a reason.

--- a/android/docs/F00-cross-cutting.md
+++ b/android/docs/F00-cross-cutting.md
@@ -267,6 +267,13 @@ normalisation and resolution, R2, R6's framing behaviour (split reads,
 comment keepalives, opaque payloads, cancellation and socket teardown),
 R7's palettes and live theme switching, R10, and R11's formatter.
 
+**R1's second criterion is now fully closed (2026-07-25).** It had only
+ever been half-verified — `http://10.0.2.2:3399` on the emulator, with no
+real HTTPS host to point at. The app now runs on a physical phone against
+`https://models.ai.heapzilla.eu` with no code change: TLS verifies clean,
+`/api/health` answers 200, and authenticated requests work. Both schemes
+are proven.
+
 R8's first criterion is **partly satisfied already**: typography is `sp`
 throughout and the review confirmed at 1.5x system font scale that text
 reflows with nothing clipped or overlapped.

--- a/android/docs/F05-message-rendering.md
+++ b/android/docs/F05-message-rendering.md
@@ -147,3 +147,21 @@ web parity would have allowed them.
 - Exporting a thread to a file.
 - Syntax highlighting inside code blocks is not required for v1 — a
   monospace block with a language label satisfies F05-R2.
+
+## Carried forward
+
+| Criterion | Verify in |
+|---|---|
+| R4 · the Settings toggle switching assistant prose to a sans face, persisting | **F13.** The serif/mono split itself is built and verified; only the toggle is outstanding. |
+
+Verified on device, both themes: every R1 construct in a live stream,
+code blocks with language label and exact-code copy, both copy
+behaviours through a clipboard round-trip, text selection in rendered
+prose, tables scrolling in their own box, an `svg` artifact from
+schemdraw rendering as a picture with tap-to-fullscreen and pinch-zoom,
+an `html` artifact as the R8 placeholder, and LaTeX passing through with
+underscores, backslashes and braces intact.
+
+Artifact decode-failure fallbacks are code-level only — neither a
+malformed `image` nor a malformed `svg` artifact could be provoked from
+the live tools.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -178,7 +178,7 @@ Mark completed features `[DONE]` in the Status column.
 | F02 | Conversation list | [F02-conversation-list.md](F02-conversation-list.md) | 02 | [DONE] |
 | F03 | Starting a conversation | [F03-new-conversation.md](F03-new-conversation.md) | 03 | [DONE] |
 | F04 | Sending a turn and streaming the reply | [F04-chat-turn-and-streaming.md](F04-chat-turn-and-streaming.md) | 04, 06a | [DONE] |
-| F05 | Rendering assistant output | [F05-message-rendering.md](F05-message-rendering.md) | 05 | [ ] |
+| F05 | Rendering assistant output | [F05-message-rendering.md](F05-message-rendering.md) | 05 | [DONE] |
 | F06 | Message actions | [F06-message-actions.md](F06-message-actions.md) | 06b | [ ] |
 | F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [ ] |
 | F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [ ] |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MarkdownParser.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MarkdownParser.kt
@@ -1,0 +1,404 @@
+package com.hpz.llmdockchat.core.markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import com.hpz.llmdockchat.core.ui.theme.LlmColors
+
+/**
+ * A hand-rolled block-level Markdown renderer (F05-R1/R2/R5/R7). No third-party
+ * Markdown library is in Architecture D7's verified dependency set — the
+ * construct list here is fixed and modest, syntax highlighting is explicitly
+ * out of scope, and streaming needs precise control over how an unterminated
+ * construct renders, which a general GFM library does not expose. See the F05
+ * implementation report for the fuller reasoning.
+ *
+ * Two-phase, matching Architecture P2:
+ *
+ * 1. [splitMdBlocks] — a cheap line scan that finds block *boundaries* only.
+ *    It is prefix-stable: once a block is closed (a blank line, or a new block
+ *    starter appears), its raw text never changes as the stream grows, so it
+ *    is only ever computed once per block. Only the last, still-open block's
+ *    raw text keeps growing.
+ * 2. [parseMdBlock] — the expensive part (regex-driven inline parsing,
+ *    `AnnotatedString` construction) on one block's raw text. Callers
+ *    `remember(raw, colors) { parseMdBlock(raw, colors) }` per block, so
+ *    Compose's own equality check skips re-running this for every
+ *    already-closed block — only the open tail block, whose `raw` actually
+ *    changed, re-parses.
+ */
+private const val FENCE_BACKTICK = "```"
+private const val FENCE_TILDE = "~~~"
+
+fun splitMdBlocks(text: String): List<String> {
+    if (text.isEmpty()) return emptyList()
+    // CRLF (or a bare CR) would otherwise fail `LIST_UNORDERED_RE`/`LIST_ORDERED_RE`'s
+    // `matches()` on the trailing `\r` and leave a stray `\r` in quoted text —
+    // normalising once here kills both instead of chasing `\r` in every regex.
+    val normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    val lines = normalized.split("\n")
+    val blocks = mutableListOf<MutableList<String>>()
+    var inFence = false
+    var fenceMarker = ""
+
+    fun current(): MutableList<String>? = blocks.lastOrNull()
+    fun startBlock(line: String) {
+        blocks += mutableListOf(line)
+    }
+    fun append(line: String) {
+        current()?.let { it += line } ?: startBlock(line)
+    }
+
+    for (line in lines) {
+        val trimmed = line.trimStart()
+        if (inFence) {
+            append(line)
+            if (trimmed.startsWith(fenceMarker)) inFence = false
+            continue
+        }
+        when {
+            trimmed.startsWith(FENCE_BACKTICK) || trimmed.startsWith(FENCE_TILDE) -> {
+                startBlock(line)
+                fenceMarker = if (trimmed.startsWith(FENCE_BACKTICK)) FENCE_BACKTICK else FENCE_TILDE
+                inFence = true
+            }
+            line.isBlank() -> blocks.add(mutableListOf()) // forces the next line to start a fresh block
+            isHeadingLine(line) || isRuleLine(line) -> startBlock(line)
+            isListItemLine(line) -> {
+                if (current()?.let { it.isNotEmpty() && isListItemLine(it.first()) } == true) append(line)
+                else startBlock(line)
+            }
+            isQuoteLine(line) -> {
+                if (current()?.let { it.isNotEmpty() && isQuoteLine(it.first()) } == true) append(line)
+                else startBlock(line)
+            }
+            looksLikeTableRow(line) -> {
+                val cur = current()
+                when {
+                    cur == null || cur.isEmpty() -> startBlock(line)
+                    looksLikeTableRow(cur.first()) -> append(line)
+                    else -> startBlock(line)
+                }
+            }
+            else -> {
+                val cur = current()
+                val continuesParagraph = cur != null && cur.isNotEmpty() &&
+                    !isHeadingLine(cur.first()) && !isRuleLine(cur.first()) &&
+                    !isListItemLine(cur.first()) && !isQuoteLine(cur.first()) &&
+                    !cur.first().trimStart().let { it.startsWith(FENCE_BACKTICK) || it.startsWith(FENCE_TILDE) }
+                if (continuesParagraph) append(line) else startBlock(line)
+            }
+        }
+    }
+    return blocks.filter { it.isNotEmpty() }.map { it.joinToString("\n") }
+}
+
+fun parseMdBlock(raw: String, colors: LlmColors): MdBlock {
+    val lines = raw.split("\n")
+    val first = lines.first()
+    val firstTrimmed = first.trimStart()
+
+    return when {
+        firstTrimmed.startsWith(FENCE_BACKTICK) || firstTrimmed.startsWith(FENCE_TILDE) -> parseCodeBlock(lines)
+        isHeadingLine(first) -> parseHeading(first, colors)
+        isRuleLine(first) && lines.size == 1 -> MdBlock.Rule
+        lines.size >= 2 && looksLikeTableRow(lines[0]) && isTableDelimiterLine(lines[1]) -> parseTable(lines, colors)
+        isListItemLine(first) -> parseList(lines, colors)
+        isQuoteLine(first) -> parseQuote(lines, colors)
+        raw.trim().startsWith("$$") -> MdBlock.MathBlock(raw)
+        else -> MdBlock.Paragraph(parseInline(joinParagraphLines(lines), colors))
+    }
+}
+
+private fun joinParagraphLines(lines: List<String>): String = lines.joinToString(" ") { it.trim() }
+
+private fun isHeadingLine(line: String): Boolean {
+    val t = line.trimStart()
+    if (!t.startsWith("#")) return false
+    val hashes = t.takeWhile { it == '#' }
+    return hashes.length in 1..6 && (t.length == hashes.length || t[hashes.length] == ' ')
+}
+
+private fun parseHeading(line: String, colors: LlmColors): MdBlock.Heading {
+    val t = line.trimStart()
+    val level = t.takeWhile { it == '#' }.length
+    val text = t.drop(level).trim()
+    return MdBlock.Heading(level, parseInline(text, colors))
+}
+
+private fun isRuleLine(line: String): Boolean {
+    val t = line.trim()
+    if (t.length < 3) return false
+    val c = t[0]
+    if (c != '-' && c != '*' && c != '_') return false
+    return t.all { it == c || it == ' ' } && t.count { it == c } >= 3
+}
+
+private val FENCE_INFO_RE = Regex("^(```+|~~~+)\\s*([A-Za-z0-9_+-]*)")
+
+private fun parseCodeBlock(lines: List<String>): MdBlock.CodeBlock {
+    val openMatch = FENCE_INFO_RE.find(lines.first().trimStart())
+    val marker = openMatch?.groupValues?.get(1)?.take(3) ?: FENCE_BACKTICK
+    val language = openMatch?.groupValues?.get(2)?.takeIf { it.isNotBlank() }
+    val closeIndex = (1 until lines.size).firstOrNull { lines[it].trimStart().startsWith(marker) }
+    val body = if (closeIndex != null) lines.subList(1, closeIndex) else lines.drop(1)
+    return MdBlock.CodeBlock(language, body.joinToString("\n"), closed = closeIndex != null)
+}
+
+private val LIST_UNORDERED_RE = Regex("^(\\s*)([-*+])\\s+(.*)$")
+private val LIST_ORDERED_RE = Regex("^(\\s*)(\\d+)[.)]\\s+(.*)$")
+
+private fun isListItemLine(line: String): Boolean =
+    LIST_UNORDERED_RE.matches(line) || LIST_ORDERED_RE.matches(line)
+
+private fun parseList(lines: List<String>, colors: LlmColors): MdBlock.ListBlock {
+    val items = mutableListOf<MdListItem>()
+    for (line in lines) {
+        val unordered = LIST_UNORDERED_RE.matchEntire(line)
+        val ordered = LIST_ORDERED_RE.matchEntire(line)
+        when {
+            unordered != null -> {
+                val depth = unordered.groupValues[1].length / 2
+                items += MdListItem(depth, ordered = false, index = null, text = parseInline(unordered.groupValues[3], colors))
+            }
+            ordered != null -> {
+                val depth = ordered.groupValues[1].length / 2
+                val idx = ordered.groupValues[2].toIntOrNull()
+                items += MdListItem(depth, ordered = true, index = idx, text = parseInline(ordered.groupValues[3], colors))
+            }
+            else -> {
+                // A continuation line (soft-wrapped text under the current item):
+                // appended to the last item rather than dropped, so nothing is lost.
+                val last = items.removeLastOrNull()
+                if (last != null) {
+                    val joined = last.text.text + " " + line.trim()
+                    items += last.copy(text = parseInline(joined, colors))
+                }
+            }
+        }
+    }
+    return MdBlock.ListBlock(items)
+}
+
+private fun isQuoteLine(line: String): Boolean = line.trimStart().startsWith(">")
+
+private fun parseQuote(lines: List<String>, colors: LlmColors): MdBlock.Quote {
+    val quoteLines = lines.map { line ->
+        var stripped = line.trimStart()
+        if (stripped.startsWith(">")) stripped = stripped.removePrefix(">").removePrefix(" ")
+        parseInline(stripped, colors)
+    }
+    return MdBlock.Quote(quoteLines)
+}
+
+/**
+ * A bare `|` mid-sentence — `P(A|B) using Bayes' theorem` — must not read as a
+ * table row and fracture the paragraph around it (a real risk with this rig's
+ * models, which write conditional-probability notation often). Requiring an
+ * edge pipe or a second pipe is enough signal without needing a real GFM
+ * grammar: genuine tables almost always have a leading/trailing `|` or 2+
+ * columns.
+ */
+private fun looksLikeTableRow(line: String): Boolean {
+    val t = line.trim()
+    if (t.isEmpty()) return false
+    return t.startsWith("|") || t.endsWith("|") || t.count { it == '|' } >= 2
+}
+
+private val TABLE_DELIMITER_CELL_RE = Regex("^:?-+:?$")
+
+private fun isTableDelimiterLine(line: String): Boolean {
+    val cells = splitTableRow(line)
+    return cells.isNotEmpty() && cells.all { TABLE_DELIMITER_CELL_RE.matches(it.trim()) }
+}
+
+private fun splitTableRow(line: String): List<String> {
+    var t = line.trim()
+    if (t.startsWith("|")) t = t.drop(1)
+    if (t.endsWith("|") && !t.endsWith("\\|")) t = t.dropLast(1)
+    // Split on unescaped pipes.
+    val cells = mutableListOf<String>()
+    val current = StringBuilder()
+    var i = 0
+    while (i < t.length) {
+        val c = t[i]
+        if (c == '\\' && i + 1 < t.length && t[i + 1] == '|') {
+            current.append('|')
+            i += 2
+            continue
+        }
+        if (c == '|') {
+            cells += current.toString()
+            current.clear()
+        } else {
+            current.append(c)
+        }
+        i++
+    }
+    cells += current.toString()
+    return cells
+}
+
+private fun parseTable(lines: List<String>, colors: LlmColors): MdBlock {
+    val header = splitTableRow(lines[0]).map { parseInline(it.trim(), colors) }
+    val alignments = splitTableRow(lines[1]).map { cell ->
+        val c = cell.trim()
+        when {
+            c.startsWith(":") && c.endsWith(":") -> TableAlign.CENTER
+            c.endsWith(":") -> TableAlign.RIGHT
+            else -> TableAlign.LEFT
+        }
+    }
+    // A ragged row (too few/many cells) is padded/truncated rather than
+    // crashing the message (F05-R5's second criterion).
+    val rows = lines.drop(2).filter { it.isNotBlank() }.map { rowLine ->
+        val cells = splitTableRow(rowLine).map { it.trim() }
+        List(header.size) { i -> parseInline(cells.getOrElse(i) { "" }, colors) }
+    }
+    return MdBlock.Table(header, alignments, rows)
+}
+
+// -- Inline formatting ------------------------------------------------------
+
+/**
+ * Bold, italic, inline code, links and `$…$`/`$$…$$` maths passthrough
+ * (F05-R7), single pass, no recursive nesting of emphasis inside emphasis —
+ * a deliberate scope cut (this renders one model's output on one phone; see
+ * the F05 implementation report).
+ *
+ * An unterminated marker (an opening `**` with no closing `**` anywhere in
+ * the text that has arrived so far) falls back to its literal characters
+ * rather than being swallowed — F05-R1's fourth criterion and F05-R7's
+ * second: nothing is silently stripped.
+ */
+fun parseInline(raw: String, colors: LlmColors): AnnotatedString = buildAnnotatedString {
+    var i = 0
+    val n = raw.length
+    while (i < n) {
+        val c = raw[i]
+        when {
+            c == '\\' && i + 1 < n && raw[i + 1] in ESCAPABLE -> {
+                append(raw[i + 1])
+                i += 2
+            }
+            c == '`' -> {
+                val end = raw.indexOf('`', i + 1)
+                if (end < 0) {
+                    append(raw.substring(i)); i = n
+                } else {
+                    withStyle(codeSpanStyle(colors)) { append(raw.substring(i + 1, end)) }
+                    i = end + 1
+                }
+            }
+            raw.startsWith("$$", i) -> {
+                val end = raw.indexOf("$$", i + 2)
+                if (end < 0) {
+                    withStyle(mathSpanStyle(colors)) { append(raw.substring(i)) }; i = n
+                } else {
+                    withStyle(mathSpanStyle(colors)) { append(raw.substring(i, end + 2)) }
+                    i = end + 2
+                }
+            }
+            c == '$' -> {
+                val end = findInlineMathClose(raw, i + 1)
+                if (end < 0) {
+                    append(c); i++
+                } else {
+                    withStyle(mathSpanStyle(colors)) { append(raw.substring(i, end + 1)) }
+                    i = end + 1
+                }
+            }
+            raw.startsWith("**", i) || raw.startsWith("__", i) -> {
+                val marker = raw.substring(i, i + 2)
+                val end = raw.indexOf(marker, i + 2)
+                if (end <= i + 2) {
+                    append(marker); i += 2
+                } else {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(raw.substring(i + 2, end)) }
+                    i = end + 2
+                }
+            }
+            (c == '*' || c == '_') -> {
+                val end = raw.indexOf(c, i + 1)
+                if (end <= i + 1) {
+                    append(c); i++
+                } else {
+                    withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(raw.substring(i + 1, end)) }
+                    i = end + 1
+                }
+            }
+            c == '[' -> {
+                val link = matchLink(raw, i)
+                if (link == null) {
+                    append(c); i++
+                } else {
+                    withLink(
+                        LinkAnnotation.Url(
+                            link.url,
+                            TextLinkStyles(style = SpanStyle(color = colors.accent, textDecoration = TextDecoration.Underline)),
+                        ),
+                    ) { append(link.text) }
+                    i = link.end
+                }
+            }
+            else -> {
+                append(c); i++
+            }
+        }
+    }
+}
+
+private val ESCAPABLE = "\\`*_{}[]()#+-.!$>~".toSet()
+
+private data class LinkMatch(val text: String, val url: String, val end: Int)
+
+/** `[text](url)`. Anything short of the full shape falls through as literal `[`. */
+private fun matchLink(raw: String, start: Int): LinkMatch? {
+    val closeText = raw.indexOf(']', start + 1)
+    if (closeText < 0 || closeText + 1 >= raw.length || raw[closeText + 1] != '(') return null
+    val closeUrl = raw.indexOf(')', closeText + 2)
+    if (closeUrl < 0) return null
+    val text = raw.substring(start + 1, closeText)
+    val url = raw.substring(closeText + 2, closeUrl)
+    if (url.isBlank()) return null
+    return LinkMatch(text, url, closeUrl + 1)
+}
+
+/**
+ * The closing `$` of an inline maths span. Requires non-blank content on
+ * both edges and no newline crossing, which keeps ordinary currency prose
+ * ("$5 and $10") from being swept up most of the time without needing a
+ * full LaTeX grammar — this renders one model's output, not arbitrary text.
+ */
+private fun findInlineMathClose(raw: String, from: Int): Int {
+    var i = from
+    while (i < raw.length) {
+        val c = raw[i]
+        if (c == '\n') return -1
+        if (c == '$') {
+            if (i == from) return -1 // empty span
+            if (raw[from] == ' ' || raw[i - 1] == ' ') return -1
+            return i
+        }
+        i++
+    }
+    return -1
+}
+
+private fun codeSpanStyle(colors: LlmColors) = SpanStyle(
+    fontFamily = FontFamily.Monospace,
+    background = colors.sunken,
+)
+
+private fun mathSpanStyle(colors: LlmColors) = SpanStyle(
+    fontFamily = FontFamily.Monospace,
+    color = colors.muted,
+)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MdBlock.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MdBlock.kt
@@ -1,0 +1,45 @@
+package com.hpz.llmdockchat.core.markdown
+
+import androidx.compose.ui.text.AnnotatedString
+
+/**
+ * A block-level Markdown construct (F05-R1), already inline-styled — bold,
+ * italic, inline code and links are resolved into the [AnnotatedString]s here,
+ * so the render layer only lays blocks out.
+ *
+ * Produced by [parseMdBlock] from one raw block's source text. The block
+ * boundaries themselves come from [splitMdBlocks], which is prefix-stable
+ * (Architecture P2): an already-closed block's raw text never changes as the
+ * stream grows, so only the still-open last block needs reparsing.
+ */
+sealed interface MdBlock {
+    data class Heading(val level: Int, val text: AnnotatedString) : MdBlock
+
+    data class Paragraph(val text: AnnotatedString) : MdBlock
+
+    /**
+     * `closed` is false while the block still lacks its closing fence — the
+     * content keeps growing but the block never stops being a code block, which
+     * is what keeps an open fence from flickering (F05-R1's second criterion).
+     */
+    data class CodeBlock(val language: String?, val code: String, val closed: Boolean) : MdBlock
+
+    data class ListBlock(val items: List<MdListItem>) : MdBlock
+
+    data class Quote(val lines: List<AnnotatedString>) : MdBlock
+
+    data class Table(
+        val header: List<AnnotatedString>,
+        val alignments: List<TableAlign>,
+        val rows: List<List<AnnotatedString>>,
+    ) : MdBlock
+
+    data object Rule : MdBlock
+
+    /** `$$…$$` on its own line(s) — F05-R7, literal source, not evaluated. */
+    data class MathBlock(val source: String) : MdBlock
+}
+
+data class MdListItem(val depth: Int, val ordered: Boolean, val index: Int?, val text: AnnotatedString)
+
+enum class TableAlign { LEFT, CENTER, RIGHT }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ChatThreadDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ChatThreadDto.kt
@@ -55,6 +55,20 @@ data class LastRunDto(
     val error: String? = null,
 )
 
+/**
+ * One row of `chat/models.py:Artifact.to_dict()` — the wire key is `type`,
+ * not `artifact_type` (that spelling is only used on the SSE frame, see
+ * `RunEvent.Artifact`).
+ */
+@Serializable
+data class ArtifactDto(
+    val id: String = "",
+    val type: String = "",
+    val content: String = "",
+    val title: String? = null,
+    val language: String? = null,
+)
+
 /** `GET /api/chat/conversations/<id>` — `to_dict(include_messages=True)`. */
 @Serializable
 data class ConversationDetailDto(
@@ -66,6 +80,9 @@ data class ConversationDetailDto(
     @SerialName("last_run") val lastRun: LastRunDto? = null,
     @SerialName("updated_at") val updatedAt: String? = null,
     val messages: List<ChatMessageDto> = emptyList(),
+    // `{message_id: [Artifact, …]}` — a sibling of `messages`, not nested
+    // inside each one (`chat/routes.py`: `result["artifacts"] = …`).
+    val artifacts: Map<String, List<ArtifactDto>> = emptyMap(),
 )
 
 /** `POST /api/chat/conversations/<id>/messages` body. */

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapper.kt
@@ -1,12 +1,14 @@
 package com.hpz.llmdockchat.data.mapper
 
 import com.hpz.llmdockchat.data.dto.ActiveRunDto
+import com.hpz.llmdockchat.data.dto.ArtifactDto
 import com.hpz.llmdockchat.data.dto.ChatMessageDto
 import com.hpz.llmdockchat.data.dto.ConversationDetailDto
 import com.hpz.llmdockchat.data.dto.LastRunDto
 import com.hpz.llmdockchat.data.dto.ParseWarningDto
 import com.hpz.llmdockchat.data.dto.ToolCallDto
 import com.hpz.llmdockchat.data.model.ActiveRun
+import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import com.hpz.llmdockchat.data.model.LastRun
@@ -23,13 +25,13 @@ fun ConversationDetailDto.toDomain(): ConversationDetail = ConversationDetail(
     modelRef = parseModelRef(mainService),
     // The server orders by seq already; sorting here makes the list's own
     // ordering independent of that, since `key` stability drives recomposition.
-    messages = messages.sortedBy { it.seq }.map { it.toDomain() },
+    messages = messages.sortedBy { it.seq }.map { it.toDomain(artifacts[it.id].orEmpty()) },
     activeRun = activeRun?.toActiveRun(),
     lastRun = lastRun?.toLastRun(),
     updatedAt = updatedAt,
 )
 
-private fun ChatMessageDto.toDomain(): ChatMessage = ChatMessage(
+private fun ChatMessageDto.toDomain(artifacts: List<ArtifactDto>): ChatMessage = ChatMessage(
     id = id,
     role = parseMessageRole(role),
     content = content,
@@ -41,7 +43,11 @@ private fun ChatMessageDto.toDomain(): ChatMessage = ChatMessage(
     toolCalls = toolCalls.map { it.toDomain() },
     parseWarning = parseWarning?.toDomain(),
     error = error?.takeIf { it.isNotBlank() },
+    artifacts = artifacts.map { it.toDomain() },
 )
+
+private fun ArtifactDto.toDomain(): ArtifactRecord =
+    ArtifactRecord(type = type, title = title, content = content, language = language)
 
 private fun ToolCallDto.toDomain(): ToolCallRecord = ToolCallRecord(
     name = name,

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ChatMessage.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ChatMessage.kt
@@ -32,6 +32,19 @@ data class ParseWarning(
 }
 
 /**
+ * A tool-produced artifact (F05-R6/R8) — `svg`, `image`, `html` or `code`.
+ * Persisted ones arrive out of band, in `GET /api/chat/conversations/<id>`'s
+ * top-level `artifacts: {message_id: [...]}` map (`chat/db.py:get_artifacts_for_conversation`),
+ * not nested on the message itself; the mapper folds them in by id.
+ */
+data class ArtifactRecord(
+    val type: String,
+    val title: String?,
+    val content: String,
+    val language: String?,
+)
+
+/**
  * A message as the **server** has it. The client never fabricates one of these
  * from streamed text — that is Architecture D3, and it is what keeps a
  * cancelled run from inventing an assistant turn that does not exist.
@@ -48,6 +61,7 @@ data class ChatMessage(
     val toolCalls: List<ToolCallRecord>,
     val parseWarning: ParseWarning?,
     val error: String?,
+    val artifacts: List<ArtifactRecord> = emptyList(),
 )
 
 /** The most recent run on a thread, whatever its status. */

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
@@ -1,0 +1,505 @@
+package com.hpz.llmdockchat.feature.thread
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.webkit.WebView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hpz.llmdockchat.core.markdown.MdBlock
+import com.hpz.llmdockchat.core.markdown.TableAlign
+import com.hpz.llmdockchat.core.markdown.parseMdBlock
+import com.hpz.llmdockchat.core.markdown.splitMdBlocks
+import com.hpz.llmdockchat.core.ui.theme.LlmColors
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.ArtifactRecord
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * The assistant answer's body (F05-R1/R2/R5/R7): split into blocks, each block
+ * memoized on its own raw text so a growing streamed answer only re-parses the
+ * one block still being written (Architecture P2 — see
+ * `core/markdown/MarkdownParser.kt` for the two-phase design).
+ *
+ * Wrapped in one [SelectionContainer] so selection spans every block, not just
+ * a single paragraph (F05-R3's second criterion).
+ */
+@Composable
+fun MarkdownBody(raw: String, modifier: Modifier = Modifier) {
+    val colors = LlmTheme.colors
+    val blocks = remember(raw) { splitMdBlocks(raw) }
+    SelectionContainer(modifier = modifier.testTag("markdown_body")) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            blocks.forEach { rawBlock ->
+                val block = remember(rawBlock, colors) { parseMdBlock(rawBlock, colors) }
+                MdBlockView(block, colors)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MdBlockView(block: MdBlock, colors: LlmColors) {
+    when (block) {
+        is MdBlock.Heading -> Text(
+            block.text,
+            color = colors.fg,
+            fontFamily = FontFamily.Serif,
+            style = headingStyle(block.level),
+        )
+        is MdBlock.Paragraph -> Text(
+            block.text,
+            color = colors.fg,
+            fontFamily = FontFamily.Serif,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        is MdBlock.CodeBlock -> CodeBlockView(block, colors)
+        is MdBlock.ListBlock -> ListBlockView(block, colors)
+        is MdBlock.Quote -> QuoteView(block, colors)
+        is MdBlock.Table -> TableView(block, colors)
+        MdBlock.Rule -> HorizontalRuleView(colors)
+        is MdBlock.MathBlock -> Text(
+            block.source,
+            color = colors.muted,
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(colors.sunken)
+                .padding(10.dp),
+        )
+    }
+}
+
+@Composable
+private fun headingStyle(level: Int) = when (level) {
+    1 -> MaterialTheme.typography.headlineSmall
+    2 -> MaterialTheme.typography.titleLarge
+    3 -> MaterialTheme.typography.titleMedium
+    else -> MaterialTheme.typography.titleSmall
+}
+
+/**
+ * F05-R2 — language label, copy button, and its own horizontal scroll so a
+ * long line never pushes the message column sideways.
+ */
+@Composable
+private fun CodeBlockView(block: MdBlock.CodeBlock, colors: LlmColors) {
+    val clipboard = LocalClipboardManager.current
+    var copied by remember { mutableStateOf(false) }
+    LaunchedEffect(copied) {
+        if (copied) {
+            kotlinx.coroutines.delay(1200)
+            copied = false
+        }
+    }
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(colors.sunken)
+            .testTag("code_block"),
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(colors.surfaceElevated)
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                block.language?.uppercase() ?: "CODE",
+                color = colors.subtle,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                if (copied) "Copied" else "Copy",
+                color = if (copied) colors.green else colors.accent,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier
+                    .clickable {
+                        // Exact code only — no fence markers, no reformatting
+                        // (F05-R2's second criterion).
+                        clipboard.setText(AnnotatedString(block.code))
+                        copied = true
+                    }
+                    .testTag("code_copy"),
+            )
+        }
+        Box(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(10.dp)) {
+            Text(
+                block.code,
+                color = colors.fg,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListBlockView(block: MdBlock.ListBlock, colors: LlmColors) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        block.items.forEach { item ->
+            Row(Modifier.padding(start = (item.depth * 16).dp)) {
+                val marker = if (item.ordered) "${item.index ?: 1}." else bulletFor(item.depth)
+                Text(
+                    marker,
+                    color = colors.subtle,
+                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.width(24.dp),
+                )
+                Text(
+                    item.text,
+                    color = colors.fg,
+                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+    }
+}
+
+private fun bulletFor(depth: Int): String = when (depth % 3) {
+    0 -> "•"
+    1 -> "◦"
+    else -> "▪"
+}
+
+@Composable
+private fun QuoteView(block: MdBlock.Quote, colors: LlmColors) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(colors.sunken)
+            .padding(start = 10.dp, top = 8.dp, bottom = 8.dp, end = 10.dp),
+    ) {
+        Box(Modifier.width(3.dp).background(colors.accent))
+        Column(Modifier.padding(start = 10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            block.lines.forEach { line ->
+                Text(line, color = colors.muted, fontFamily = FontFamily.Serif, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+/** F05-R5 — scrolls sideways in its own box; the message column does not. */
+@Composable
+private fun TableView(block: MdBlock.Table, colors: LlmColors) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(colors.sunken)
+            .horizontalScroll(rememberScrollState())
+            .testTag("md_table"),
+    ) {
+        Column {
+            Row(Modifier.background(colors.surfaceElevated)) {
+                block.header.forEachIndexed { i, cell ->
+                    TableCell(cell, colors, colors.fg, bold = true, align = block.alignments.getOrElse(i) { TableAlign.LEFT })
+                }
+            }
+            block.rows.forEach { row ->
+                Row {
+                    row.forEachIndexed { i, cell ->
+                        TableCell(cell, colors, colors.muted, bold = false, align = block.alignments.getOrElse(i) { TableAlign.LEFT })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableCell(text: AnnotatedString, colors: LlmColors, color: androidx.compose.ui.graphics.Color, bold: Boolean, align: TableAlign) {
+    Text(
+        text,
+        color = color,
+        fontFamily = FontFamily.Serif,
+        style = if (bold) MaterialTheme.typography.labelLarge else MaterialTheme.typography.bodyMedium,
+        textAlign = when (align) {
+            TableAlign.LEFT -> androidx.compose.ui.text.style.TextAlign.Start
+            TableAlign.CENTER -> androidx.compose.ui.text.style.TextAlign.Center
+            TableAlign.RIGHT -> androidx.compose.ui.text.style.TextAlign.End
+        },
+        modifier = Modifier.width(140.dp).padding(horizontal = 10.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun HorizontalRuleView(colors: LlmColors) {
+    Box(Modifier.fillMaxWidth().height(1.dp).background(colors.line))
+}
+
+// -- Artifacts (F05-R6/R8) ---------------------------------------------------
+
+/**
+ * `svg` and `image` render as pictures, `code` as a code block, `html` as a
+ * labelled placeholder (F05-R8, cut for v1 — no WebView sandbox for arbitrary
+ * scripted content on the phone). A failed decode falls back to a placeholder
+ * rather than a broken message (F05-R6's fifth criterion).
+ */
+@Composable
+fun ArtifactCard(artifact: ArtifactRecord, modifier: Modifier = Modifier) {
+    val colors = LlmTheme.colors
+    Column(
+        modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(colors.sunken)
+            .testTag("artifact_${artifact.type}"),
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(artifact.type.uppercase(), color = colors.subtle, style = MaterialTheme.typography.labelSmall)
+            Text(
+                artifact.title ?: "Artifact",
+                color = colors.muted,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        when (artifact.type) {
+            "svg" -> SvgArtifactBody(artifact, colors)
+            "image" -> ImageArtifactBody(artifact, colors)
+            "code" -> Box(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(10.dp)) {
+                Text(artifact.content, color = colors.fg, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
+            }
+            "html" -> HtmlArtifactPlaceholder(colors)
+            else -> HtmlArtifactPlaceholder(colors)
+        }
+    }
+}
+
+@Composable
+private fun HtmlArtifactPlaceholder(colors: LlmColors) {
+    Column(Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("This artifact can be opened on the desktop.", color = colors.muted, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun ImageArtifactBody(artifact: ArtifactRecord, colors: LlmColors) {
+    // Same encoding the composer uses for attachments (F04-R9): a
+    // `data:image/…;base64,…` URL.
+    val bitmap = remember(artifact.content) { decodeDataUrl(artifact.content) }
+    var fullScreen by remember { mutableStateOf(false) }
+    if (bitmap == null) {
+        Text(
+            "This image couldn't be decoded.",
+            color = colors.subtle,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(12.dp),
+        )
+        return
+    }
+    Image(
+        bitmap = bitmap.asImageBitmap(),
+        contentDescription = artifact.title,
+        contentScale = ContentScale.Fit,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .clickable { fullScreen = true }
+            .testTag("artifact_image"),
+    )
+    if (fullScreen) FullScreenBitmapViewer(bitmap) { fullScreen = false }
+}
+
+@Composable
+private fun SvgArtifactBody(artifact: ArtifactRecord, colors: LlmColors) {
+    if (artifact.content.isBlank()) {
+        Text(
+            "This diagram couldn't be rendered.",
+            color = colors.subtle,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(12.dp),
+        )
+        return
+    }
+    var fullScreen by remember { mutableStateOf(false) }
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .background(androidx.compose.ui.graphics.Color.White)
+            .testTag("artifact_svg"),
+    ) {
+        SvgWebView(artifact.content, zoomable = false, modifier = Modifier.fillMaxSize())
+        // A plain WebView consumes touch input for its own gesture detection
+        // even with JS off, so a `.clickable` on the Box behind it never fires
+        // (the WebView is a real Android View and claims the touch first).
+        // This transparent overlay sits in front of it in the Compose tree and
+        // catches the tap before it reaches the WebView.
+        Box(Modifier.matchParentSize().clickable { fullScreen = true })
+    }
+    if (fullScreen) {
+        Dialog(onDismissRequest = { fullScreen = false }, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+            Box(Modifier.fillMaxSize().background(androidx.compose.ui.graphics.Color.Black).clickable { fullScreen = false }) {
+                SvgWebView(artifact.content, zoomable = true, modifier = Modifier.fillMaxSize())
+            }
+        }
+    }
+}
+
+/**
+ * A static SVG has no interactivity to sandbox against, unlike F05-R8's
+ * arbitrary HTML — so unlike that placeholder, rendering it in a plain
+ * (JS-disabled) `WebView` is cheap and gives pinch-zoom for free via the
+ * platform's own zoom controls, with no new dependency.
+ */
+@Composable
+private fun SvgWebView(svg: String, zoomable: Boolean, modifier: Modifier = Modifier) {
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            WebView(ctx).apply {
+                setBackgroundColor(android.graphics.Color.WHITE)
+                settings.javaScriptEnabled = false
+                // The SVG source is untrusted model output — `javaScriptEnabled =
+                // false` stops script execution but not a network fetch from
+                // `<img src>` or a CSS `url()`, so a remote `xlink:href` would
+                // otherwise beacon out silently. Blocks both the thumbnail and
+                // full-screen instances, since they share this factory.
+                settings.blockNetworkLoads = true
+                settings.setSupportZoom(zoomable)
+                settings.builtInZoomControls = zoomable
+                settings.displayZoomControls = false
+            }
+        },
+        update = { webView ->
+            val html = "<html><body style=\"margin:0;display:flex;align-items:center;justify-content:center;\">$svg</body></html>"
+            webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+        },
+    )
+}
+
+/** F05-R6's fourth criterion — tap an image, get it full-screen with pinch-zoom. */
+@Composable
+fun FullScreenBitmapViewer(bitmap: Bitmap, onDismiss: () -> Unit) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(androidx.compose.ui.graphics.Color.Black)
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        scale = (scale * zoom).coerceIn(1f, 6f)
+                        offsetX += pan.x
+                        offsetY += pan.y
+                    }
+                }
+                .pointerInput(Unit) { detectTapGestures(onTap = { onDismiss() }) }
+                .testTag("fullscreen_image"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(scaleX = scale, scaleY = scale, translationX = offsetX, translationY = offsetY),
+            )
+        }
+    }
+}
+
+// -- Copy / share (F05-R3) ---------------------------------------------------
+
+/** Copies the message's raw Markdown source — not the rendered text (F05-R3's first criterion). */
+@Composable
+fun MessageActionsRow(content: String, modifier: Modifier = Modifier) {
+    val colors = LlmTheme.colors
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+    LaunchedEffect(copied) {
+        if (copied) {
+            kotlinx.coroutines.delay(1200)
+            copied = false
+        }
+    }
+    Row(modifier.testTag("message_actions"), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            if (copied) "Copied" else "Copy",
+            color = if (copied) colors.green else colors.subtle,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier
+                .clickable {
+                    clipboard.setText(AnnotatedString(content))
+                    copied = true
+                }
+                .testTag("message_copy"),
+        )
+        Text(
+            "Share",
+            color = colors.subtle,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier
+                .clickable {
+                    val send = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, content)
+                    }
+                    context.startActivity(Intent.createChooser(send, null))
+                }
+                .testTag("message_share"),
+        )
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.Image
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.MessageRole
 import com.hpz.llmdockchat.data.model.ParseWarning
@@ -38,7 +39,7 @@ import com.hpz.llmdockchat.data.model.ToolCallRecord
 /**
  * The mockup's split (screen 04): the user's own words in mono, the model's in
  * serif, so it is obvious who is talking without an avatar. Markdown rendering
- * is F05 — this shows the text as it came.
+ * is F05, via [MarkdownBody].
  */
 @Composable
 fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier) {
@@ -50,6 +51,7 @@ fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier) {
             toolCalls = message.toolCalls,
             parseWarning = message.parseWarning,
             error = message.error,
+            artifacts = message.artifacts,
             modifier = modifier,
         )
     }
@@ -58,6 +60,11 @@ fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier) {
 @Composable
 private fun UserBubble(message: ChatMessage, modifier: Modifier = Modifier) {
     val colors = LlmTheme.colors
+    // F05-R6's fourth criterion: a photo the user attached opens full-screen
+    // with pinch-zoom, same as an image artifact — decoded once here so the
+    // viewer (which wants a Bitmap) doesn't re-decode what the thumbnail
+    // already did.
+    var fullScreenDataUrl by remember { mutableStateOf<String?>(null) }
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -66,7 +73,9 @@ private fun UserBubble(message: ChatMessage, modifier: Modifier = Modifier) {
     ) {
         if (message.images.isNotEmpty()) {
             Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.padding(bottom = 6.dp)) {
-                message.images.forEach { ImageThumbnail(it, size = 84.dp) }
+                message.images.forEach { url ->
+                    ImageThumbnail(url, size = 84.dp, onTap = { fullScreenDataUrl = url })
+                }
             }
         }
         if (message.content.isNotBlank()) {
@@ -85,6 +94,13 @@ private fun UserBubble(message: ChatMessage, modifier: Modifier = Modifier) {
             }
         }
     }
+    // Reachable only via a tap forwarded from a thumbnail that already decoded
+    // this exact `dataUrl` successfully, so a second, memoized decode here is
+    // just re-reading the same deterministic result.
+    fullScreenDataUrl?.let { dataUrl ->
+        val bitmap = remember(dataUrl) { decodeDataUrl(dataUrl) }
+        if (bitmap != null) FullScreenBitmapViewer(bitmap) { fullScreenDataUrl = null }
+    }
 }
 
 /**
@@ -100,9 +116,9 @@ fun AssistantBubble(
     parseWarning: ParseWarning?,
     error: String?,
     modifier: Modifier = Modifier,
+    artifacts: List<ArtifactRecord> = emptyList(),
     trailing: @Composable (() -> Unit)? = null,
 ) {
-    val colors = LlmTheme.colors
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -113,15 +129,11 @@ fun AssistantBubble(
         toolCalls.forEach { ToolCallCard(it) }
         parseWarning?.let { ParseWarningChip(it) }
         if (content.isNotBlank()) {
-            Text(
-                content,
-                color = colors.fg,
-                fontFamily = FontFamily.Serif,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.testTag("assistant_text"),
-            )
+            MarkdownBody(content, modifier = Modifier.testTag("assistant_text"))
         }
+        artifacts.forEach { ArtifactCard(it) }
         error?.let { ErrorNote(it) }
+        if (content.isNotBlank()) MessageActionsRow(content)
         trailing?.invoke()
     }
 }
@@ -270,9 +282,20 @@ fun ErrorNote(message: String) {
  * Decodes a `data:image/…;base64,…` URL — the same encoding the web composer
  * sends. Done here rather than with an image loader because the bytes are
  * already in the payload; there is nothing to fetch.
+ *
+ * [onTap] is separate from [onRemove] on purpose: the composer's draft strip
+ * passes only [onRemove], a sent message's thumbnail passes only [onTap]
+ * (F05-R6's fourth criterion), and the two can coexist — the remove button is
+ * a small circle drawn *after* the image, so it wins hit-testing in its own
+ * corner and the image's tap handler only ever sees the rest of the thumbnail.
  */
 @Composable
-fun ImageThumbnail(dataUrl: String, size: androidx.compose.ui.unit.Dp, onRemove: (() -> Unit)? = null) {
+fun ImageThumbnail(
+    dataUrl: String,
+    size: androidx.compose.ui.unit.Dp,
+    onRemove: (() -> Unit)? = null,
+    onTap: (() -> Unit)? = null,
+) {
     val colors = LlmTheme.colors
     val bitmap = remember(dataUrl) { decodeDataUrl(dataUrl) }
     Box(Modifier.size(size)) {
@@ -281,7 +304,11 @@ fun ImageThumbnail(dataUrl: String, size: androidx.compose.ui.unit.Dp, onRemove:
                 bitmap = bitmap.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
-                modifier = Modifier.size(size).clip(RoundedCornerShape(10.dp)),
+                modifier = Modifier
+                    .size(size)
+                    .clip(RoundedCornerShape(10.dp))
+                    .let { m -> if (onTap != null) m.clickable(onClick = onTap) else m }
+                    .testTag("image_thumbnail"),
             )
         } else {
             Box(

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
@@ -300,6 +300,7 @@ private fun StreamingBubble(turn: StreamingTurn) {
         // Set only when the turn is being held over because that refetch
         // failed, so a failure is never shown without its cause.
         error = turn.error,
+        artifacts = turn.artifacts,
         modifier = Modifier.testTag("streaming_turn"),
         trailing = {
             turn.toolCalls.forEach { ToolCallCard(it) }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
@@ -1,5 +1,6 @@
 package com.hpz.llmdockchat.feature.thread
 
+import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import com.hpz.llmdockchat.data.model.ParseWarning
@@ -34,6 +35,8 @@ data class StreamingTurn(
     val reasoning: String = "",
     val toolCalls: List<StreamingToolCall> = emptyList(),
     val parseWarning: ParseWarning? = null,
+    /** Frames arrive as they're produced; the panel appears as soon as one has (F05-R6/R8). */
+    val artifacts: List<ArtifactRecord> = emptyList(),
     /** Stop has been requested; the server cancels cooperatively, so this lingers a moment. */
     val stopping: Boolean = false,
     /**

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
@@ -7,6 +7,7 @@ import com.hpz.llmdockchat.core.net.RunEvent
 import com.hpz.llmdockchat.core.net.appError
 import com.hpz.llmdockchat.core.prefs.DraftStore
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import com.hpz.llmdockchat.data.model.ParseWarning
 import kotlinx.coroutines.CancellationException
@@ -379,6 +380,7 @@ private class TurnAccumulator(private val userMessage: PendingUserMessage?) {
     private val content = StringBuilder()
     private val reasoning = StringBuilder()
     private val toolCalls = mutableListOf<StreamingToolCall>()
+    private val artifacts = mutableListOf<ArtifactRecord>()
     private var runId: String? = null
     private var parseWarning: ParseWarning? = null
     private var dirty = false
@@ -415,6 +417,8 @@ private class TurnAccumulator(private val userMessage: PendingUserMessage?) {
             is RunEvent.ToolResult -> completeCall(event)
             is RunEvent.ParseWarning ->
                 parseWarning = ParseWarning(event.kind, event.description, event.snippet)
+            is RunEvent.Artifact ->
+                artifacts += ArtifactRecord(event.artifactType, event.title, event.content, language = null)
             else -> Unit
         }
     }
@@ -443,6 +447,7 @@ private class TurnAccumulator(private val userMessage: PendingUserMessage?) {
         reasoning = reasoning.toString(),
         toolCalls = toolCalls.toList(),
         parseWarning = parseWarning,
+        artifacts = artifacts.toList(),
         stopping = stopping,
     )
 

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/markdown/MarkdownParserTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/markdown/MarkdownParserTest.kt
@@ -1,0 +1,276 @@
+package com.hpz.llmdockchat.core.markdown
+
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.hpz.llmdockchat.core.ui.theme.DarkLlmColors
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * F05-R1/R2/R5/R7's hand-rolled block parser (`MarkdownParser.kt`). Every
+ * construct, its unterminated form, LaTeX passthrough and non-Markdown text
+ * are exercised here — logic criteria backed by a JVM test, per
+ * `WORK_INSTRUCTIONS.md` §7.
+ */
+class MarkdownParserTest {
+
+    private val colors = DarkLlmColors
+    private fun block(raw: String) = parseMdBlock(raw, colors)
+    private fun blocksOf(text: String) = splitMdBlocks(text).map { block(it) }
+
+    // -- headings ------------------------------------------------------------
+
+    @Test
+    fun `ATX headings of every level parse with their text`() {
+        assertEquals(1, (block("# Title") as MdBlock.Heading).level)
+        assertEquals("Title", (block("# Title") as MdBlock.Heading).text.text)
+        assertEquals(3, (block("### Sub") as MdBlock.Heading).level)
+    }
+
+    // -- emphasis --------------------------------------------------------------
+
+    @Test
+    fun `bold and italic apply the expected span styles`() {
+        val bold = parseInline("this is **bold** text", colors)
+        assertEquals("this is bold text", bold.text)
+        assertTrue(bold.spanStyles.any { it.item.fontWeight == FontWeight.Bold && bold.text.substring(it.start, it.end) == "bold" })
+
+        val italic = parseInline("this is *italic* text", colors)
+        assertEquals("this is italic text", italic.text)
+        assertTrue(italic.spanStyles.any { it.item.fontStyle == FontStyle.Italic && italic.text.substring(it.start, it.end) == "italic" })
+    }
+
+    @Test
+    fun `underscore emphasis works the same as asterisks`() {
+        val bold = parseInline("__bold__ and _italic_", colors)
+        assertEquals("bold and italic", bold.text)
+        assertTrue(bold.spanStyles.any { it.item.fontWeight == FontWeight.Bold })
+        assertTrue(bold.spanStyles.any { it.item.fontStyle == FontStyle.Italic })
+    }
+
+    @Test
+    fun `an unterminated bold marker falls back to literal asterisks, nothing lost`() {
+        val text = parseInline("Value is **bold text without close", colors)
+        assertEquals("Value is **bold text without close", text.text)
+        assertTrue(text.spanStyles.none { it.item.fontWeight == FontWeight.Bold })
+    }
+
+    @Test
+    fun `an unterminated inline code backtick falls back to literal text`() {
+        val text = parseInline("here is `code without close", colors)
+        assertEquals("here is `code without close", text.text)
+    }
+
+    // -- inline code -----------------------------------------------------------
+
+    @Test
+    fun `inline code is preserved verbatim including special characters`() {
+        val text = parseInline("run `git diff --stat` now", colors)
+        assertEquals("run git diff --stat now", text.text)
+    }
+
+    // -- links -------------------------------------------------------------
+
+    @Test
+    fun `a markdown link renders its text and carries the url`() {
+        val text = parseInline("see [the docs](https://example.com/path) for more", colors)
+        assertEquals("see the docs for more", text.text)
+        val annotations = text.getLinkAnnotations(0, text.length)
+        assertEquals(1, annotations.size)
+    }
+
+    @Test
+    fun `an unclosed link bracket falls back to literal text, nothing lost`() {
+        val text = parseInline("this [is not a link at all", colors)
+        assertEquals("this [is not a link at all", text.text)
+    }
+
+    // -- lists ---------------------------------------------------------------
+
+    @Test
+    fun `unordered and ordered list items parse with their depth`() {
+        val list = block("- one\n- two\n  - nested") as MdBlock.ListBlock
+        assertEquals(3, list.items.size)
+        assertEquals("one", list.items[0].text.text)
+        assertFalse(list.items[0].ordered)
+        assertEquals(1, list.items[2].depth)
+
+        val ordered = block("1. first\n2. second") as MdBlock.ListBlock
+        assertTrue(ordered.items[0].ordered)
+        assertEquals(1, ordered.items[0].index)
+        assertEquals(2, ordered.items[1].index)
+    }
+
+    @Test
+    fun `nested lists at multiple depths keep their own indentation`() {
+        val list = block("- top\n  - mid\n    - deep") as MdBlock.ListBlock
+        assertEquals(listOf(0, 1, 2), list.items.map { it.depth })
+    }
+
+    // -- blockquote ------------------------------------------------------------
+
+    @Test
+    fun `a blockquote strips the marker but keeps the text`() {
+        val quote = block("> line one\n> line two") as MdBlock.Quote
+        assertEquals(listOf("line one", "line two"), quote.lines.map { it.text })
+    }
+
+    // -- horizontal rule ---------------------------------------------------
+
+    @Test
+    fun `three or more dashes alone is a rule`() {
+        assertTrue(block("---") is MdBlock.Rule)
+        assertTrue(block("***") is MdBlock.Rule)
+    }
+
+    // -- fenced code -----------------------------------------------------------
+
+    @Test
+    fun `a closed fenced code block carries its language and exact body`() {
+        val code = block("```python\nprint(1)\nprint(2)\n```") as MdBlock.CodeBlock
+        assertEquals("python", code.language)
+        assertEquals("print(1)\nprint(2)", code.code)
+        assertTrue(code.closed)
+    }
+
+    @Test
+    fun `an open fence with no closing marker still renders as a code block, not raw text`() {
+        // The mid-stream case (F05-R1's second criterion): the fence opened but
+        // has not closed yet. It must already be a CodeBlock, not a Paragraph
+        // that later flips — that flip is exactly the flicker the spec forbids.
+        val code = block("```python\nprint(1)\nstill typ") as MdBlock.CodeBlock
+        assertEquals("python", code.language)
+        assertEquals("print(1)\nstill typ", code.code)
+        assertFalse(code.closed)
+    }
+
+    @Test
+    fun `code block content is exact, no reformatting or stripped indentation`() {
+        val code = block("```\n    indented line\n\ttabbed\n```") as MdBlock.CodeBlock
+        assertEquals("    indented line\n\ttabbed", code.code)
+    }
+
+    // -- tables (F05-R5) -----------------------------------------------------
+
+    @Test
+    fun `a well-formed table parses its header, alignment and rows`() {
+        val table = block("| A | B |\n|---|:-:|\n| 1 | 2 |") as MdBlock.Table
+        assertEquals(listOf("A", "B"), table.header.map { it.text })
+        assertEquals(listOf(TableAlign.LEFT, TableAlign.CENTER), table.alignments)
+        assertEquals(listOf(listOf("1", "2")), table.rows.map { row -> row.map { it.text } })
+    }
+
+    @Test
+    fun `a ragged row is padded rather than crashing the block`() {
+        val table = block("| A | B | C |\n|---|---|---|\n| 1 |") as MdBlock.Table
+        assertEquals(listOf("1", "", ""), table.rows[0].map { it.text })
+    }
+
+    @Test
+    fun `a bare pipe mid-sentence does not fracture the paragraph around it`() {
+        // Review fix S3: conditional-probability notation is exactly the kind
+        // of thing this rig's models write, and a single `|` is not a table.
+        val text = "The result is P(A|B) using Bayes' theorem, which is useful."
+        val blocks = blocksOf(text)
+        assertEquals(1, blocks.size)
+        assertEquals(text, (blocks[0] as MdBlock.Paragraph).text.text)
+    }
+
+    @Test
+    fun `a real table still forms even with edge pipes and multiple columns`() {
+        // The stricter check must not regress genuine tables: an edge `|` or
+        // 2+ columns is still enough signal on its own.
+        assertTrue(block("| A | B |\n|---|---|") is MdBlock.Table)
+        assertTrue(block("A|B|C\n-|-|-") is MdBlock.Table)
+    }
+
+    @Test
+    fun `a header row with no delimiter yet is plain text, not a broken table`() {
+        // Before the second (delimiter) line has arrived, this must not be
+        // rendered as a table — and once it never arrives, it is ordinary text.
+        val result = block("| A | B |")
+        assertTrue(result is MdBlock.Paragraph || result is MdBlock.CodeBlock)
+    }
+
+    // -- maths passthrough (F05-R7) --------------------------------------------
+
+    @Test
+    fun `inline math with underscores, asterisks and backslashes survives intact`() {
+        val source = "the loss is \$\\frac{\\partial L}{\\partial \\theta} = \\sum_i x_i^2 * \\alpha_i\$ here"
+        val text = parseInline(source, colors)
+        assertTrue(text.text.contains("\\frac{\\partial L}{\\partial \\theta} = \\sum_i x_i^2 * \\alpha_i"))
+        // Nothing was consumed as bold/italic despite the `*` inside the span.
+        assertTrue(text.spanStyles.none { it.item.fontWeight == FontWeight.Bold || it.item.fontStyle == FontStyle.Italic })
+    }
+
+    @Test
+    fun `a block dollar-dollar formula round-trips as literal source`() {
+        val source = "$$\\sum_{i=0}^n x_i * \\alpha_i \\\\ \\text{next line}$$"
+        val result = block(source) as MdBlock.MathBlock
+        assertEquals(source, result.source)
+    }
+
+    @Test
+    fun `an unterminated inline math span is not silently stripped`() {
+        val text = parseInline("partial formula \$x_i^2 with no close", colors)
+        assertTrue(text.text.contains("x_i^2 with no close"))
+    }
+
+    @Test
+    fun `plain currency text with two dollar signs is not lost even if mis-tagged as math`() {
+        val text = parseInline("costs \$5 and \$10 today", colors)
+        assertEquals("costs \$5 and \$10 today", text.text)
+    }
+
+    // -- non-markdown / prefix stability --------------------------------------
+
+    @Test
+    fun `CRLF line endings do not break list detection`() {
+        // Review fix S4: `split("\n")` leaves a trailing `\r` that fails
+        // `matches()` on the list regexes, collapsing every item into one
+        // paragraph. A backend on this rig is unlikely to emit CRLF, but it
+        // costs one line to normalise. Goes through `splitMdBlocks` (not
+        // `parseMdBlock` directly) since that is where the normalisation
+        // lives, matching how `MarkdownBody` actually calls this pipeline.
+        val list = blocksOf("- item one\r\n- item two\r").single() as MdBlock.ListBlock
+        assertEquals(listOf("item one", "item two"), list.items.map { it.text.text })
+    }
+
+    @Test
+    fun `a CRLF blockquote carries no stray carriage return in its text`() {
+        val quote = blocksOf("> line one\r\n> line two\r").single() as MdBlock.Quote
+        assertEquals(listOf("line one", "line two"), quote.lines.map { it.text })
+    }
+
+    @Test
+    fun `plain text with no markdown constructs renders unchanged, nothing lost`() {
+        val plain = "Just a normal sentence with no special characters at all."
+        val blocks = blocksOf(plain)
+        assertEquals(1, blocks.size)
+        assertEquals(plain, (blocks[0] as MdBlock.Paragraph).text.text)
+    }
+
+    @Test
+    fun `splitting is prefix-stable — earlier blocks are byte-identical as the text grows`() {
+        val before = "First paragraph.\n\nSecond paragraph starts here"
+        val after = before + " and keeps going with more words."
+        val blocksBefore = splitMdBlocks(before)
+        val blocksAfter = splitMdBlocks(after)
+        assertEquals(2, blocksBefore.size)
+        assertEquals(2, blocksAfter.size)
+        // The closed first block is untouched by what streams in after it.
+        assertEquals(blocksBefore[0], blocksAfter[0])
+    }
+
+    @Test
+    fun `a table forming across deltas reclassifies once, not on every delta`() {
+        val headerOnly = splitMdBlocks("| A | B |")
+        val withDelimiter = splitMdBlocks("| A | B |\n|---|---|")
+        val withRow = splitMdBlocks("| A | B |\n|---|---|\n| 1 | 2 |")
+        assertTrue(block(headerOnly.last()) !is MdBlock.Table)
+        assertTrue(block(withDelimiter.last()) is MdBlock.Table)
+        assertTrue(block(withRow.last()) is MdBlock.Table)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapperTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapperTest.kt
@@ -1,0 +1,56 @@
+package com.hpz.llmdockchat.data.mapper
+
+import com.hpz.llmdockchat.data.dto.ArtifactDto
+import com.hpz.llmdockchat.data.dto.ChatMessageDto
+import com.hpz.llmdockchat.data.dto.ConversationDetailDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `GET /api/chat/conversations/<id>` carries artifacts as a sibling of
+ * `messages` — `{message_id: [Artifact, …]}` — not nested on the message
+ * (`chat/routes.py`, `chat/db.py:get_artifacts_for_conversation`). F05-R6/R8
+ * render these, so the mapper folding them onto the right message by id is
+ * what makes that possible.
+ */
+class ChatThreadMapperTest {
+
+    private fun message(id: String, seq: Int) =
+        ChatMessageDto(id = id, role = "assistant", content = "answer $seq", seq = seq)
+
+    @Test
+    fun `an artifact is folded onto the message it belongs to, by id`() {
+        val dto = ConversationDetailDto(
+            id = "c1",
+            title = "t",
+            mainService = "llamacpp-laguna-s-2.1-q4",
+            messages = listOf(message("m1", 1), message("m2", 2)),
+            artifacts = mapOf(
+                "m2" to listOf(ArtifactDto(id = "a1", type = "svg", content = "<svg/>", title = "Circuit")),
+            ),
+        )
+
+        val domain = dto.toDomain()
+
+        assertTrue(domain.messages.first { it.id == "m1" }.artifacts.isEmpty())
+        val artifact = domain.messages.first { it.id == "m2" }.artifacts.single()
+        assertEquals("svg", artifact.type)
+        assertEquals("Circuit", artifact.title)
+        assertEquals("<svg/>", artifact.content)
+    }
+
+    @Test
+    fun `a message with no entry in the artifacts map gets an empty list, not a crash`() {
+        val dto = ConversationDetailDto(
+            id = "c1",
+            title = "t",
+            mainService = "llamacpp-laguna-s-2.1-q4",
+            messages = listOf(message("m1", 1)),
+        )
+
+        val domain = dto.toDomain()
+
+        assertEquals(emptyList<Any>(), domain.messages.single().artifacts)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
@@ -312,6 +312,30 @@ class ThreadViewModelTest {
         assertEquals("Parser dropped a malformed tool call", warning.displayText)
     }
 
+    // -- F05-R6/R8 · artifact frames land on the streaming turn --------------
+
+    @Test
+    fun `an artifact frame is carried on the streaming turn as it arrives`() = threadTest {
+        conversation()
+        transport.payloads = listOf(
+            RUN_STARTED,
+            """{"type": "artifact", "artifact_type": "svg", "title": "Circuit Diagram", "content": "<svg></svg>"}""",
+        )
+        transport.stayOpen = true
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("draw it")
+        viewModel.send()
+
+        val artifacts = viewModel.awaitState { it.thread.streaming?.artifacts?.isNotEmpty() == true }
+            .thread.streaming!!.artifacts
+        assertEquals(1, artifacts.size)
+        assertEquals("svg", artifacts.single().type)
+        assertEquals("Circuit Diagram", artifacts.single().title)
+        assertEquals("<svg></svg>", artifacts.single().content)
+    }
+
     // -- F04-R7 · completion and title ---------------------------------------
 
     @Test


### PR DESCRIPTION
Markdown, code blocks, tables, artifacts, copy/share. Implemented by one agent, independently reviewed and driven on device by a second, then a fix-up round.

## The renderer decision

**Hand-rolled block parser, no new dependency.** The Compose Markdown libraries are View-based Markwon wrappers that fight Compose's selection and theming model; the required construct set is fixed and modest; syntax highlighting is explicitly out of scope; and streaming needed exact control over how an unterminated construct renders, which a general GFM library does not expose.

## Streaming (Architecture P2)

Prefix-stable block splitting plus per-block `remember(rawBlock, colors)`. The reviewer verified the prefix-stability claim rather than accepting it — probing every prefix length of a growing table char-by-char and confirming **exactly one** type transition as the delimiter row completes, not one per delta. Closed blocks are byte-identical before and after more text arrives, so Compose's own memoisation does the caching.

## What the review found

- **SVG artifacts could not be tapped at all.** A `WebView` is a real Android View and claims the touch before the ancestor Compose `.clickable` ever sees it, so tap-to-fullscreen silently did nothing despite the code reading correctly. Fixed with a transparent overlay drawn after the WebView — a pattern worth remembering wherever a View sits inside a clickable Compose parent.
- **A user's own attached photo had no tap handler**, so it could never be opened full-screen — the most likely image in a phone thread.
- **The SVG WebView did not block network loads.** `javaScriptEnabled = false` was set, but that does not stop `<img src>` or CSS `url()` fetches, and model-generated SVG is untrusted; a remote `xlink:href` would have beaconed out invisibly.
- **A bare `|` in prose fractured a paragraph** — `P(A|B) using Bayes' theorem` split in two. Realistic for this rig's output.
- **CRLF input destroyed list structure**, because the list regexes use `matches()` and a trailing `\r` fails.

## An F04 gap this surfaced

Artifact frames were being parsed correctly and then **silently dropped** by F04's accumulator, so no tool-produced diagram could ever have appeared. Neither the F04 implementer nor its reviewer caught it, because no test conversation had an MCP tool enabled — it only became visible once something had to render artifacts. The server returns artifacts as a sibling map keyed by message id, not nested in the message.

## Verified on device, both themes

Every R1 construct in a live stream; code blocks with language label and exact-code copy; both copy behaviours through a clipboard round-trip; text selection inside rendered prose; tables scrolling in their own box; a real schemdraw **SVG artifact rendering as a picture** with tap-to-fullscreen and pinch-zoom; an `html` artifact as the R8 labelled placeholder; and LaTeX round-tripping with underscores, backslashes and braces intact.

Carried forward: R4's Settings toggle → F13. Artifact decode-failure fallbacks are code-level only — neither a malformed `image` nor a malformed `svg` could be provoked from the live tools.

301 tests, all green.