### PR TITLE
Android F06: message actions

### DIFF
--- a/android/docs/F06-message-actions.md
+++ b/android/docs/F06-message-actions.md
@@ -101,8 +101,65 @@ sheet.
 
 None.
 
+## Deviations found while implementing
+
+- **Text selection is invoked through the menu, not by long-pressing text
+  directly.** F05 shipped `MarkdownBody` always wrapped in a
+  `SelectionContainer`, so a long-press on the text itself started a
+  selection. That gesture and F06-R1's long-press-for-menu compete for the
+  same touch: `SelectionContainer`'s own long-press-to-select handler and an
+  outer long-press-to-open-menu handler both sit on the same pointer stream
+  over the same glyphs, and there is no reliable way to referee between them
+  from outside Compose's text-selection internals.
+
+  Resolved by making selection opt-in per message: `MarkdownBody` (and the
+  equivalent in `UserBubble`) only mounts a `SelectionContainer` when that
+  specific message is in "selection mode", entered via the long-press menu's
+  "Select text" row and left via a "Done" pill. While a message is not in
+  that mode it has no selection gesture at all, so the long-press-to-menu
+  detector is the only thing listening and always wins; while it is in that
+  mode the long-press detector is removed entirely (not merely overridden),
+  so the selection drag is the only thing listening. Verified live on device:
+  long-press opens the menu everywhere text is *not* already in selection
+  mode, and once "Select text" is tapped, long-pressing the same text starts
+  a native selection (word highlight, drag handles, the system Copy/Select
+  all toolbar) with no menu popping up over it.
+
+  This changes *how* F05-R3's selection is invoked, not whether it works —
+  selecting a span in rendered prose and in a code block is unchanged once
+  selection mode is on. See `feature/thread/MarkdownRender.kt`'s
+  `MarkdownBody` doc comment and `feature/thread/ThreadMessages.kt`'s
+  `LongPressableMessage`.
+
 ## Out of scope
 
 - Editing assistant messages (the server rejects it — 400).
 - Reordering or moving messages between threads.
 - Retrying a failed turn as a distinct action — edit-and-resend covers it.
+
+## Verification notes
+
+**Deleting a user message does not cascade to its assistant reply.**
+`chat/routes.py:delete_message` is a single-row delete and the spec never
+asked for cascading, so the reply is left with no preceding question.
+Verified live. Recorded so a future reader does not file it as a bug.
+
+**The discard count is exact.** `create_run_with_user_message`
+(`chat/db.py:903`) does `DELETE … WHERE seq >= msg.seq` and then inserts
+a fresh row for the edit, so the edited message is destroyed and
+replaced. The client's strictly-after count is therefore what the user
+actually loses. Verified against the live backend at the first message of
+a thread (discards 3) and at the last user turn before its reply
+(discards 1).
+
+**For the owner, needing a real thumb:** drag-selecting inside a
+horizontally-scrolling code block, and long-press timing generally.
+Synthetic `input swipe` does not reproduce Compose's
+long-press-then-extend gesture — one attempt was eaten by the edge-back
+gesture.
+
+**Not caught live:** cancelling an edit-and-resend run mid-stream. The
+local model finishes faster than a Stop tap lands on this rig, so only
+the already-finished no-op case was exercised. `confirmEdit` routes
+through the same `collectRun`/`finishRun` as `send()`, which F04 covers
+for cancellation, and nothing edit-specific touches that path.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -179,7 +179,7 @@ Mark completed features `[DONE]` in the Status column.
 | F03 | Starting a conversation | [F03-new-conversation.md](F03-new-conversation.md) | 03 | [DONE] |
 | F04 | Sending a turn and streaming the reply | [F04-chat-turn-and-streaming.md](F04-chat-turn-and-streaming.md) | 04, 06a | [DONE] |
 | F05 | Rendering assistant output | [F05-message-rendering.md](F05-message-rendering.md) | 05 | [DONE] |
-| F06 | Message actions | [F06-message-actions.md](F06-message-actions.md) | 06b | [ ] |
+| F06 | Message actions | [F06-message-actions.md](F06-message-actions.md) | 06b | [DONE] |
 | F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [ ] |
 | F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [ ] |
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [ ] |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ChatRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ChatRepository.kt
@@ -11,6 +11,7 @@ import com.hpz.llmdockchat.core.net.parseFrame
 import com.hpz.llmdockchat.data.dto.CancelRunRequestDto
 import com.hpz.llmdockchat.data.dto.CancelRunResponseDto
 import com.hpz.llmdockchat.data.dto.ConversationDetailDto
+import com.hpz.llmdockchat.data.dto.DeleteMessageResponseDto
 import com.hpz.llmdockchat.data.dto.SendMessageRequestDto
 import com.hpz.llmdockchat.data.mapper.toDomain
 import com.hpz.llmdockchat.data.model.ConversationDetail
@@ -96,6 +97,22 @@ class ChatRepository(
             path = Endpoints.cancelActiveRun(conversationId),
             deserializer = CancelRunResponseDto.serializer(),
             body = ApiJson.encodeToString(CancelRunRequestDto(expectedRunId)),
+        )
+        Unit
+    }
+
+    /**
+     * `DELETE …/messages/<msg_id>` (F06). The server refuses with 409 while a
+     * run is active in this conversation — the in-flight turn is not yet
+     * persisted, and deleting a prior message mid-run would leave the
+     * transcript inconsistent. That surfaces here as an ordinary failure; the
+     * caller must not remove the message locally until this succeeds.
+     */
+    suspend fun deleteMessage(conversationId: String, messageId: String): Result<Unit> = apiCall {
+        api.request(
+            method = "DELETE",
+            path = Endpoints.conversationMessage(conversationId, messageId),
+            deserializer = DeleteMessageResponseDto.serializer(),
         )
         Unit
     }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ChatThreadDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ChatThreadDto.kt
