### PR TITLE
Android: real-device layout, scrolling and capture fixes

### DIFF
--- a/android/WORK_INSTRUCTIONS.md
+++ b/android/WORK_INSTRUCTIONS.md
@@ -108,6 +108,19 @@ State these in the brief; do not assume they are inferred:
   explicitly assign it to you, do not install to it, do not clear its app
   data (that destroys their stored credential and signs them out), and do
   not touch their real conversations.
+- **One agent per device, and the owner outranks every agent.** A device
+  is assigned to exactly one agent at a time; the orchestrator hands it
+  over explicitly and never to two at once. The moment the owner starts
+  using a device themselves, every agent is off it — a `uiautomator dump`
+  or a stray `input tap` while a human is mid-gesture wastes their time
+  and corrupts both sets of observations. When a device is withdrawn
+  mid-run, do not wait for it: write the device-dependent checks down as
+  line items for the owner and carry on with everything else.
+- **Prefer the owner for anything about feel.** Scroll behaviour, gesture
+  conflicts, keyboard handling and animation are judged far better by a
+  thumb than by injected single-pointer events. Hand those over as a
+  short list in plain language rather than burning device time on
+  synthetic approximations of them.
 - **Never** call the dashboard's configuration endpoints — see F00-R10.
 - **Never** edit a requirements file except to add to its *Deviations*
   section, and only with a reason.

--- a/android/docs/F04-chat-turn-and-streaming.md
+++ b/android/docs/F04-chat-turn-and-streaming.md
@@ -270,3 +270,23 @@ persists the reply. Reattachment is F09.
   re-sending — that is F06).
 - Streaming to more than one thread at a time in the UI. Multiple runs can
   exist server-side; the app renders the one that is open.
+
+## Known gap — attachments are not persisted (F04-R9)
+
+Composer **text** is persisted to DataStore via `DraftStore`, so it
+survives process death and the 401 round-trip F00-R3 describes.
+**Attachments are not** — they live only in `ThreadViewModel._state`
+(`addAttachment`). Anything that destroys the ViewModel, most commonly
+process death while the system photo picker is in the foreground, brings
+the text back and drops the images with no indication. Observed once on a
+real device: a one-character draft returned and its image did not, and
+the turn was sent without it.
+
+Not fixed in the real-device fix pass, deliberately. Once the ViewModel
+is gone nothing knows an attachment existed, so it cannot even be
+reported — the fix is to persist attachments, and at ~140 KB per base64
+data URL that is wrong for DataStore (which rewrites the whole file) and
+risks `TransactionTooLarge` in `SavedStateHandle`. The right shape is
+files in `cacheDir` keyed by conversation, with the draft record pointing
+at them. That is a small feature, not a fix — schedule it rather than
+bolting it on.

--- a/android/src/app/src/main/AndroidManifest.xml
+++ b/android/src/app/src/main/AndroidManifest.xml
@@ -20,13 +20,27 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.LLMDockChat">
+            android:theme="@style/Theme.LLMDockChat"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Grants the camera app write access to one cache file per capture,
+             so a photo arrives at full resolution instead of as MediaStore's
+             thumbnail extra. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/MainActivity.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/MainActivity.kt
@@ -4,9 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -36,15 +36,21 @@ class MainActivity : ComponentActivity() {
         val container = (application as LlmDockApplication).container
         setContent {
             LLMDockChatTheme {
-                Scaffold(
+                // Deliberately edge-to-edge and inset-free: window insets are
+                // owned by each screen's own Scaffold, which is the only layer
+                // that can put a bar's *background* behind the system bar while
+                // padding that bar's *content* clear of it. Consuming them here
+                // as well is what produced the grey bands under every screen
+                // (fix pass A2), so this layer contributes nothing but a colour.
+                Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .background(LlmTheme.colors.app)
                         // Surfaces Compose test tags as resource ids, so a
                         // `uiautomator` dump can name what it is tapping.
                         .semantics { testTagsAsResourceId = true },
-                    containerColor = LlmTheme.colors.app,
-                ) { innerPadding ->
-                    AppRoot(container, Modifier.padding(innerPadding))
+                ) {
+                    AppRoot(container)
                 }
             }
         }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MarkdownParser.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/markdown/MarkdownParser.kt
@@ -335,6 +335,35 @@ fun parseInline(raw: String, colors: LlmColors): AnnotatedString = buildAnnotate
                     i = end + 1
                 }
             }