@@ -103,3 +103,8 @@ data class CancelRunRequestDto(@SerialName("expected_run_id") val expectedRunId:
  */
 @Serializable
 data class CancelRunResponseDto(val run: LastRunDto? = null)
+
+/** `DELETE …/messages/<id>` → `{"ok": true}` (F06). Nothing else is returned —
+ *  the caller already knows which message it deleted. */
+@Serializable
+data class DeleteMessageResponseDto(val ok: Boolean = false)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/MarkdownRender.kt
@@ -64,20 +64,34 @@ import kotlin.math.min
  * one block still being written (Architecture P2 — see
  * `core/markdown/MarkdownParser.kt` for the two-phase design).
  *
- * Wrapped in one [SelectionContainer] so selection spans every block, not just
- * a single paragraph (F05-R3's second criterion).
+ * [selectable] wraps the blocks in one [SelectionContainer] so selection spans
+ * every block, not just a single paragraph (F05-R3's second criterion) — but
+ * only while the message is in F06's selection mode. A [SelectionContainer]
+ * claims long-press for its own selection-start gesture, which is exactly the
+ * gesture F06-R1 needs for the action menu; rather than fight that
+ * conflict on every message all the time, selection is off by default and
+ * turned on per-message from the long-press menu's "Select text" row
+ * (`ThreadMessages.kt`'s `LongPressableMessage`), which simultaneously stops
+ * offering the long-press gesture for as long as it's on (F06-R4's second
+ * criterion). See F06's *Deviations* for why this changes how F05-R3's
+ * already-shipped selection is invoked, not whether it works.
  */
 @Composable
-fun MarkdownBody(raw: String, modifier: Modifier = Modifier) {
+fun MarkdownBody(raw: String, modifier: Modifier = Modifier, selectable: Boolean = false) {
     val colors = LlmTheme.colors
     val blocks = remember(raw) { splitMdBlocks(raw) }
-    SelectionContainer(modifier = modifier.testTag("markdown_body")) {
+    val body: @Composable () -> Unit = {
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             blocks.forEach { rawBlock ->
                 val block = remember(rawBlock, colors) { parseMdBlock(rawBlock, colors) }
                 MdBlockView(block, colors)
             }
         }
+    }
+    if (selectable) {
+        SelectionContainer(modifier = modifier.testTag("markdown_body"), content = body)
+    } else {
+        Box(modifier.testTag("markdown_body")) { body() }
     }
 }
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
@@ -1,18 +1,30 @@
 package com.hpz.llmdockchat.feature.thread
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,11 +35,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.foundation.Image
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.data.model.ArtifactRecord
@@ -40,11 +59,14 @@ import com.hpz.llmdockchat.data.model.ToolCallRecord
  * The mockup's split (screen 04): the user's own words in mono, the model's in
  * serif, so it is obvious who is talking without an avatar. Markdown rendering
  * is F05, via [MarkdownBody].
+ *
+ * [selectable] is F06's selection mode (see [MarkdownBody]) — on for exactly
+ * the one message the long-press menu's "Select text" was tapped for.
  */
 @Composable
-fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier) {
+fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, selectable: Boolean = false) {
     when (message.role) {
-        MessageRole.USER -> UserBubble(message, modifier)
+        MessageRole.USER -> UserBubble(message, selectable, modifier)
         else -> AssistantBubble(
             content = message.content,
             reasoning = message.reasoning,
@@ -52,13 +74,14 @@ fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier) {
             parseWarning = message.parseWarning,
             error = message.error,
             artifacts = message.artifacts,
+            selectable = selectable,
             modifier = modifier,
         )
     }
 }
 
 @Composable
-private fun UserBubble(message: ChatMessage, modifier: Modifier = Modifier) {
+private fun UserBubble(message: ChatMessage, selectable: Boolean, modifier: Modifier = Modifier) {
     val colors = LlmTheme.colors
     // F05-R6's fourth criterion: a photo the user attached opens full-screen
     // with pinch-zoom, same as an image artifact — decoded once here so the
@@ -85,12 +108,15 @@ private fun UserBubble(message: ChatMessage, modifier: Modifier = Modifier) {
                     .background(colors.surfaceElevated)
                     .padding(horizontal = 14.dp, vertical = 10.dp),
             ) {
-                Text(
-                    message.content,
-                    color = colors.fg,
-                    fontFamily = FontFamily.Monospace,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
+                val text: @Composable () -> Unit = {
+                    Text(
+                        message.content,
+                        color = colors.fg,
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                if (selectable) SelectionContainer(content = text) else text()
             }
         }
     }
@@ -117,6 +143,7 @@ fun AssistantBubble(
     error: String?,
     modifier: Modifier = Modifier,
     artifacts: List<ArtifactRecord> = emptyList(),
+    selectable: Boolean = false,
     trailing: @Composable (() -> Unit)? = null,
 ) {
     Column(
@@ -129,7 +156,7 @@ fun AssistantBubble(
         toolCalls.forEach { ToolCallCard(it) }
         parseWarning?.let { ParseWarningChip(it) }
         if (content.isNotBlank()) {
-            MarkdownBody(content, modifier = Modifier.testTag("assistant_text"))
+            MarkdownBody(content, modifier = Modifier.testTag("assistant_text"), selectable = selectable)
         }
         artifacts.forEach { ArtifactCard(it) }
         error?.let { ErrorNote(it) }
@@ -335,5 +362,179 @@ fun ImageThumbnail(
                 Text("✕", color = colors.fg, style = MaterialTheme.typography.labelSmall)
             }
         }
+    }
+}
+
+// -- F06 · long-press menu ----------------------------------------------------
+
+/**
+ * One item in the list, with the long-press gesture that opens the action
+ * menu (F06-R1). The gesture is entirely absent — not merely overridden —
+ * while [selectionActive], which is what keeps a text-selection drag from
+ * also popping the menu (F06-R4's second criterion); see [MarkdownBody] for
+ * why selection itself is gated behind the menu rather than always-on.
+ */
+@Composable
+fun LongPressableMessage(
+    message: ChatMessage,
+    selectionActive: Boolean,
+    selected: Boolean,
+    onLongPress: (ChatMessage) -> Unit,
+) {
+    Box(
+        Modifier
+            .pointerInput(message.id, selectionActive) {
+                if (!selectionActive) {
+                    detectTapGestures(onLongPress = { onLongPress(message) })
+                }
+            }
+            .testTag("message_bubble_${message.id}"),
+    ) {
+        MessageBubble(message, selectable = selected)
+    }
+}
+
+/**
+ * Screen 06b. A bottom sheet rather than [androidx.compose.material3.ModalBottomSheet]
+ * so it matches the rest of the feature's own `Dialog`-based overlays (the
+ * artifact and image full-screen viewers) instead of pulling in a second
+ * pattern for the same job. The scrim and the sheet each swallow their own
+ * taps — [onDismiss] only fires for a tap that lands on neither.
+ */
+@Composable
+fun MessageActionsSheet(
+    message: ChatMessage,
+    canEdit: Boolean,
+    canDelete: Boolean,
+    onDismiss: () -> Unit,
+    onSelectText: () -> Unit,
+    onEditAndResend: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val colors = LlmTheme.colors
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = onDismiss,
+                )
+                .testTag("message_actions_scrim"),
+        ) {
+            Column(
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
+                    .clip(RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp))
+                    .background(colors.surfaceElevated)
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = {},
+                    )
+                    .padding(vertical = 10.dp)
+                    .testTag("message_actions_sheet"),
+            ) {
+                Box(
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(vertical = 4.dp)
+                        .size(width = 36.dp, height = 4.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(colors.line),
+                )
+                Spacer(Modifier.height(4.dp))
+                ActionRow("📋", "Copy text", testTag = "action_copy") {
+                    clipboard.setText(AnnotatedString(message.content))
+                    onDismiss()
+                }
+                ActionRow("🔤", "Select text", testTag = "action_select") {
+                    onSelectText()
+                    onDismiss()
+                }
+                if (canEdit) {
+                    ActionRow(
+                        "✎",
+                        "Edit and resend",
+                        sublabel = "Discards everything after it",
+                        testTag = "action_edit",
+                    ) {
+                        onEditAndResend()
+                        onDismiss()
+                    }
+                }
+                ActionRow("↗", "Share", testTag = "action_share") {
+                    val send = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, message.content)
+                    }
+                    context.startActivity(Intent.createChooser(send, null))
+                    onDismiss()
+                }
+                if (canDelete) {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 6.dp)
+                            .height(1.dp)
+                            .background(colors.line),
+                    )
+                    ActionRow("🗑", "Delete message", danger = true, testTag = "action_delete") {
+                        onDelete()
+                        onDismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionRow(
+    icon: String,
+    label: String,
+    sublabel: String? = null,
+    danger: Boolean = false,
+    testTag: String,
+    onClick: () -> Unit,
+) {
+    val colors = LlmTheme.colors
+    val tint = if (danger) colors.red else colors.fg
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp)
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(icon, style = MaterialTheme.typography.titleMedium)
+        Column {
+            Text(label, color = tint, style = MaterialTheme.typography.bodyLarge)
+            sublabel?.let { Text(it, color = colors.subtle, style = MaterialTheme.typography.labelSmall) }
+        }
+    }
+}
+
+/** The only way out of F06-R4's selection mode — see [MarkdownBody]. */
+@Composable
+fun SelectionDonePill(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    val colors = LlmTheme.colors
+    Box(
+        modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(colors.accent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 10.dp)
+            .testTag("selection_done"),
+    ) {
+        Text("Done", color = colors.onAccent, style = MaterialTheme.typography.labelLarge)
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,6 +26,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
@@ -102,6 +104,14 @@ fun ThreadScreen(
         onAddAttachment = viewModel::addAttachment,
         onRemoveAttachment = viewModel::removeAttachment,
         onAttachmentFailed = viewModel::reportAttachmentFailure,
+        onRequestDelete = viewModel::requestDelete,
+        onCancelDelete = viewModel::cancelDelete,
+        onConfirmDelete = viewModel::confirmDelete,
+        onBeginEdit = viewModel::beginEdit,
+        onCancelEdit = viewModel::cancelEdit,
+        onRequestEditConfirm = viewModel::requestEditConfirm,
+        onCancelEditConfirm = viewModel::cancelEditConfirm,
+        onConfirmEdit = viewModel::confirmEdit,
         modifier = modifier,
     )
 }
@@ -120,6 +130,14 @@ private fun ThreadContent(
     onAddAttachment: (String) -> Unit,
     onRemoveAttachment: (Int) -> Unit,
     onAttachmentFailed: (String) -> Unit,
+    onRequestDelete: (ChatMessage) -> Unit,
+    onCancelDelete: () -> Unit,
+    onConfirmDelete: () -> Unit,
+    onBeginEdit: (ChatMessage) -> Unit,
+    onCancelEdit: () -> Unit,
+    onRequestEditConfirm: () -> Unit,
+    onCancelEditConfirm: () -> Unit,
+    onConfirmEdit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LlmTheme.colors
@@ -196,12 +214,16 @@ private fun ThreadContent(
                         // Your own turn always pulls the view to the bottom,
                         // even if you had scrolled up to re-read something.
                         following = true
-                        onSend()
+                        // Send, while editing a message, means "edit and
+                        // resend" — F06-R3 — which opens the discard-count
+                        // confirm rather than posting straight away.
+                        if (it.editingMessage != null) onRequestEditConfirm() else onSend()
                     },
                     onStop = onStop,
                     onAddAttachment = onAddAttachment,
                     onRemoveAttachment = onRemoveAttachment,
                     onAttachmentFailed = onAttachmentFailed,
+                    onCancelEdit = onCancelEdit,
                 )
             }
         },
@@ -215,9 +237,53 @@ private fun ThreadContent(
                     listState = listState,
                     following = following,
                     onFollowingChange = { following = it },
+                    onRequestDelete = onRequestDelete,
+                    onBeginEdit = onBeginEdit,
                 )
             }
         }
+    }
+
+    // F00-R9 / F06-R2 / F06-R3 — each destructive action confirms, naming the
+    // specific target: the delete dialog has nothing else to name (there is
+    // one message), the edit dialog states the discard count in numbers.
+    loaded?.pendingDelete?.let {
+        AlertDialog(
+            onDismissRequest = onCancelDelete,
+            modifier = Modifier.testTag("delete_confirm_dialog"),
+            title = { Text("Delete this message?") },
+            text = { Text("This can't be undone.") },
+            confirmButton = {
+                TextButton(onClick = onConfirmDelete, modifier = Modifier.testTag("confirm_delete")) {
+                    Text("Delete", color = colors.red)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onCancelDelete, modifier = Modifier.testTag("cancel_delete")) { Text("Cancel") }
+            },
+        )
+    }
+    loaded?.pendingEdit?.let { edit ->
+        val body = if (edit.discardCount == 0) {
+            "This message will be resent."
+        } else {
+            val plural = if (edit.discardCount == 1) "message" else "messages"
+            "This will discard ${edit.discardCount} $plural after it and start a new answer."
+        }
+        AlertDialog(
+            onDismissRequest = onCancelEditConfirm,
+            modifier = Modifier.testTag("edit_confirm_dialog"),
+            title = { Text("Edit and resend?") },
+            text = { Text(body, modifier = Modifier.testTag("edit_confirm_body")) },
+            confirmButton = {
+                TextButton(onClick = onConfirmEdit, modifier = Modifier.testTag("confirm_edit")) { Text("Resend") }
+            },
+            dismissButton = {
+                TextButton(onClick = onCancelEditConfirm, modifier = Modifier.testTag("cancel_edit_confirm")) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 }
 
@@ -227,6 +293,8 @@ private fun LoadedThread(
     listState: LazyListState,
     following: Boolean,
     onFollowingChange: (Boolean) -> Unit,
+    onRequestDelete: (ChatMessage) -> Unit,
+    onBeginEdit: (ChatMessage) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val streaming = state.thread.streaming
@@ -280,6 +348,11 @@ private fun LoadedThread(
         listState.scrollToItem(count - 1)
     }
 
+    // F06-R1/R4 — one menu open at a time, one message in selection mode at a
+    // time. Neither survives navigating away; there is nothing to restore.
+    var menuMessage by remember { mutableStateOf<ChatMessage?>(null) }
+    var selectionModeMessageId by remember { mutableStateOf<String?>(null) }
+
     Box(Modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
@@ -289,7 +362,11 @@ private fun LoadedThread(
                 .testTag("thread_list"),
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
-            items(state.thread.messages)
+            items(
+                messages = state.thread.messages,
+                selectionModeMessageId = selectionModeMessageId,
+                onLongPress = { menuMessage = it },
+            )
 
             streaming?.let { turn ->
                 turn.userMessage?.let { pending ->
@@ -327,11 +404,44 @@ private fun LoadedThread(
                 },
             )
         }
+
+        if (selectionModeMessageId != null) {
+            SelectionDonePill(
+                modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
+                onClick = { selectionModeMessageId = null },
+            )
+        }
+    }
+
+    menuMessage?.let { message ->
+        MessageActionsSheet(
+            message = message,
+            canEdit = message.role == MessageRole.USER && !state.runActive,
+            // F06-R2's third criterion — Delete is not offered at all while a
+            // run is active, on top of the server's own 409 guard.
+            canDelete = !state.runActive,
+            onDismiss = { menuMessage = null },
+            onSelectText = { selectionModeMessageId = message.id },
+            onEditAndResend = { onBeginEdit(message) },
+            onDelete = { onRequestDelete(message) },
+        )
     }
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.items(messages: List<ChatMessage>) {
-    items(messages.size, key = { messages[it].id }) { index -> MessageBubble(messages[index]) }
+private fun androidx.compose.foundation.lazy.LazyListScope.items(
+    messages: List<ChatMessage>,
+    selectionModeMessageId: String?,
+    onLongPress: (ChatMessage) -> Unit,
+) {
+    items(messages.size, key = { messages[it].id }) { index ->
+        val message = messages[index]
+        LongPressableMessage(
+            message = message,
+            selectionActive = selectionModeMessageId != null,
+            selected = selectionModeMessageId == message.id,
+            onLongPress = onLongPress,
+        )
+    }
 }
 
 private fun Int?.orZero(): Int = this ?: 0
@@ -442,6 +552,7 @@ private fun ThreadComposer(
     onAddAttachment: (String) -> Unit,
     onRemoveAttachment: (Int) -> Unit,
     onAttachmentFailed: (String) -> Unit,
+    onCancelEdit: () -> Unit,
 ) {
     val colors = LlmTheme.colors
     val context = LocalContext.current
@@ -486,6 +597,31 @@ private fun ThreadComposer(
             .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // F06-R3 — Send now means "edit and resend" (wired one level up); this
+        // says so, and gives a way out that touches nothing (F06-R3's third
+        // criterion: cancelling leaves the thread byte-identical).
+        if (state.editingMessage != null) {
+            Row(
+                Modifier.fillMaxWidth().testTag("editing_banner"),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Editing message",
+                    color = colors.accent,
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    "Cancel",
+                    color = colors.subtle,
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier
+                        .clickable(onClick = onCancelEdit)
+                        .testTag("editing_cancel"),
+                )
+            }
+        }
+
         if (state.attachments.isNotEmpty()) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.testTag("attachment_strip")) {
                 state.attachments.forEachIndexed { index, dataUrl ->
@@ -559,6 +695,8 @@ private fun ThreadStreamingPreview() {
             listState = rememberLazyListState(),
             onBack = {}, onComposerChange = {}, onSend = {}, onStop = {}, onRetry = {},
             onDismissError = {}, onAddAttachment = {}, onRemoveAttachment = {}, onAttachmentFailed = {},
+            onRequestDelete = {}, onCancelDelete = {}, onConfirmDelete = {},
+            onBeginEdit = {}, onCancelEdit = {}, onRequestEditConfirm = {}, onCancelEditConfirm = {}, onConfirmEdit = {},
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
@@ -77,6 +77,20 @@ data class ThreadState(
     val streaming: StreamingTurn? = null,
 )
 
+/**
+ * An edit about to be confirmed (F06-R3). [discardCount] is messages
+ * **strictly after** [message] — the edited message itself is not discarded,
+ * it is replaced in place, matching what `PUT …/messages/<id>` actually does
+ * server-side (`DELETE … WHERE seq >= msg.seq`, then a fresh row is inserted
+ * for the edit itself).
+ */
+data class PendingEdit(
+    val message: ChatMessage,
+    val content: String,
+    val images: List<String>,
+    val discardCount: Int,
+)
+
 sealed interface ThreadUiState {
     data object Loading : ThreadUiState
 
@@ -91,6 +105,16 @@ sealed interface ThreadUiState {
         val sending: Boolean = false,
         /** Surfaced once and dismissed — a 409, a failed Stop, an unreadable photo. */
         val actionError: String? = null,
+        /** Confirm-before-delete (F06-R2, F00-R9). Null until Delete is tapped in the menu. */
+        val pendingDelete: ChatMessage? = null,
+        /**
+         * The composer is prefilled with this message's text/images and Send
+         * now means "edit and resend" (F06-R3). Only ever a user message —
+         * the server rejects editing an assistant one.
+         */
+        val editingMessage: ChatMessage? = null,
+        /** Confirm-before-edit-and-resend, holding the exact discard count. */
+        val pendingEdit: PendingEdit? = null,
     ) : ThreadUiState {
 
         /**

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
@@ -8,7 +8,9 @@ import com.hpz.llmdockchat.core.net.appError
 import com.hpz.llmdockchat.core.prefs.DraftStore
 import com.hpz.llmdockchat.data.ChatRepository
 import com.hpz.llmdockchat.data.model.ArtifactRecord
+import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
+import com.hpz.llmdockchat.data.model.MessageRole
 import com.hpz.llmdockchat.data.model.ParseWarning
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -39,6 +41,10 @@ class ThreadViewModel(
     val state: StateFlow<ThreadUiState> = _state.asStateFlow()
 
     private var streamJob: Job? = null
+
+    /** What the composer held before [beginEdit] overwrote it, restored by [cancelEdit]. */
+    private var composerBeforeEdit: String = ""
+    private var attachmentsBeforeEdit: List<String> = emptyList()
 
     fun load() {
         viewModelScope.launch {
@@ -166,12 +172,140 @@ class ThreadViewModel(
         loaded()?.let { _state.value = it.copy(actionError = message) }
     }
 
+    // -- delete (F06-R2) -------------------------------------------------------
+
+    /** Opens the confirm. The menu itself hides Delete while a run is active; this is the second guard. */
+    fun requestDelete(message: ChatMessage) {
+        val current = loaded() ?: return
+        if (current.runActive) return
+        _state.value = current.copy(pendingDelete = message)
+    }
+
+    /** No request — the confirm's whole point is that cancelling touches nothing. */
+    fun cancelDelete() {
+        loaded()?.let { _state.value = it.copy(pendingDelete = null) }
+    }
+
+    /**
+     * The message is **not** removed optimistically — only a refetch after a
+     * confirmed 200 does that (F06-R2's second criterion: a 409 must show the
+     * server's message, not a row that quietly vanished and came back).
+     */
+    fun confirmDelete() {
+        val current = loaded() ?: return
+        val target = current.pendingDelete ?: return
+        _state.value = current.copy(pendingDelete = null)
+        viewModelScope.launch {
+            repository.deleteMessage(conversationId, target.id).fold(
+                onSuccess = { reloadConversation() },
+                onFailure = { failure ->
+                    loaded()?.let { _state.value = it.copy(actionError = failure.appError.displayMessage) }
+                },
+            )
+        }
+    }
+
+    // -- edit and resend (F06-R3) ----------------------------------------------
+
+    /**
+     * The menu hides this action on an assistant message; this is the second
+     * guard (the server would 400 it anyway — F06-R3's fourth criterion).
+     */
+    fun beginEdit(message: ChatMessage) {
+        if (message.role != MessageRole.USER) return
+        val current = loaded() ?: return
+        if (current.runActive) return
+        composerBeforeEdit = current.composer
+        attachmentsBeforeEdit = current.attachments
+        _state.value = current.copy(
+            editingMessage = message,
+            composer = message.content,
+            attachments = message.images,
+            pendingEdit = null,
+            actionError = null,
+        )
+    }
+
+    /** Leaves edit mode and restores whatever was in the composer before it started. No request. */
+    fun cancelEdit() {
+        val current = loaded() ?: return
+        if (current.editingMessage == null) return
+        _state.value = current.copy(
+            editingMessage = null,
+            pendingEdit = null,
+            composer = composerBeforeEdit,
+            attachments = attachmentsBeforeEdit,
+        )
+        drafts.save(conversationId, composerBeforeEdit)
+    }
+
+    /**
+     * Send, while editing, opens the confirm instead of sending. [discardCount]
+     * is computed from what this client already has loaded — verified against
+     * the server's own truncation in `ThreadEditAndResendTest`.
+     */
+    fun requestEditConfirm() {
+        val current = loaded() ?: return
+        val target = current.editingMessage ?: return
+        if (current.composer.isBlank() && current.attachments.isEmpty()) return
+        _state.value = current.copy(
+            pendingEdit = PendingEdit(
+                message = target,
+                content = current.composer.trim(),
+                images = current.attachments,
+                discardCount = current.thread.messages.count { it.seq > target.seq },
+            ),
+        )
+    }
+
+    /** Stays in edit mode; only the confirm closes. No request. */
+    fun cancelEditConfirm() {
+        loaded()?.let { _state.value = it.copy(pendingEdit = null) }
+    }
+
+    /**
+     * `PUT …/messages/<id>` truncates from [PendingEdit.message]'s position on
+     * the server *before* the run even starts, so the local copy is truncated
+     * here too rather than left to show stale turns under the new answer for
+     * the length of the stream. If the request is rejected before any frame
+     * arrives — a 409, someone else started a run in between — [finishRun]
+     * refetches to undo this rather than trust the rollback to be correct on
+     * its own (F06-R3's last criterion).
+     */
+    fun confirmEdit() {
+        val current = loaded() ?: return
+        val edit = current.pendingEdit ?: return
+        val pending = PendingUserMessage(edit.content, edit.images)
+        val messagesBeforeEdit = current.thread.messages
+        _state.value = current.copy(
+            pendingEdit = null,
+            editingMessage = null,
+            composer = "",
+            attachments = emptyList(),
+            sending = true,
+            actionError = null,
+            thread = ThreadState(
+                messages = messagesBeforeEdit.filter { it.seq < edit.message.seq },
+                streaming = StreamingTurn(userMessage = pending),
+            ),
+        )
+        drafts.clear(conversationId)
+
+        collectRun(
+            flow = repository.editAndResend(conversationId, edit.message.id, pending.content, pending.images),
+            restoreOnEarlyFailure = pending,
+            titleBefore = current.conversation.title,
+            messagesBeforeEdit = messagesBeforeEdit,
+        )
+    }
+
     // -- the stream ----------------------------------------------------------
 
     private fun collectRun(
         flow: Flow<RunEvent>,
         restoreOnEarlyFailure: PendingUserMessage?,
         titleBefore: String,
+        messagesBeforeEdit: List<ChatMessage>? = null,
     ) {
         streamJob?.cancel()
         streamJob = viewModelScope.launch {
@@ -244,6 +378,7 @@ class ThreadViewModel(
                 failureMessage = failureMessage,
                 restoreOnEarlyFailure = restoreOnEarlyFailure,
                 expectTitle = !titleFrameSeen && titleBefore == UNTITLED,
+                messagesBeforeEdit = messagesBeforeEdit,
             )
         }
     }
@@ -259,6 +394,7 @@ class ThreadViewModel(
         failureMessage: String?,
         restoreOnEarlyFailure: PendingUserMessage?,
         expectTitle: Boolean,
+        messagesBeforeEdit: List<ChatMessage>? = null,
     ) {
         val current = loaded()
 
@@ -268,14 +404,25 @@ class ThreadViewModel(
             // back, so dropping `streaming` leaves no phantom turn behind, and
             // the text goes back in the composer rather than vanishing.
             val restored = restoreOnEarlyFailure?.content.orEmpty()
-            _state.value = (current ?: return).copy(
+            val loadedCurrent = current ?: return
+            // `confirmEdit` truncated `messages` locally on the assumption the
+            // request would succeed. A rejection here means the server never
+            // touched anything (F06-R3's last criterion), so that truncation
+            // has to come back — a refetch proves it rather than trusting the
+            // in-memory rollback to be right on its own.
+            val messages = if (messagesBeforeEdit != null) {
+                repository.load(conversationId).getOrNull()?.messages ?: messagesBeforeEdit
+            } else {
+                loadedCurrent.thread.messages
+            }
+            _state.value = loadedCurrent.copy(
                 sending = false,
-                thread = current.thread.copy(streaming = null),
-                composer = current.composer.ifBlank { restored },
-                attachments = current.attachments.ifEmpty { restoreOnEarlyFailure?.images.orEmpty() },
+                thread = loadedCurrent.thread.copy(streaming = null, messages = messages),
+                composer = loadedCurrent.composer.ifBlank { restored },
+                attachments = loadedCurrent.attachments.ifEmpty { restoreOnEarlyFailure?.images.orEmpty() },
                 actionError = error.appError.displayMessage,
             )
-            if (current.composer.isBlank() && restored.isNotBlank()) drafts.save(conversationId, restored)
+            if (loadedCurrent.composer.isBlank() && restored.isNotBlank()) drafts.save(conversationId, restored)
             return
         }
 

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ChatRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ChatRepositoryTest.kt
@@ -244,6 +244,36 @@ class ChatRepositoryTest {
         assertTrue(events.filterIsInstance<RunEvent.Delta>().first().reasoning.length > 200)
     }
 
+    // -- delete (F06) ----------------------------------------------------------
+
+    @Test
+    fun `delete DELETEs the message path`() = runTest {
+        server.enqueue(MockResponse.Builder().body("""{"ok": true}""").build())
+
+        repository.deleteMessage("c1", "m2").getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/chat/conversations/c1/messages/m2", request.url.encodedPath)
+    }
+
+    /** The server refuses a delete while a run is active in that conversation. */
+    @Test
+    fun `a 409 on delete fails with the server's message`() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(409)
+                .body("""{"error": "Cannot delete a message while a run is active"}""")
+                .build(),
+        )
+
+        val failure = repository.deleteMessage("c1", "m2").exceptionOrNull()
+
+        val http = (failure as ApiException).error as AppError.Http
+        assertEquals(409, http.status)
+        assertEquals("Cannot delete a message while a run is active", http.message)
+    }
+
     // -- cancel --------------------------------------------------------------
 
     @Test

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
@@ -1,0 +1,380 @@
+package com.hpz.llmdockchat.feature.thread
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.hpz.llmdockchat.core.auth.Reauthenticator
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiException
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.SessionAuthenticator
+import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.model.ChatMessage
+import com.hpz.llmdockchat.data.model.MessageRole
+import com.hpz.llmdockchat.testing.FakeDraftStore
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import com.hpz.llmdockchat.testing.readFixture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Delete and edit-and-resend (F06-R2, F06-R3): the confirm-then-request shape,
+ * the two 409 paths (delete refused mid-run, edit rejected after the local
+ * truncation already ran), and the discard count against a four-message
+ * fixture recorded the same way the F04 ones were.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThreadMessageActionsTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var transport: FakeSseTransport
+    private lateinit var drafts: FakeDraftStore
+    private lateinit var repository: ChatRepository
+    private val store = ViewModelStore()
+    private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "actions-main") }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainExecutor.asCoroutineDispatcher())
+        server = MockWebServer()
+        server.start()
+        transport = FakeSseTransport()
+        drafts = FakeDraftStore()
+        val urlStore = FakeServerUrlStore(baseUrl(server.url("/").toString()))
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .authenticator(SessionAuthenticator(FakeTokenStore("totp-test"), SessionState(), Reauthenticator.NoCredential))
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+        repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+    }
+
+    @After
+    fun tearDown() {
+        store.clear()
+        server.close()
+        Dispatchers.resetMain()
+        mainExecutor.shutdownNow()
+    }
+
+    private fun conversation(fixture: String = "conversation_multi_turn.json") =
+        server.enqueue(MockResponse.Builder().body(readFixture(fixture)).build())
+
+    private fun viewModel(): ThreadViewModel = ViewModelProvider.create(
+        store,
+        viewModelFactory {
+            initializer {
+                ThreadViewModel(
+                    conversationId = CONVERSATION_ID,
+                    repository = repository,
+                    drafts = drafts,
+                    coalesceWindowMs = 0,
+                    titleSettleDelayMs = 1,
+                )
+            }
+        },
+    )[ThreadViewModel::class]
+
+    private fun threadTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }
+
+    private suspend fun ThreadViewModel.awaitLoaded(): ThreadUiState.Loaded =
+        withTimeout(10_000) { state.first { it is ThreadUiState.Loaded } as ThreadUiState.Loaded }
+
+    private suspend fun ThreadViewModel.awaitState(
+        predicate: (ThreadUiState.Loaded) -> Boolean,
+    ): ThreadUiState.Loaded = withTimeout(10_000) {
+        state.first { it is ThreadUiState.Loaded && predicate(it) } as ThreadUiState.Loaded
+    }
+
+    private fun ThreadUiState.Loaded.message(id: String): ChatMessage = thread.messages.single { it.id == id }
+
+    // -- F06-R2 · delete -------------------------------------------------------
+
+    @Test
+    fun `deleting removes the message and it stays gone after a refetch`() = threadTest {
+        conversation()
+        server.enqueue(MockResponse.Builder().body("""{"ok": true}""").build())
+        conversation("conversation_multi_turn_after_delete.json") // the reload confirmDelete triggers
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+        server.takeRequest() // drain the initial load
+
+        viewModel.requestDelete(loaded.message("m2"))
+        assertNotNull(viewModel.awaitState { it.pendingDelete != null }.pendingDelete)
+        viewModel.confirmDelete()
+
+        val settled = viewModel.awaitState { it.thread.messages.size == 3 }
+        assertTrue(settled.thread.messages.none { it.id == "m2" })
+        assertNull(settled.pendingDelete)
+
+        val deleteRequest = withTimeout(10_000) { server.takeRequest() }
+        assertEquals("DELETE", deleteRequest.method)
+        assertEquals("/api/chat/conversations/$CONVERSATION_ID/messages/m2", deleteRequest.url.encodedPath)
+    }
+
+    /**
+     * The server's 409 guard against deleting mid-run — F06-R2's second
+     * criterion. The message must not vanish and reappear; it must never have
+     * moved, because nothing is removed until the request succeeds.
+     */
+    @Test
+    fun `a 409 on delete shows the server's message and removes nothing`() = threadTest {
+        conversation()
+        server.enqueue(
+            MockResponse.Builder()
+                .code(409)
+                .body("""{"error": "Cannot delete a message while a run is active"}""")
+                .build(),
+        )
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.requestDelete(loaded.message("m2"))
+        viewModel.confirmDelete()
+
+        val state = viewModel.awaitState { it.actionError != null }
+        assertEquals("Cannot delete a message while a run is active", state.actionError)
+        assertEquals(4, state.thread.messages.size)
+        assertTrue(state.thread.messages.any { it.id == "m2" })
+    }
+
+    /** The ViewModel's own guard — the menu is the first one, this is the second (F06-R2's third criterion). */
+    @Test
+    fun `requestDelete is refused while a run is active, so confirming does nothing`() = threadTest {
+        conversation()
+        transport.payloads = listOf("""{"type": "run_started", "run_id": "run-1"}""")
+        transport.stayOpen = true
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("another turn")
+        viewModel.send()
+        val running = viewModel.awaitState { it.runActive }
+
+        viewModel.requestDelete(running.message("m2"))
+
+        // No confirm was opened, so nothing to confirm — and no DELETE request follows.
+        assertNull(viewModel.state.value.let { (it as ThreadUiState.Loaded).pendingDelete })
+        val requestsBefore = server.requestCount
+        viewModel.confirmDelete()
+        assertEquals(requestsBefore, server.requestCount)
+    }
+
+    @Test
+    fun `cancelling the delete confirm makes no request`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+        val requestsBefore = server.requestCount
+
+        viewModel.requestDelete(loaded.message("m2"))
+        viewModel.awaitState { it.pendingDelete != null }
+        viewModel.cancelDelete()
+
+        val settled = viewModel.awaitState { it.pendingDelete == null }
+        assertEquals(4, settled.thread.messages.size)
+        assertEquals(requestsBefore, server.requestCount)
+    }
+
+    // -- F06-R3 · edit and resend -----------------------------------------------
+
+    /**
+     * `seq >= msg.seq` is what the server deletes (`db.py:create_run_with_user_message`);
+     * the message itself survives in edited form, so the count shown to the
+     * user is everything **strictly after** it — three messages when editing
+     * the first turn of this four-message fixture.
+     */
+    @Test
+    fun `the discard count is every message strictly after the edited one`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.beginEdit(loaded.message("m1"))
+        viewModel.onComposerChange("What is a diode?")
+        viewModel.requestEditConfirm()
+
+        val edit = viewModel.awaitState { it.pendingEdit != null }.pendingEdit!!
+        assertEquals("m1", edit.message.id)
+        assertEquals(3, edit.discardCount)
+    }
+
+    @Test
+    fun `editing the last user turn before its reply discards exactly one message`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.beginEdit(loaded.message("m3"))
+        viewModel.onComposerChange("Who patented it?")
+        viewModel.requestEditConfirm()
+
+        assertEquals(1, viewModel.awaitState { it.pendingEdit != null }.pendingEdit!!.discardCount)
+    }
+
+    /** Only a user message may be edited — the ViewModel's own guard, behind the menu's (F06-R3's fourth criterion). */
+    @Test
+    fun `beginEdit on an assistant message is refused`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.beginEdit(loaded.message("m2"))
+
+        assertNull(viewModel.state.value.let { (it as ThreadUiState.Loaded).editingMessage })
+    }
+
+    @Test
+    fun `editing a message discards everything after it and streams a new answer from the edit`() = threadTest {
+        conversation()
+        transport.payloads = listOf(
+            """{"type": "run_started", "run_id": "run-2"}""",
+            """{"choices":[{"index":0,"delta":{"content":"A diode is"}}]}""",
+            "[DONE]",
+            """{"type": "message_saved", "message_id": "m5", "seq": 2}""",
+        )
+        conversation("conversation_multi_turn_after_edit.json") // the refetch after the run completes
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.beginEdit(loaded.message("m1"))
+        viewModel.onComposerChange("What is a diode?")
+        viewModel.requestEditConfirm()
+        viewModel.awaitState { it.pendingEdit != null }
+        viewModel.confirmEdit()
+
+        // Truncated locally before the first frame even lands — no stale
+        // m2/m3/m4 shown underneath the new streaming answer.
+        val truncated = viewModel.awaitState { it.thread.streaming?.userMessage != null }
+        assertTrue(truncated.thread.messages.isEmpty())
+        assertEquals("What is a diode?", truncated.thread.streaming?.userMessage?.content)
+        assertNull(truncated.editingMessage)
+
+        val settled = viewModel.awaitState { it.thread.streaming == null }
+        assertEquals(2, settled.thread.messages.size)
+        assertEquals("What is a diode?", settled.thread.messages[0].content)
+        assertEquals(MessageRole.ASSISTANT, settled.thread.messages[1].role)
+
+        // `editAndResend` is the stream transport, not a plain JSON call — see
+        // `ChatRepositoryTest` for the PUT method/path assertion against a real
+        // request; what belongs here is that this ViewModel actually invoked it
+        // for the edited message, not `send`.
+        val putRequest = transport.requests.last()
+        assertEquals("PUT", putRequest.method)
+        assertEquals("/api/chat/conversations/$CONVERSATION_ID/messages/m1", putRequest.path)
+    }
+
+    /**
+     * The truncation in [ThreadViewModel.confirmEdit] is optimistic — applied
+     * before the server has actually accepted the edit. A 409 means it
+     * accepted nothing, so the rollback has to prove that by asking the
+     * server again rather than trusting its own arithmetic (F06-R3's last
+     * criterion).
+     */
+    @Test
+    fun `a 409 on edit leaves the thread intact, verified by refetch`() = threadTest {
+        conversation()
+        transport.failWith = ApiException(
+            AppError.Http(409, "A run is already active for this conversation", fromServer = true),
+        )
+        conversation() // the refetch confirmEdit's early-failure path issues to undo the local truncation
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+
+        viewModel.beginEdit(loaded.message("m1"))
+        viewModel.onComposerChange("What is a diode?")
+        viewModel.requestEditConfirm()
+        viewModel.awaitState { it.pendingEdit != null }
+        viewModel.confirmEdit()
+
+        val state = viewModel.awaitState { it.actionError != null }
+        assertEquals(4, state.thread.messages.size)
+        assertTrue(state.thread.messages.any { it.id == "m1" && it.content == "What is a transistor?" })
+        assertTrue(state.thread.messages.any { it.id == "m2" })
+        assertTrue(state.thread.messages.any { it.id == "m3" })
+        assertTrue(state.thread.messages.any { it.id == "m4" })
+        assertNull(state.thread.streaming)
+        assertFalse(state.runActive)
+    }
+
+    @Test
+    fun `cancelling the edit confirm leaves the thread byte-identical and sends no request`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+        val requestsBefore = server.requestCount
+
+        viewModel.beginEdit(loaded.message("m1"))
+        viewModel.onComposerChange("What is a diode?")
+        viewModel.requestEditConfirm()
+        viewModel.awaitState { it.pendingEdit != null }
+        viewModel.cancelEditConfirm()
+
+        val settled = viewModel.awaitState { it.pendingEdit == null }
+        assertEquals(4, settled.thread.messages.size)
+        // Still in edit mode — only the confirm was dismissed.
+        assertEquals("m1", settled.editingMessage?.id)
+        assertEquals(requestsBefore, server.requestCount)
+    }
+
+    @Test
+    fun `cancelling the edit itself restores the composer and sends no request`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("a half-written question")
+        val loaded = viewModel.awaitState { it.composer == "a half-written question" }
+        val requestsBefore = server.requestCount
+
+        viewModel.beginEdit(loaded.message("m1"))
+        assertEquals("What is a transistor?", viewModel.awaitState { it.editingMessage != null }.composer)
+
+        viewModel.cancelEdit()
+
+        val settled = viewModel.awaitState { it.editingMessage == null }
+        assertEquals("a half-written question", settled.composer)
+        assertEquals(4, settled.thread.messages.size)
+        assertEquals(requestsBefore, server.requestCount)
+    }
+
+    private companion object {
+        const val CONVERSATION_ID = "39dc7f47-91da-4a0f-b731-59f507a12c1b"
+    }
+}