+            // Must be tested before the `[` case, or the `!` falls through to
+            // the default branch as a literal and the rest is picked up as an
+            // ordinary link — which is exactly what shipped: `!` followed by
+            // blue underlined alt text pointing at a URL the phone cannot
+            // fetch. Every schemdraw turn hit it, because the tool emits a
+            // Markdown image next to the artifact that already draws it.
+            c == '!' && i + 1 < n && raw[i + 1] == '[' -> {
+                val image = matchImage(raw, i)
+                if (image == null) {
+                    append(c); i++
+                } else {
+                    // Inline images are not rendered on the phone (F05-R6
+                    // covers artifacts, not arbitrary remote images), so this
+                    // is a caption, not a control: no link, nothing to tap,
+                    // and no pretence that the picture is one tap away. With
+                    // no alt text there is nothing to caption, so the literal
+                    // source stands in — this parser never silently strips.
+                    withStyle(imageRefStyle(colors)) {
+                        append(
+                            if (image.text.isBlank()) {
+                                raw.substring(i, image.end)
+                            } else {
+                                "Image: ${image.text}"
+                            },
+                        )
+                    }
+                    i = image.end
+                }
+            }
             c == '[' -> {
                 val link = matchLink(raw, i)
                 if (link == null) {
@@ -359,6 +388,12 @@ fun parseInline(raw: String, colors: LlmColors): AnnotatedString = buildAnnotate
 private val ESCAPABLE = "\\`*_{}[]()#+-.!$>~".toSet()
 
 private data class LinkMatch(val text: String, val url: String, val end: Int)
+
+/**
+ * `![alt](url)` — the same shape as a link, one character further along.
+ * [LinkMatch.end] is still an index into `raw`, so it spans the leading `!`.
+ */
+private fun matchImage(raw: String, start: Int): LinkMatch? = matchLink(raw, start + 1)
 
 /** `[text](url)`. Anything short of the full shape falls through as literal `[`. */
 private fun matchLink(raw: String, start: Int): LinkMatch? {
@@ -401,4 +436,10 @@ private fun codeSpanStyle(colors: LlmColors) = SpanStyle(
 private fun mathSpanStyle(colors: LlmColors) = SpanStyle(
     fontFamily = FontFamily.Monospace,
     color = colors.muted,
+)
+
+/** Reads as a figure caption — deliberately not the accent colour a link uses. */
+private fun imageRefStyle(colors: LlmColors) = SpanStyle(
+    color = colors.subtle,
+    fontStyle = FontStyle.Italic,
 )

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/connect/ConnectScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -100,8 +100,16 @@ private fun ConnectContent(
         modifier = modifier
             .fillMaxSize()
             .background(colors.app)
+            // Connect has no Scaffold, so it owns its own insets (fix pass
+            // A2 — nothing above it supplies any). `safeDrawing` is the union
+            // of the system bars, the cutout and the IME, and it sits
+            // *outside* the scroll so the keyboard shrinks the viewport and
+            // the form scrolls inside it. Inside the scroll — where
+            // `imePadding()` used to be — it only lengthened the content,
+            // which on a window the OEM also resizes for the IME meant the
+            // keyboard was paid for twice (fix pass B1).
+            .safeDrawingPadding()
             .verticalScroll(rememberScrollState())
-            .imePadding()
             .padding(horizontal = 22.dp, vertical = 28.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/conversations/ConversationListScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/conversations/ConversationListScreen.kt
@@ -131,6 +131,8 @@ private fun ConversationListContent(
         loaded?.actionError?.let { snackbarHost.showSnackbar(it) }
     }
 
+    FollowNewConversations(loaded?.conversations, listState)
+
     Scaffold(
         modifier = modifier.testTag("conversation_list_screen"),
         containerColor = colors.app,
@@ -181,6 +183,11 @@ private fun ConversationListContent(
                             LazyColumn(
                                 state = listState,
                                 modifier = Modifier.fillMaxSize().testTag("conversation_list"),
+                                // Fix pass A5: the FAB floats over the list, so
+                                // without this the last conversation's title
+                                // sits under it and its timestamp is
+                                // unreachable — there is no further scroll.
+                                contentPadding = PaddingValues(bottom = FAB_CLEARANCE),
                             ) {
                                 items(state.conversations, key = { it.id }) { item ->
                                     ConversationRow(
@@ -230,6 +237,38 @@ private fun ConversationListContent(
             },
             onDismiss = { pendingBatchDelete = false },
         )
+    }
+}
+
+/**
+ * Fix pass A3 — "the conversation I just started is not in the list".
+ *
+ * The refresh on return does happen; what goes wrong is where the new row
+ * lands. `LazyColumn` anchors its viewport on the first visible item's *key*,
+ * so when a refresh prepends a conversation the anchor stays put and the new
+ * row is laid out above the fold, with nothing on screen changing. The reader
+ * concludes the thread was lost.
+ *
+ * So: when the head of the list changes, work out how many rows were prepended
+ * and, if the viewport was sitting inside that region — i.e. at or near the top
+ * — put it back at the top. Someone who has scrolled down to read older threads
+ * keeps their place.
+ */
+@Composable
+private fun FollowNewConversations(conversations: List<ConversationSummary>?, listState: LazyListState) {
+    val head = conversations?.firstOrNull()?.id
+    var previousHead by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(head) {
+        val previous = previousHead
+        previousHead = head
+        if (previous == null || head == null || head == previous || conversations == null) {
+            return@LaunchedEffect
+        }
+        val prepended = conversations.indexOfFirst { it.id == previous }
+        if (prepended > 0 && listState.firstVisibleItemIndex <= prepended) {
+            listState.scrollToItem(0)
+        }
     }
 }
 
@@ -341,7 +380,10 @@ private fun ConversationRowBody(
                 overflow = TextOverflow.Ellipsis,
             )
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                EngineChip(item.modelRef, item.engine)
+                // C2: the model name is the part that gives way when the row
+                // is narrow. Un-weighted, the chip took the whole width and
+                // the live badge next to it ellipsised to "● genera…".
+                EngineChip(item.modelRef, item.engine, Modifier.weight(1f, fill = false))
                 if (item.isGenerating) GeneratingIndicator(item.activeRun)
             }
         }
@@ -351,10 +393,10 @@ private fun ConversationRowBody(
 }
 
 @Composable
-private fun EngineChip(modelRef: ModelRef, engine: Engine) {
+private fun EngineChip(modelRef: ModelRef, engine: Engine, modifier: Modifier = Modifier) {
     val chip = LlmTheme.colors.chipColors(engine)
     Box(
-        modifier = Modifier
+        modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .background(chip.background)
             .padding(horizontal = 8.dp, vertical = 3.dp)
@@ -370,6 +412,9 @@ private fun EngineChip(modelRef: ModelRef, engine: Engine) {
         )
     }
 }
+
+/** Extended FAB (56 dp) plus the Scaffold's own 16 dp margin. */
+private val FAB_CLEARANCE = 80.dp
 
 private fun LlmColors.chipColors(engine: Engine): ChipColors = when (engine) {
     Engine.LLAMA_CPP -> engineLlamaCpp

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -373,7 +374,9 @@ private fun ModelPickerSheet(
         containerColor = colors.surface,
         modifier = Modifier.testTag("model_picker_sheet"),
     ) {
-        LazyColumn(Modifier.fillMaxWidth()) {
+        // C3: the sheet draws behind the navigation bar, so without
+        // this its last row is unreachable under the 44 dp button bar.
+        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
             item { PickerSectionHeader("Local services") }
             if (localServices.isEmpty()) {
                 item {
@@ -425,7 +428,9 @@ private fun PromptPickerSheet(
         containerColor = colors.surface,
         modifier = Modifier.testTag("prompt_picker_sheet"),
     ) {
-        LazyColumn(Modifier.fillMaxWidth()) {
+        // C3: the sheet draws behind the navigation bar, so without
+        // this its last row is unreachable under the 44 dp button bar.
+        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
             item {
                 PickerRow(
                     title = "Server default",
@@ -465,7 +470,9 @@ private fun ToolsPickerSheet(
         containerColor = colors.surface,
         modifier = Modifier.testTag("tools_picker_sheet"),
     ) {
-        LazyColumn(Modifier.fillMaxWidth()) {
+        // C3: the sheet draws behind the navigation bar, so without
+        // this its last row is unreachable under the 44 dp button bar.
+        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
             items(servers, key = { it.id }) { server ->
                 Row(
                     modifier = Modifier

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ImageAttachments.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ImageAttachments.kt
@@ -1,11 +1,14 @@
 package com.hpz.llmdockchat.feature.thread
 
 import android.content.ContentResolver
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
+import androidx.core.content.FileProvider
 import java.io.ByteArrayOutputStream
+import java.io.File
 
 /**
  * Images on the wire are `data:image/jpeg;base64,…` URLs — the same encoding
@@ -52,6 +55,25 @@ fun readImage(resolver: ContentResolver, uri: Uri): Bitmap? {
     }
     return resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
 }
+
+/**
+ * Somewhere for the camera app to write a full-resolution capture, handed over
+ * as a `content://` Uri through the app's [FileProvider] (`camera-captures` in
+ * `res/xml/file_paths.xml`). Cache-dir, because the file is only ever read once
+ * — the attachment itself lives on as a downscaled data URL.
+ */
+fun newCaptureUri(context: Context): Uri {
+    val dir = File(context.cacheDir, CAPTURE_DIR).apply { mkdirs() }
+    val file = File.createTempFile("capture_", ".jpg", dir)
+    return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+}
+
+/** Best-effort: a capture left behind is cache, and the OS will reclaim it. */
+fun discardCapture(context: Context, uri: Uri) {
+    runCatching { context.contentResolver.delete(uri, null, null) }
+}
+
+private const val CAPTURE_DIR = "camera-captures"
 
 fun decodeDataUrl(dataUrl: String): Bitmap? {
     val encoded = dataUrl.substringAfter(BASE64_MARKER, "").takeIf { it.isNotEmpty() } ?: return null

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
@@ -172,7 +172,11 @@ private fun CodeBlockView(block: MdBlock.CodeBlock, colors: LlmColors) {
                     .testTag("code_copy"),
             )
         }
-        Box(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(10.dp)) {
+        // C4: the padding goes *outside* the scroll container, so the viewport
+        // ends at the inset and long lines are clipped there. Inside it, the
+        // padding scrolled along with the text and code slid out under the
+        // block's own left edge.
+        Box(Modifier.fillMaxWidth().padding(10.dp).horizontalScroll(rememberScrollState())) {
             Text(
                 block.code,
                 color = colors.fg,
@@ -314,7 +318,7 @@ fun ArtifactCard(artifact: ArtifactRecord, modifier: Modifier = Modifier) {
         when (artifact.type) {
             "svg" -> SvgArtifactBody(artifact, colors)
             "image" -> ImageArtifactBody(artifact, colors)
-            "code" -> Box(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(10.dp)) {
+            "code" -> Box(Modifier.fillMaxWidth().padding(10.dp).horizontalScroll(rememberScrollState())) {
                 Text(artifact.content, color = colors.fg, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
             }
             "html" -> HtmlArtifactPlaceholder(colors)
@@ -417,13 +421,51 @@ private fun SvgWebView(svg: String, zoomable: Boolean, modifier: Modifier = Modi
                 settings.setSupportZoom(zoomable)
                 settings.builtInZoomControls = zoomable
                 settings.displayZoomControls = false
+                // Obey the viewport meta in [svgDocument] rather than assuming
+                // the 980 px desktop width a WebView guesses for a page without
+                // one — that guess is half of why the diagram sat off-frame.
+                settings.useWideViewPort = true
+                settings.loadWithOverviewMode = true
+                isVerticalScrollBarEnabled = false
+                isHorizontalScrollBarEnabled = false
             }
         },
         update = { webView ->
-            val html = "<html><body style=\"margin:0;display:flex;align-items:center;justify-content:center;\">$svg</body></html>"
-            webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+            val html = svgDocument(svg, zoomable)
+            // `update` runs on every recomposition, and a reload resets the
+            // user's zoom — so only reload when the document actually changed.
+            if (webView.tag != html) {
+                webView.tag = html
+                webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+            }
         },
     )
+}
+
+/**
+ * Fits the diagram to its frame.
+ *
+ * Schemdraw sizes its root element in **points** (`width="173.168pt"`) and puts
+ * the real geometry in the `viewBox`. Nothing in the old wrapper related that
+ * to the size of the frame, so a drawing wider than the phone was simply
+ * cropped — and because the body centred it, the overflow went off *both*
+ * edges and the left of the circuit could not be reached at any zoom. Capping
+ * both dimensions at 100% and letting the viewBox supply the aspect ratio is
+ * what makes it fit; `width/height:auto` is needed to stop the `pt` attributes
+ * winning.
+ */
+private fun svgDocument(svg: String, zoomable: Boolean): String {
+    val scaling = if (zoomable) "initial-scale=1,minimum-scale=1,maximum-scale=6" else "initial-scale=1,user-scalable=no"
+    return """
+        <html><head>
+        <meta name="viewport" content="width=device-width,$scaling">
+        <style>
+          html,body{margin:0;height:100%;}
+          body{display:flex;align-items:center;justify-content:center;}
+          svg{max-width:100%;max-height:100%;width:auto;height:auto;display:block;}
+        </style>
+        </head><body>$svg</body></html>
+    """.trimIndent()
 }
 
 /** F05-R6's fourth criterion — tap an image, get it full-screen with pinch-zoom. */

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
@@ -1,5 +1,6 @@
 package com.hpz.llmdockchat.feature.thread
 
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.PickVisualMediaRequest
@@ -10,13 +11,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -38,13 +42,19 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.first
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
@@ -123,6 +133,11 @@ private fun ThreadContent(
         }
     }
 
+    // Whether the thread follows the tail of the answer. Hoisted here because
+    // both halves of the screen move it: the list turns it off when the reader
+    // scrolls up, and sending turns it back on. See [LoadedThread].
+    var following by remember { mutableStateOf(true) }
+
     Scaffold(
         modifier = modifier.testTag("thread_screen"),
         containerColor = colors.app,
@@ -166,6 +181,30 @@ private fun ThreadContent(
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
             )
         },
+        // The composer is the Scaffold's bottom bar rather than the last child
+        // of the body (fix pass B1). That is what keeps the keyboard from
+        // destroying the screen: Scaffold measures the bar first and gives the
+        // thread what is left, instead of a Column handing the composer an
+        // unbounded height and squeezing the list — and the app bar — to
+        // nothing.
+        bottomBar = {
+            loaded?.let {
+                ThreadComposer(
+                    state = it,
+                    onComposerChange = onComposerChange,
+                    onSend = {
+                        // Your own turn always pulls the view to the bottom,
+                        // even if you had scrolled up to re-read something.
+                        following = true
+                        onSend()
+                    },
+                    onStop = onStop,
+                    onAddAttachment = onAddAttachment,
+                    onRemoveAttachment = onRemoveAttachment,
+                    onAttachmentFailed = onAttachmentFailed,
+                )
+            }
+        },
     ) { padding ->
         Box(Modifier.fillMaxSize().padding(padding)) {
             when (state) {
@@ -174,12 +213,8 @@ private fun ThreadContent(
                 is ThreadUiState.Loaded -> LoadedThread(
                     state = state,
                     listState = listState,
-                    onComposerChange = onComposerChange,
-                    onSend = onSend,
-                    onStop = onStop,
-                    onAddAttachment = onAddAttachment,
-                    onRemoveAttachment = onRemoveAttachment,
-                    onAttachmentFailed = onAttachmentFailed,
+                    following = following,
+                    onFollowingChange = { following = it },
                 )
             }
         }
@@ -190,26 +225,47 @@ private fun ThreadContent(
 private fun LoadedThread(
     state: ThreadUiState.Loaded,
     listState: LazyListState,
-    onComposerChange: (String) -> Unit,
-    onSend: () -> Unit,
-    onStop: () -> Unit,
-    onAddAttachment: (String) -> Unit,
-    onRemoveAttachment: (Int) -> Unit,
-    onAttachmentFailed: (String) -> Unit,
+    following: Boolean,
+    onFollowingChange: (Boolean) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val streaming = state.thread.streaming
 
-    // "At the bottom" is the whole auto-scroll rule (F04-R3): follow the tail
-    // while the user is there, stop the instant they scroll up, resume when
-    // they come back. No separate follow flag to get out of sync.
     val atBottom by remember { derivedStateOf { !listState.canScrollForward } }
     val tailSignal = streaming?.content?.length.orZero() +
         streaming?.reasoning?.length.orZero() +
         state.thread.messages.size
 
-    LaunchedEffect(tailSignal) {
-        if (atBottom && listState.layoutInfo.totalItemsCount > 0) {
+    // F04-R3. Following the tail has to be a *mode*, not a measurement taken
+    // when the effect happens to run. Deriving it from `canScrollForward`
+    // loses a race with the stream: a delta makes the list scrollable one
+    // frame before the effect that would have scrolled it runs, so the first
+    // delta reads "not at the bottom", declines to scroll, and the thread
+    // never follows again. That is fix pass A1 — it passed on the emulator
+    // only because the taller viewport delayed the first overflow.
+    //
+    // The mode is turned off by the reader dragging the content downwards
+    // (nested scroll below), and turned back on by the list settling at its
+    // end — whether that is the ↓ button, a manual scroll back, or the
+    // auto-scroll itself.
+    LaunchedEffect(atBottom) {
+        if (atBottom) onFollowingChange(true)
+    }
+
+    val stopFollowingOnDragBack = remember(onFollowingChange) {
+        object : NestedScrollConnection {
+            // Only gestures reach a nested-scroll connection; `scrollToItem`
+            // and `animateScrollToItem` do not dispatch through it, so the
+            // auto-scroll can never switch itself off.
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f) onFollowingChange(false)
+                return Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(tailSignal, following) {
+        if (following && listState.layoutInfo.totalItemsCount > 0) {
             listState.scrollToItem(listState.layoutInfo.totalItemsCount - 1)
         }
     }
@@ -224,61 +280,53 @@ private fun LoadedThread(
         listState.scrollToItem(count - 1)
     }
 
-    Column(Modifier.fillMaxSize()) {
-        Box(Modifier.weight(1f)) {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize().testTag("thread_list"),
-                contentPadding = PaddingValues(vertical = 8.dp),
-            ) {
-                items(state.thread.messages)
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(stopFollowingOnDragBack)
+                .testTag("thread_list"),
+            contentPadding = PaddingValues(vertical = 8.dp),
+        ) {
+            items(state.thread.messages)
 
-                streaming?.let { turn ->
-                    turn.userMessage?.let { pending ->
-                        item(key = "pending_user") {
-                            MessageBubble(pending.asMessage())
-                        }
-                    }
-                    // Its own item, so a delta recomposes this element alone
-                    // rather than the whole column (Architecture P2).
-                    item(key = "streaming") { StreamingBubble(turn) }
-                }
-
-                // A persisted failure has no message of its own when the model
-                // died before producing any text; the run's error is still the
-                // truth about that turn (F04-R8).
-                if (streaming == null) {
-                    state.runError?.takeIf { state.thread.messages.lastOrNull()?.error == null }?.let { error ->
-                        item(key = "run_error") {
-                            Box(Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) { ErrorNote(error) }
-                        }
+            streaming?.let { turn ->
+                turn.userMessage?.let { pending ->
+                    item(key = "pending_user") {
+                        MessageBubble(pending.asMessage())
                     }
                 }
-
-                // Scrolling this 1 dp tail into view lands exactly at the
-                // bottom of the content, whatever the last item's height.
-                item(key = "tail") { Spacer(Modifier.height(1.dp)) }
+                // Its own item, so a delta recomposes this element alone
+                // rather than the whole column (Architecture P2).
+                item(key = "streaming") { StreamingBubble(turn) }
             }
 
-            if (!atBottom) {
-                JumpToLatest(
-                    modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
-                    onClick = {
-                        scope.launch { listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1) }
-                    },
-                )
+            // A persisted failure has no message of its own when the model
+            // died before producing any text; the run's error is still the
+            // truth about that turn (F04-R8).
+            if (streaming == null) {
+                state.runError?.takeIf { state.thread.messages.lastOrNull()?.error == null }?.let { error ->
+                    item(key = "run_error") {
+                        Box(Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) { ErrorNote(error) }
+                    }
+                }
             }
+
+            // Scrolling this 1 dp tail into view lands exactly at the
+            // bottom of the content, whatever the last item's height.
+            item(key = "tail") { Spacer(Modifier.height(1.dp)) }
         }
 
-        ThreadComposer(
-            state = state,
-            onComposerChange = onComposerChange,
-            onSend = onSend,
-            onStop = onStop,
-            onAddAttachment = onAddAttachment,
-            onRemoveAttachment = onRemoveAttachment,
-            onAttachmentFailed = onAttachmentFailed,
-        )
+        if (!atBottom) {
+            JumpToLatest(
+                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+                onClick = {
+                    onFollowingChange(true)
+                    scope.launch { listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1) }
+                },
+            )
+        }
     }
 }
 
@@ -404,16 +452,37 @@ private fun ThreadComposer(
         if (bitmap == null) onAttachmentFailed("That image could not be read.")
         else onAddAttachment(bitmap.toDataUrl())
     }
-    val takePhoto = rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
-        if (bitmap != null) onAddAttachment(bitmap.toDataUrl())
+
+    // Fix pass A4. `TakePicturePreview` returns the camera app's *thumbnail*
+    // (the MediaStore `"data"` extra) — a couple of hundred pixels, useless to
+    // a vision model. `TakePicture` writes the real capture to a Uri we own,
+    // which then goes through exactly the same read-and-downscale path as a
+    // gallery pick.
+    var pendingPhoto by remember { mutableStateOf<Uri?>(null) }
+    val takePhoto = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { saved ->
+        val uri = pendingPhoto
+        pendingPhoto = null
+        if (!saved || uri == null) return@rememberLauncherForActivityResult
+        val bitmap = runCatching { readImage(context.contentResolver, uri) }.getOrNull()
+        if (bitmap == null) onAttachmentFailed("That photo could not be read.")
+        else onAddAttachment(bitmap.toDataUrl())
+        discardCapture(context, uri)
     }
 
     Column(
         Modifier
             .fillMaxWidth()
             .background(colors.surface)
-            .navigationBarsPadding()
-            .imePadding()
+            // The only insets the composer needs, in either state:
+            // `safeDrawing` is the union of the system bars, the cutout and
+            // the IME, so the bottom is the navigation bar when the keyboard
+            // is down and the keyboard when it is up — never both stacked,
+            // which is what left the 94 dp grey band under the composer (A2).
+            // The horizontal side matters in landscape, where a three-button
+            // bar sits against one edge and would otherwise cover Send.
+            .windowInsetsPadding(
+                WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+            )
             .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -435,7 +504,15 @@ private fun ThreadComposer(
             onSend = onSend,
             onStop = onStop,
             onPickImage = { pickImage.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) },
-            onTakePhoto = { takePhoto.launch(null) },
+            onTakePhoto = {
+                val uri = runCatching { newCaptureUri(context) }.getOrNull()
+                if (uri == null) {
+                    onAttachmentFailed("The camera could not be opened.")
+                } else {
+                    pendingPhoto = uri
+                    takePhoto.launch(uri)
+                }
+            },
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -1,6 +1,8 @@
 package com.hpz.llmdockchat.navigation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -167,6 +169,12 @@ fun AppNavHost(
  * `saveState`/`restoreState`, the standard bottom-nav idiom: each tab's
  * ViewModel and `rememberSaveable` state (including scroll position) survive
  * switching away and back.
+ *
+ * Insets (fix pass A2): this Scaffold applies none of its own
+ * ([WindowInsets] of zero) — [AppBottomBar] is a `NavigationBar`, which pads
+ * itself clear of the navigation bar while keeping its background behind it.
+ * `consumeWindowInsets` then tells the tab's own Scaffold that the bottom is
+ * already spoken for, so it applies only the top.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -176,6 +184,7 @@ private fun TabScaffold(navController: NavHostController, content: @Composable (
 
     Scaffold(
         containerColor = LlmTheme.colors.app,
+        contentWindowInsets = WindowInsets(0),
         bottomBar = {
             AppBottomBar(currentRoute = currentRoute) { route ->
                 if (route != currentRoute) {
@@ -188,7 +197,12 @@ private fun TabScaffold(navController: NavHostController, content: @Composable (
             }
         },
     ) { padding ->
-        Box(Modifier.fillMaxSize().padding(padding)) { content() }
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .consumeWindowInsets(padding),
+        ) { content() }
     }
 }
 

--- a/android/src/app/src/main/res/xml/file_paths.xml
+++ b/android/src/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Full-resolution camera captures, handed to the camera app by Uri and
+         read back once before being discarded (see ImageAttachments.kt). -->
+    <cache-path name="camera-captures" path="camera-captures/" />
+</paths>

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/markdown/MarkdownParserTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/markdown/MarkdownParserTest.kt
@@ -87,6 +87,42 @@ class MarkdownParserTest {
         assertEquals("this [is not a link at all", text.text)
     }
 
+    // -- images ---------------------------------------------------------------
+
+    @Test
+    fun `an image renders as a caption, not a stray bang and a link`() {
+        val text = parseInline("![RC low-pass filter](http://x/a.svg)", colors)
+        assertEquals("Image: RC low-pass filter", text.text)
+        assertEquals(0, text.getLinkAnnotations(0, text.length).size)
+    }
+
+    @Test
+    fun `an image with no alt text keeps its literal source`() {
+        val text = parseInline("![](http://x/a.svg)", colors)
+        assertEquals("![](http://x/a.svg)", text.text)
+        assertEquals(0, text.getLinkAnnotations(0, text.length).size)
+    }
+
+    @Test
+    fun `an image inside a sentence leaves the surrounding prose alone`() {
+        val text = parseInline("before ![a diagram](http://x/a.svg) after", colors)
+        assertEquals("before Image: a diagram after", text.text)
+    }
+
+    @Test
+    fun `an escaped bang before a link stays a link`() {
+        val text = parseInline("""\![the docs](https://example.com)""", colors)
+        assertEquals("!the docs", text.text)
+        assertEquals(1, text.getLinkAnnotations(0, text.length).size)
+    }
+
+    @Test
+    fun `a bang that is not an image is literal`() {
+        val text = parseInline("wow! [the docs](https://example.com)", colors)
+        assertEquals("wow! the docs", text.text)
+        assertEquals(1, text.getLinkAnnotations(0, text.length).size)
+    }
+
     // -- lists ---------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
The first pass on physical hardware. F00–F05 had been verified only on an emulator, which could not reproduce any of the following.

## The blocker

**Opening the keyboard destroyed the chat screen** — app bar measured to zero bounds, thread collapsed to ~40 dp, and you typed blind.

Root cause, measured on the device: ColorOS reports `ime=1127` **and** shrinks the window 2376→1705 px. So the app paid for the keyboard twice — once by the OEM resize, again via `imePadding()` — 1798 px of demand in a 1705 px window. `windowSoftInputMode="adjustResize"` stops the resize and makes `WindowInsets.ime` the single authority.

## A Must criterion that passed on the emulator and failed on hardware

**The thread never followed a streaming answer.** Deriving "at bottom" from `canScrollForward` loses a race with the stream: a delta makes the list scrollable one frame *before* the effect that would scroll it runs, so the very first delta reads "not at the bottom", declines, and it never follows again. It passed emulator review only because the taller viewport delayed the first overflow.

Following is now a **mode**, cleared only by a user drag and re-armed when the list settles at its end. The load-bearing detail: only gestures reach a `NestedScrollConnection`, so the auto-scroll cannot switch itself off.

## Measured improvements

| | before | after |
|---|---|---|
| Thread list height | 1356 px | **1740 px** (+28%) |
| Conversation list rows visible | 6 | **8** (+42% viewport) |
| Composer → nav bar dead space | 282 px | 18 px |
| Camera capture | 192×256 | **1176×1568** |

## Diagnoses that turned out better than the symptom suggested

- **The list was not failing to refresh.** It refreshes; `LazyColumn` anchors on the first visible item's key, so a prepended conversation lays out *above the fold* and nothing on screen changes.
- **SVG artifacts were not an overflow-clipping problem.** Schemdraw sizes its root in **points** (`width="327.536pt"`) with the real geometry only in the `viewBox`, and the old wrapper *centred* the overflow so it spilled off both edges — which is why the left of a circuit was unreachable at any zoom.
- **Camera photos were thumbnails** because `TakePicturePreview()` returns the MediaStore `"data"` extra by contract, not the capture.

## Known gap, recorded not fixed

Composer text is persisted; **attachments are not**. Process death behind the photo picker restores the text and silently drops the images. Fixing it properly means files in `cacheDir` — 140 KB base64 URLs are wrong for DataStore and risk `TransactionTooLarge` in `SavedStateHandle`. Recorded in F04's doc as a scheduled feature rather than bolted on.

306 tests, all green.