--- a/android/src/app/src/test/resources/fixtures/conversation_multi_turn.json
+++ b/android/src/app/src/test/resources/fixtures/conversation_multi_turn.json
@@ -1,0 +1,64 @@
+{
+  "id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+  "title": "F06-TEST multi turn",
+  "main_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+  "sidekick_service": null,
+  "parent_conversation_id": null,
+  "selected_text": null,
+  "project_id": null,
+  "mcp_servers": [],
+  "active_run": null,
+  "last_run": {
+    "id": "035d944d-5105-451c-96d6-0d84d831a128",
+    "status": "completed",
+    "error": null
+  },
+  "created_at": "2026-07-25T05:54:19Z",
+  "updated_at": "2026-07-25T05:54:40Z",
+  "messages": [
+    {
+      "id": "m1",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "What is a transistor?",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 1,
+      "created_at": "2026-07-25T05:54:20Z"
+    },
+    {
+      "id": "m2",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "assistant",
+      "content": "A transistor is a semiconductor device used to amplify or switch signals.",
+      "reasoning_content": null,
+      "model_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+      "images": [],
+      "seq": 2,
+      "created_at": "2026-07-25T05:54:25Z"
+    },
+    {
+      "id": "m3",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "Who invented it?",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 3,
+      "created_at": "2026-07-25T05:54:30Z"
+    },
+    {
+      "id": "m4",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "assistant",
+      "content": "It was invented at Bell Labs in 1947.",
+      "reasoning_content": null,
+      "model_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+      "images": [],
+      "seq": 4,
+      "created_at": "2026-07-25T05:54:35Z"
+    }
+  ]
+}

--- a/android/src/app/src/test/resources/fixtures/conversation_multi_turn_after_delete.json
+++ b/android/src/app/src/test/resources/fixtures/conversation_multi_turn_after_delete.json
@@ -1,0 +1,53 @@
+{
+  "id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+  "title": "F06-TEST multi turn",
+  "main_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+  "sidekick_service": null,
+  "parent_conversation_id": null,
+  "selected_text": null,
+  "project_id": null,
+  "mcp_servers": [],
+  "active_run": null,
+  "last_run": {
+    "id": "035d944d-5105-451c-96d6-0d84d831a128",
+    "status": "completed",
+    "error": null
+  },
+  "created_at": "2026-07-25T05:54:19Z",
+  "updated_at": "2026-07-25T05:54:41Z",
+  "messages": [
+    {
+      "id": "m1",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "What is a transistor?",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 1,
+      "created_at": "2026-07-25T05:54:20Z"
+    },
+    {
+      "id": "m3",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "Who invented it?",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 3,
+      "created_at": "2026-07-25T05:54:30Z"
+    },
+    {
+      "id": "m4",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "assistant",
+      "content": "It was invented at Bell Labs in 1947.",
+      "reasoning_content": null,
+      "model_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+      "images": [],
+      "seq": 4,
+      "created_at": "2026-07-25T05:54:35Z"
+    }
+  ]
+}

--- a/android/src/app/src/test/resources/fixtures/conversation_multi_turn_after_edit.json
+++ b/android/src/app/src/test/resources/fixtures/conversation_multi_turn_after_edit.json
@@ -1,0 +1,42 @@
+{
+  "id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+  "title": "F06-TEST multi turn",
+  "main_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+  "sidekick_service": null,
+  "parent_conversation_id": null,
+  "selected_text": null,
+  "project_id": null,
+  "mcp_servers": [],
+  "active_run": null,
+  "last_run": {
+    "id": "6c1e8b1a-0000-0000-0000-000000000001",
+    "status": "completed",
+    "error": null
+  },
+  "created_at": "2026-07-25T05:54:19Z",
+  "updated_at": "2026-07-25T05:54:50Z",
+  "messages": [
+    {
+      "id": "m1-edited",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "What is a diode?",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 1,
+      "created_at": "2026-07-25T05:54:45Z"
+    },
+    {
+      "id": "m5",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "assistant",
+      "content": "A diode is a two-terminal device that conducts current in one direction.",
+      "reasoning_content": null,
+      "model_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+      "images": [],
+      "seq": 2,
+      "created_at": "2026-07-25T05:54:49Z"
+    }
+  ]
+}


### PR DESCRIPTION
Long-press menu, delete, edit-and-resend, copy and share. Implemented by one agent, independently reviewed and driven on device by a second.

## The destructive path

Edit-and-resend cannot be undone: `create_run_with_user_message` (`chat/db.py:903`) does `DELETE … WHERE seq >= msg.seq` and inserts a fresh row. So the confirm names a number — *"This will discard N messages after it"* — computed strictly-after, because the edited message is replaced rather than lost from the user's point of view.

The reviewer verified that count **against the live backend**, not just the tests: editing the first message of a 4-message thread discarded exactly 3, editing the last user turn discarded exactly 1, both confirmed by refetch. An off-by-one here would mean the confirm lies about destroying someone's conversation.

Delete is guarded three ways — hidden while a run is active, refused again in the ViewModel, and never applied to the list until the server confirms, so the mid-run 409 cannot leave an optimistically removed row. A 409 on edit **refetches to prove** nothing was truncated rather than trusting a local rollback, and the same branch covers a network failure after the local pre-truncation but before the stream opens.

## The gesture trade

F05 wrapped every message in an always-on `SelectionContainer`. Its long-press-to-select and this feature's long-press-to-menu compete for the same pointer stream, and there is no reliable way to referee between them from outside Compose's selection internals.

Selection is now **opt-in per message**: long-press → Select text → drag → Done. Exactly one detector is ever mounted, so neither gesture is ever ambiguous. It costs three taps on a common action, and the reviewer's judgment — which I agree with — is that a permanently-discoverable four-tap flow beats intermittent gesture-arbitration bugs on a single-user app. Flagged to the owner as a taste call they can overrule.

## Verified live

Both gestures including **selection inside a fenced code block** (a gap the implementer had left as mechanism-only), menu contents differing correctly by role, cancel-at-every-stage leaving the thread byte-identical by refetch, and a full edit-and-resend round trip streaming a new answer.

Recorded as behaviour, not bugs: deleting a user message leaves its assistant reply orphaned (the server does a single-row delete and the spec never asked for cascading). Left for a real thumb: drag-select ergonomics inside a horizontally-scrolling code block, and long-press timing.

319 tests, all green.