### PR TITLE
F07: model selection

### DIFF
--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -147,8 +147,34 @@ token. Then send `Authorization: Bearer totp-…` on every other call.
 
 ### Test fixtures
 
-- Chat-capable model for testing: **`llamacpp-gemma-4-26b-a4b-it-q8`**,
-  running on `:3301`, `kind=chat` — it passes the F07-R1 picker filter.
+- Chat-capable model for testing: **`llamacpp-mimo-v2-5-q4`**, running on
+  `:3307`, `kind=chat` — it passes the F07-R1 picker filter. It replaced
+  `llamacpp-gemma-4-26b-a4b-it-q8` (which was on `:3301`) on 2026-07-25,
+  so any older thread or fixture naming gemma points at a model that is
+  no longer running. **Confirm what is actually up before assuming** —
+  the owner swaps this, and the port changes with the model. Run from the
+  repo root (`dev.sh token` returns empty elsewhere, and the call then
+  silently 401s):
+
+  ```
+  TOKEN=$(android/scripts/dev.sh token)
+  curl -s -H "Authorization: Bearer $TOKEN" localhost:3399/api/services \
+    | python3 -c 'import sys,json
+  for s in json.load(sys.stdin)["services"]:
+      if s.get("status") == "running":
+          print(s["name"], s.get("host_port"), s.get("kind"))'
+  ```
+
+- **The port field is `host_port`, not `port`.** `GET /api/services`
+  returns a *list* under `services`, and each entry carries `host_port`
+  (an int) plus the raw Docker `ports` map. There is no `port` key —
+  reading one yields `None` and looks like "the API doesn't expose the
+  port". `services.json` is the other way round: keyed by name, with
+  `port`. F07-R1 renders `host_port`.
+- **`kind=chat` alone is not the picker filter.** `open-webui` is
+  `running` with `kind=chat` and is not a model. The name-prefix test
+  (`llamacpp-`/`vllm-`/`ds4-`) in F07-R1 is what excludes it — don't drop
+  it as redundant.`
 - **Creating and deleting conversations is fine.** They share `chat.db`
   with the web UI, so prefix test threads to make them identifiable and
   clean up afterwards.

--- a/android/docs/F07-model-selection.md
+++ b/android/docs/F07-model-selection.md
@@ -124,3 +124,51 @@ None.
 - Editing the curated OpenRouter list (dashboard only).
 - Typing an arbitrary `openrouter:` model id by hand. The picker is the
   only path in v1, even though the server would accept any id.
+
+## Verification notes
+
+**Two R1 criteria are outstanding, both needing a container transition
+this project's agents are forbidden to make.** Everything else in R1, R2,
+R4 and R6 is verified on device; R3 and R5 are verified apart from the
+sub-criteria named below.
+
+| Outstanding | Why it could not be closed |
+|---|---|
+| R1 · live add on start elsewhere | No agent may start or stop a container. JVM evidence only: `ServicesStreamRepositoryTest` (merge + reconnect) and `NewChatViewModelTest`'s delta-updates-the-list test. |
+| R1 · "nothing is running" empty state | `llamacpp-mimo-v2-5-q4` is the rig's only running chat-capable service and cannot be stopped to force the branch. **No test at all** — a Compose `if (running.isEmpty())` branch with no Compose UI test infrastructure in this project. |
+| R3 · group hidden when unconfigured | Needs a dashboard with no `OPENROUTER_API_KEY`. |
+
+**One owner action closes both R1 items:** open the model picker, stop
+`llamacpp-mimo-v2-5-q4`, watch the row grey out and the empty state
+appear, then start it again and watch it return — all without touching
+refresh.
+
+**The engine-prefix filter is load-bearing, not redundant with `kind`.**
+`open-webui` is genuinely `running` with `kind: "chat"` on this rig, so
+`kind` alone would put Open WebUI in the model picker. `isChatCapable` is
+`engine != Engine.UNKNOWN && (kind.isBlank() || kind == "chat")`; the
+`Engine.UNKNOWN` half is what excludes it. Verified end to end on device,
+and pinned by a named unit test. Do not "simplify" it away.
+
+**`kind` is defaulted, not required.** `isChatCapable` treats blank as
+chat, matching the web's `(kind || 'chat') === 'chat'` in
+`useRunningServices.js`. An earlier stricter `kind == "chat"` rejected
+services whose `kind` the dashboard omits.
+
+**`mergeServiceEvent` ignores a delta naming a service not already in the
+list.** Accepted, not a bug: a stopped or `not-created` service is
+already in the snapshot, so start/stop deltas update it in place. Only a
+service added to `services.json` *after* the snapshot is missed, and the
+delta frame carries no `kind`/`host_port`, so a new row could not be
+built from it without a refetch. It resolves on the next reconnect.
+
+**The delta frame shape is flat, and `favorite` is nested.**
+`dashboard/routes/services.py:services_stream` emits
+`{"type":"delta","service_name","status","action","container_id","timestamp"}`
+with `favorite` only ever inside an optional `metadata` object — not a
+top-level field. Keepalives are `: keepalive` SSE comments, already
+dropped by `SseFrameParser`.
+
+**The port field is `host_port`.** `GET /api/services` has no `port` key;
+reading one yields null. `services.json` is the opposite shape. See
+`android/CLAUDE.md`.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -180,7 +180,7 @@ Mark completed features `[DONE]` in the Status column.
 | F04 | Sending a turn and streaming the reply | [F04-chat-turn-and-streaming.md](F04-chat-turn-and-streaming.md) | 04, 06a | [DONE] |
 | F05 | Rendering assistant output | [F05-message-rendering.md](F05-message-rendering.md) | 05 | [DONE] |
 | F06 | Message actions | [F06-message-actions.md](F06-message-actions.md) | 06b | [DONE] |
-| F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [ ] |
+| F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [WIP] — two R1 criteria need a container transition, see the feature file |
 | F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [ ] |
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [ ] |
 | F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [ ] |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
@@ -37,6 +37,7 @@ import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.PromptsRepository
 import com.hpz.llmdockchat.data.ReachabilityRepository
 import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
@@ -110,6 +111,7 @@ class AppContainer(
     val conversationsRepository = ConversationsRepository(apiClient)
     val chatRepository = ChatRepository(apiClient, sseTransport)
     val servicesRepository = ServicesRepository(apiClient)
+    val servicesStreamRepository = ServicesStreamRepository(sseTransport)
     val promptsRepository = PromptsRepository(apiClient)
     val mcpServersRepository = McpServersRepository(apiClient)
     val openRouterModelsRepository = OpenRouterModelsRepository(apiClient)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
@@ -32,6 +32,9 @@ object Endpoints {
     const val PROMPTS = "/api/chat/prompts"
     const val MCP_SERVERS = "/api/chat/mcp-servers"
 
+    /** F07-R1's third criterion — a snapshot, then deltas as containers start/stop. */
+    const val SERVICES_STREAM = "/api/services/stream"
+
     /** Read-only from the phone (F03) — editing the curated list is desktop Tools-page work. */
     const val OPENROUTER_MODELS_SETTINGS = "/api/chat/settings/openrouter-models"
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/ServiceStreamEvent.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/ServiceStreamEvent.kt
@@ -1,0 +1,72 @@
+package com.hpz.llmdockchat.core.net
+
+import com.hpz.llmdockchat.data.dto.ServiceDto
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+
+/**
+ * One frame of `GET /api/services/stream` (F07-R1's third criterion), read the
+ * same way [parseFrame] reads a chat run — pure, total, dependency-light — but
+ * this is its own parser, not a reuse of [parseFrame]: the two endpoints share
+ * nothing but "SSE" (`dashboard/routes/services.py:services_stream`, not
+ * `chat/run_manager.py`).
+ *
+ * [Delta] deliberately carries only [serviceName], [status] and [favorite] —
+ * the three fields a picker actually needs to update in place
+ * (`ComposeManagerEvent`'s `action`/`container_id`/`timestamp` are not read).
+ * Neither this type nor [Snapshot] (via [ServiceDto]) ever has a field for
+ * `api_key`, so one cannot leak through here even by accident (F07-R6).
+ */
+sealed interface ServiceStreamEvent {
+
+    /** Always the first frame on connect — the full service list as it stands right now. */
+    data class Snapshot(val services: List<ServiceDto>) : ServiceStreamEvent
+
+    /** A container's status changed, or its `favorite` flag did, elsewhere (dashboard or another client). */
+    data class Delta(val serviceName: String, val status: String?, val favorite: Boolean?) : ServiceStreamEvent
+
+    data class Error(val message: String) : ServiceStreamEvent
+
+    /** An unrecognised `type`, or a payload that is not JSON at all — never thrown, always this. */
+    data class Unknown(val raw: String) : ServiceStreamEvent
+}
+
+private val ServiceStreamJson = Json { ignoreUnknownKeys = true }
+
+/** Pure, total, no IO — same contract as [parseFrame]. Every input produces an event; nothing throws. */
+fun parseServiceStreamFrame(payload: String): ServiceStreamEvent {
+    val root = runCatching { ServiceStreamJson.parseToJsonElement(payload.trim()) }.getOrNull() as? JsonObject
+        ?: return ServiceStreamEvent.Unknown(payload)
+
+    return when (root.string("type")) {
+        "snapshot" -> root.snapshotFrame(payload)
+        "delta" -> root.deltaFrame(payload)
+        "error" -> ServiceStreamEvent.Error(root.string("message") ?: "Unknown error")
+        else -> ServiceStreamEvent.Unknown(payload)
+    }
+}
+
+private fun JsonObject.snapshotFrame(payload: String): ServiceStreamEvent {
+    val data = this["data"] as? JsonObject ?: return ServiceStreamEvent.Unknown(payload)
+    val servicesElement = data["services"] ?: return ServiceStreamEvent.Unknown(payload)
+    val services = runCatching {
+        ServiceStreamJson.decodeFromJsonElement(ListSerializer(ServiceDto.serializer()), servicesElement)
+    }.getOrNull() ?: return ServiceStreamEvent.Unknown(payload)
+    return ServiceStreamEvent.Snapshot(services)
+}
+
+private fun JsonObject.deltaFrame(payload: String): ServiceStreamEvent {
+    val name = string("service_name") ?: return ServiceStreamEvent.Unknown(payload)
+    val metadata = this["metadata"] as? JsonObject
+    return ServiceStreamEvent.Delta(
+        serviceName = name,
+        status = string("status"),
+        favorite = (metadata?.get("favorite") as? JsonPrimitive)?.booleanOrNull,
+    )
+}
+
+private fun JsonObject.string(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ChatRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ChatRepository.kt
@@ -11,8 +11,10 @@ import com.hpz.llmdockchat.core.net.parseFrame
 import com.hpz.llmdockchat.data.dto.CancelRunRequestDto
 import com.hpz.llmdockchat.data.dto.CancelRunResponseDto
 import com.hpz.llmdockchat.data.dto.ConversationDetailDto
+import com.hpz.llmdockchat.data.dto.ConversationIdResponseDto
 import com.hpz.llmdockchat.data.dto.DeleteMessageResponseDto
 import com.hpz.llmdockchat.data.dto.SendMessageRequestDto
+import com.hpz.llmdockchat.data.dto.UpdateMainServiceRequestDto
 import com.hpz.llmdockchat.data.mapper.toDomain
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import kotlinx.coroutines.flow.Flow
@@ -113,6 +115,22 @@ class ChatRepository(
             method = "DELETE",
             path = Endpoints.conversationMessage(conversationId, messageId),
             deserializer = DeleteMessageResponseDto.serializer(),
+        )
+        Unit
+    }
+
+    /**
+     * `PUT /api/chat/conversations/<id>` with `main_service` (F07-R4). The
+     * caller guards against an active run — the server has no special-cased
+     * rejection for this field, so the guard is entirely client-side, same as
+     * F06-R3's edit-while-a-run-is-active guard.
+     */
+    suspend fun updateMainService(conversationId: String, mainService: String): Result<Unit> = apiCall {
+        api.request(
+            method = "PUT",
+            path = Endpoints.conversation(conversationId),
+            deserializer = ConversationIdResponseDto.serializer(),
+            body = ApiJson.encodeToString(UpdateMainServiceRequestDto(mainService = mainService)),
         )
         Unit
     }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesStreamRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesStreamRepository.kt
@@ -1,0 +1,84 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.Endpoints
+import com.hpz.llmdockchat.core.net.ServiceStreamEvent
+import com.hpz.llmdockchat.core.net.SseTransport
+import com.hpz.llmdockchat.core.net.StreamRequest
+import com.hpz.llmdockchat.core.net.parseServiceStreamFrame
+import com.hpz.llmdockchat.data.mapper.toDomain
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * The live `GET /api/services/stream` (F07-R1's third criterion, F00-R12):
+ * a snapshot on connect, then deltas as containers start or stop, or a
+ * favorite flag changes, anywhere — the dashboard, another client, this one.
+ *
+ * [F10] is expected to reuse this unchanged for the models list — everything
+ * here is generic over "the current service list", nothing specific to the
+ * model picker.
+ */
+class ServicesStreamRepository(private val transport: SseTransport) {
+
+    /**
+     * Emits the current service list every time it changes. Never completes on
+     * its own: a dropped connection (the server restarting, a network blip) is
+     * retried after [reconnectDelayMs] rather than surfaced as a flow failure,
+     * since the picker has nothing useful to show for "the stream hiccuped" —
+     * it just keeps the last list on screen until the reconnect lands.
+     */
+    fun stream(reconnectDelayMs: Long = RECONNECT_DELAY_MS): Flow<List<ServiceSummary>> = flow {
+        var current = emptyList<ServiceSummary>()
+        while (true) {
+            try {
+                transport.open(StreamRequest(path = Endpoints.SERVICES_STREAM))
+                    .collect { payload ->
+                        current = mergeServiceEvent(current, parseServiceStreamFrame(payload))
+                        emit(current)
+                    }
+            } catch (e: CancellationException) {
+                // The collector went away (the sheet closed, a downstream
+                // `take`/screen navigation) — not a dropped connection. Must
+                // propagate, never be treated as "reconnect": swallowing it
+                // here would keep this loop alive after its own job is
+                // already cancelled, spinning on `delay` forever.
+                throw e
+            } catch (e: Throwable) {
+                // A dropped connection — retried below rather than surfaced,
+                // since the picker has nothing better to show than the last
+                // list it had.
+            }
+            delay(reconnectDelayMs)
+        }
+    }
+
+    companion object {
+        const val RECONNECT_DELAY_MS = 2_000L
+    }
+}
+
+/**
+ * Pure and separately tested. A [ServiceStreamEvent.Snapshot] replaces
+ * [current] wholesale; a [ServiceStreamEvent.Delta] updates the one named
+ * service in place, leaving every other row untouched; [ServiceStreamEvent.Error]
+ * and [ServiceStreamEvent.Unknown] leave [current] as it was — an unrecognised
+ * frame is exactly the case a live picker must not go blank over.
+ */
+fun mergeServiceEvent(current: List<ServiceSummary>, event: ServiceStreamEvent): List<ServiceSummary> =
+    when (event) {
+        is ServiceStreamEvent.Snapshot -> event.services.map { it.toDomain() }
+        is ServiceStreamEvent.Delta -> current.map { service ->
+            if (service.name != event.serviceName) {
+                service
+            } else {
+                service.copy(
+                    status = event.status ?: service.status,
+                    favorite = event.favorite ?: service.favorite,
+                )
+            }
+        }
+        is ServiceStreamEvent.Error, is ServiceStreamEvent.Unknown -> current
+    }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ConversationDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ConversationDto.kt
@@ -81,3 +81,11 @@ data class ConversationIdResponseDto(val id: String = "")
  */
 @Serializable
 data class UpdateMcpServersRequestDto(@SerialName("mcp_servers_json") val mcpServersJson: String)
+
+/**
+ * `PUT /api/chat/conversations/<id>` body for switching a thread's model
+ * mid-conversation (F07-R4). Earlier messages are untouched — each already
+ * carries its own `model_service` — only the next turn is affected.
+ */
+@Serializable
+data class UpdateMainServiceRequestDto(@SerialName("main_service") val mainService: String)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
@@ -1,14 +1,22 @@
 package com.hpz.llmdockchat.data.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** One row of `GET /api/services` (`dashboard/docker_utils.py:get_docker_services`). Only the
- * fields F03's model picker needs. */
+/**
+ * One row of `GET /api/services` (`dashboard/docker_utils.py:get_docker_services`). Only the
+ * fields F03's and F07's model pickers need — in particular, no `api_key` field:
+ * the server includes one on every row, and the fastest way to guarantee it
+ * never reaches a screen or a log line (F07-R6) is to never give it a place
+ * to land.
+ */
 @Serializable
 data class ServiceDto(
     val name: String = "",
     val status: String = "",
     val kind: String = "",
+    @SerialName("host_port") val hostPort: Int = 0,
+    val favorite: Boolean = false,
 )
 
 @Serializable

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/NewChatMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/NewChatMapper.kt
@@ -9,7 +9,8 @@ import com.hpz.llmdockchat.data.model.McpServerInfo
 import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ServiceSummary
 
-fun ServiceDto.toDomain(): ServiceSummary = ServiceSummary(name = name, status = status, kind = kind)
+fun ServiceDto.toDomain(): ServiceSummary =
+    ServiceSummary(name = name, status = status, kind = kind, port = hostPort, favorite = favorite)
 
 fun PromptDto.toDomain(): ManagedPrompt = ManagedPrompt(id = id, name = name, sortOrder = sortOrder)
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceSummary.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceSummary.kt
@@ -1,10 +1,14 @@
 package com.hpz.llmdockchat.data.model
 
-/** A row of `GET /api/services` (F03, F10). */
+/** A row of `GET /api/services` (F03, F07, F10). */
 data class ServiceSummary(
     val name: String,
     val status: String,
     val kind: String,
+    /** `host_port` server-side — the port the picker shows (F07-R1). 0 when the server omitted it. */
+    val port: Int = 0,
+    /** Set on the dashboard; the phone only ever reads it (F07-R5). */
+    val favorite: Boolean = false,
 ) {
     val engine: Engine get() = ModelRef.Local(name).engine
 
@@ -15,8 +19,12 @@ data class ServiceSummary(
      * `open-webui` through (it isn't in `services.json`, so its `kind`
      * defaults to `"chat"`), and the prefix alone would let an embedding
      * service through.
+     *
+     * A blank `kind` counts as `"chat"` too — `useRunningServices.js` reads
+     * `(s.kind || 'chat') === kind` for exactly this reason (a snapshot from
+     * before the `kind` column existed must not filter everything out).
      */
-    val isChatCapable: Boolean get() = engine != Engine.UNKNOWN && kind == "chat"
+    val isChatCapable: Boolean get() = engine != Engine.UNKNOWN && (kind.isBlank() || kind == "chat")
 
     val isRunning: Boolean get() = status == "running"
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheet.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheet.kt
@@ -1,0 +1,216 @@
+package com.hpz.llmdockchat.feature.modelpicker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.Engine
+import com.hpz.llmdockchat.data.model.ModelOption
+import com.hpz.llmdockchat.data.model.ModelRef
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import com.hpz.llmdockchat.data.model.engine
+
+/**
+ * The model picker (F07), shared by [com.hpz.llmdockchat.feature.newchat.NewChatScreen]
+ * (choosing a model for a brand-new thread) and
+ * [com.hpz.llmdockchat.feature.thread.ThreadScreen] (switching mid-thread,
+ * F07-R4) — screen 07a. Grown out of F03's own flat, minimal build once F07
+ * existed to own it (see F03's *Deviations*), without touching
+ * [ModelOption], the repositories the two screens read from, or
+ * `ConversationsRepository.create`'s signature: this composable only takes
+ * richer input than F03's did.
+ *
+ * [services] is unfiltered — every row `GET /api/services` returned, not just
+ * chat-capable ones — so an embedding service or `open-webui` never reaches
+ * this composable only by the caller doing it right; this filters for itself
+ * too, so a picker instantiated against the raw list can never show one
+ * (F07-R1's second criterion, belt-and-suspenders with [ServiceSummary.isChatCapable]).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelPickerSheet(
+    services: List<ServiceSummary>,
+    remoteModels: List<ModelOption.Remote>,
+    remoteModelsConfigured: Boolean,
+    onSelect: (ModelOption) -> Unit,
+    onDismiss: () -> Unit,
+    selectedRef: ModelRef? = null,
+) {
+    val colors = LlmTheme.colors
+    val chatCapable = services.filter { it.isChatCapable }
+    // Favourites first; sortedByDescending is stable, so the server's own
+    // host-port ordering holds within each group otherwise (F07-R5).
+    val running = chatCapable.filter { it.isRunning }.sortedByDescending { it.favorite }
+    val stopped = chatCapable.filter { !it.isRunning }.sortedByDescending { it.favorite }
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = colors.surface,
+        modifier = Modifier.testTag("model_picker_sheet"),
+    ) {
+        // C3 (F03): the sheet draws behind the navigation bar, so without this
+        // its last row is unreachable under the 44 dp button bar.
+        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
+            item { ModelPickerSectionHeader("Running") }
+            if (running.isEmpty()) {
+                item {
+                    Text(
+                        "Nothing is running. Start a model from the Models tab.",
+                        color = colors.amber,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                            .testTag("model_picker_nothing_running"),
+                    )
+                }
+            }
+            items(running, key = { "running:${it.name}" }) { service ->
+                LocalServiceRow(
+                    service = service,
+                    selected = selectedRef == ModelRef.Local(service.name),
+                    onClick = { onSelect(ModelOption.LocalService(service.name, service.status)) },
+                )
+            }
+
+            if (stopped.isNotEmpty()) {
+                item { ModelPickerSectionHeader("Stopped") }
+                items(stopped, key = { "stopped:${it.name}" }) { service ->
+                    // F07-R2: visible, greyed, and not clickable — starting one
+                    // is F11's guarded action, reached from there, not here.
+                    LocalServiceRow(service = service, selected = false, onClick = null)
+                }
+            }
+
+            if (remoteModelsConfigured && remoteModels.isNotEmpty()) {
+                item { ModelPickerSectionHeader("OpenRouter") }
+                items(remoteModels, key = { "remote:${it.modelId}" }) { option ->
+                    RemoteModelRow(
+                        option = option,
+                        selected = selectedRef == ModelRef.OpenRouter(option.modelId),
+                        onClick = { onSelect(option) },
+                    )
+                }
+            }
+
+            item { Spacer(Modifier.height(16.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun LocalServiceRow(service: ServiceSummary, selected: Boolean, onClick: (() -> Unit)?) {
+    val colors = LlmTheme.colors
+    val enabled = onClick != null
+    val rowAlpha = if (enabled) 1f else 0.5f
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(if (selected) colors.accentDeep.copy(alpha = 0.25f) else colors.surface)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("model_option_${service.name}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(
+            Modifier.size(8.dp).clip(CircleShape)
+                .background(if (service.isRunning) colors.green else colors.subtle.copy(alpha = rowAlpha)),
+        )
+        Column(Modifier.weight(1f)) {
+            Text(
+                service.name,
+                color = colors.fg.copy(alpha = rowAlpha),
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                "${service.engine.label()} · :${service.port}${service.statusSuffix()}",
+                color = colors.subtle.copy(alpha = rowAlpha),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        if (selected) Text("✓", color = colors.accent, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+/** `running`/`exited`/`not-created` — R2's second criterion: the two stopped states read differently. */
+private fun ServiceSummary.statusSuffix(): String = when (status) {
+    "running" -> ""
+    "not-created" -> " · not created"
+    else -> " · $status"
+}
+
+@Composable
+private fun RemoteModelRow(option: ModelOption.Remote, selected: Boolean, onClick: () -> Unit) {
+    val colors = LlmTheme.colors
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(if (selected) colors.accentDeep.copy(alpha = 0.25f) else colors.surface)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("model_option_${option.modelId}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(Modifier.size(8.dp).clip(CircleShape).background(colors.engineOpenRouter.foreground))
+        Column(Modifier.weight(1f)) {
+            Text(option.label, color = colors.fg, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                option.modelId,
+                color = colors.subtle,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (selected) Text("✓", color = colors.accent, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+@Composable
+private fun ModelPickerSectionHeader(title: String) {
+    Text(
+        title,
+        color = LlmTheme.colors.subtle,
+        style = MaterialTheme.typography.labelMedium,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+private fun Engine.label(): String = when (this) {
+    Engine.LLAMA_CPP -> "llama.cpp"
+    Engine.VLLM -> "vLLM"
+    Engine.DS4 -> "ds4"
+    Engine.OPEN_ROUTER -> "OpenRouter"
+    Engine.UNKNOWN -> "Unknown"
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
@@ -47,6 +46,7 @@ import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.data.model.ManagedPrompt
 import com.hpz.llmdockchat.data.model.McpServerInfo
 import com.hpz.llmdockchat.data.model.ModelOption
+import com.hpz.llmdockchat.feature.modelpicker.ModelPickerSheet
 
 /**
  * Screen 03 · New chat sheet (F03). A pushed screen rather than a modal, as
@@ -205,9 +205,10 @@ private fun NewChatSheetBody(
 
     if (showModelPicker) {
         ModelPickerSheet(
-            localServices = state.localServices,
+            services = state.services,
             remoteModels = state.remoteModels,
             remoteModelsConfigured = state.remoteModelsConfigured,
+            selectedRef = state.selectedModel?.ref,
             onSelect = {
                 onSelectModel(it)
                 showModelPicker = false
@@ -353,61 +354,6 @@ private fun ToolsFailureBanner(
                     Text("Open anyway", color = colors.muted)
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ModelPickerSheet(
-    localServices: List<ModelOption.LocalService>,
-    remoteModels: List<ModelOption.Remote>,
-    remoteModelsConfigured: Boolean,
-    onSelect: (ModelOption) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val colors = LlmTheme.colors
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = colors.surface,
-        modifier = Modifier.testTag("model_picker_sheet"),
-    ) {
-        // C3: the sheet draws behind the navigation bar, so without
-        // this its last row is unreachable under the 44 dp button bar.
-        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
-            item { PickerSectionHeader("Local services") }
-            if (localServices.isEmpty()) {
-                item {
-                    Text(
-                        "No chat-capable services found.",
-                        color = colors.muted,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    )
-                }
-            }
-            items(localServices, key = { "local:${it.serviceName}" }) { option ->
-                PickerRow(
-                    title = option.serviceName,
-                    subtitle = if (option.isRunning) "Running" else "Not running",
-                    subtitleColor = if (option.isRunning) colors.green else colors.subtle,
-                    onClick = { onSelect(option) },
-                    testTag = "model_option_${option.serviceName}",
-                )
-            }
-            if (remoteModelsConfigured && remoteModels.isNotEmpty()) {
-                item { PickerSectionHeader("OpenRouter") }
-                items(remoteModels, key = { "remote:${it.modelId}" }) { option ->
-                    PickerRow(
-                        title = option.label,
-                        subtitle = option.modelId,
-                        onClick = { onSelect(option) },
-                        testTag = "model_option_${option.modelId}",
-                    )
-                }
-            }
-            item { Spacer(Modifier.height(16.dp)) }
         }
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModel.kt
@@ -10,10 +10,12 @@ import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.PromptsRepository
 import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ManagedPrompt
 import com.hpz.llmdockchat.data.model.McpServerInfo
 import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ModelRef
+import com.hpz.llmdockchat.data.model.ServiceSummary
 import com.hpz.llmdockchat.data.model.parseModelRef
 import com.hpz.llmdockchat.data.model.wireValue
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +29,14 @@ sealed interface NewChatUiState {
 
     data class Loaded(
         val localServices: List<ModelOption.LocalService>,
+        /**
+         * The full, unfiltered `GET /api/services` row set, kept live by
+         * [ServicesStreamRepository] (F07-R1's third criterion) — what
+         * [com.hpz.llmdockchat.feature.modelpicker.ModelPickerSheet] actually
+         * renders. [localServices] above is untouched by F07: it still drives
+         * the remembered-model resolution below, exactly as F03 built it.
+         */
+        val services: List<ServiceSummary> = emptyList(),
         val remoteModels: List<ModelOption.Remote>,
         val remoteModelsConfigured: Boolean,
         val selectedModel: ModelOption?,
@@ -65,6 +75,7 @@ class NewChatViewModel(
     private val openRouterModelsRepository: OpenRouterModelsRepository,
     private val conversationsRepository: ConversationsRepository,
     private val preferences: NewChatPreferences,
+    private val servicesStreamRepository: ServicesStreamRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<NewChatUiState>(NewChatUiState.Loading)
@@ -131,6 +142,7 @@ class NewChatViewModel(
 
             _state.value = NewChatUiState.Loaded(
                 localServices = localServices,
+                services = services,
                 remoteModels = remoteModels,
                 remoteModelsConfigured = remoteConfigured,
                 selectedModel = selectedModel,
@@ -140,6 +152,17 @@ class NewChatViewModel(
                 mcpServers = mcpServers,
                 selectedMcpServerIds = rememberedMcpIds.intersect(mcpServers.map { it.id }.toSet()),
             )
+
+            // F07-R1's third criterion: a container started or stopped
+            // elsewhere while this sheet is open shows up with no manual
+            // refresh. Runs for the screen's lifetime (Architecture D5) —
+            // NEW_CHAT is a short pushed screen (F03), not a persistent tab,
+            // so an always-open connection here is cheap.
+            launch {
+                servicesStreamRepository.stream().collect { live ->
+                    updateLoaded { it.copy(services = live) }
+                }
+            }
         }
     }
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadMessages.kt
@@ -54,6 +54,8 @@ import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.MessageRole
 import com.hpz.llmdockchat.data.model.ParseWarning
 import com.hpz.llmdockchat.data.model.ToolCallRecord
+import com.hpz.llmdockchat.data.model.displayName
+import com.hpz.llmdockchat.data.model.parseModelRef
 
 /**
  * The mockup's split (screen 04): the user's own words in mono, the model's in
@@ -76,8 +78,28 @@ fun MessageBubble(message: ChatMessage, modifier: Modifier = Modifier, selectabl
             artifacts = message.artifacts,
             selectable = selectable,
             modifier = modifier,
+            trailing = { MessageModelChip(message.modelService) },
         )
     }
+}
+
+/**
+ * F07-R4's second criterion: a thread's model can change mid-conversation, and
+ * every persisted message already carries the one that actually produced it
+ * (`model_service`). Null on a message from before switching existed, or on a
+ * message role other than assistant (the server never sets it on a user
+ * message), so this renders nothing rather than a misleading blank chip.
+ */
+@Composable
+private fun MessageModelChip(modelService: String?) {
+    if (modelService.isNullOrBlank()) return
+    Text(
+        parseModelRef(modelService).displayName,
+        color = LlmTheme.colors.subtle,
+        fontFamily = FontFamily.Monospace,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.testTag("message_model"),
+    )
 }
 
 @Composable

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -68,8 +70,10 @@ import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import com.hpz.llmdockchat.data.model.MessageRole
+import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ModelRef
 import com.hpz.llmdockchat.data.model.displayName
+import com.hpz.llmdockchat.feature.modelpicker.ModelPickerSheet
 import kotlinx.coroutines.launch
 
 /**
@@ -112,6 +116,9 @@ fun ThreadScreen(
         onRequestEditConfirm = viewModel::requestEditConfirm,
         onCancelEditConfirm = viewModel::cancelEditConfirm,
         onConfirmEdit = viewModel::confirmEdit,
+        onOpenModelPicker = viewModel::openModelPicker,
+        onCloseModelPicker = viewModel::closeModelPicker,
+        onSwitchModel = { viewModel.switchModel(it.ref) },
         modifier = modifier,
     )
 }
@@ -138,6 +145,9 @@ private fun ThreadContent(
     onRequestEditConfirm: () -> Unit,
     onCancelEditConfirm: () -> Unit,
     onConfirmEdit: () -> Unit,
+    onOpenModelPicker: () -> Unit,
+    onCloseModelPicker: () -> Unit,
+    onSwitchModel: (ModelOption) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LlmTheme.colors
@@ -195,6 +205,9 @@ private fun ThreadContent(
                     IconButton(onClick = onBack, modifier = Modifier.testTag("thread_back")) {
                         Text("←", color = colors.fg)
                     }
+                },
+                actions = {
+                    if (loaded != null) ThreadOverflowMenu(canSwitchModel = loaded.canSwitchModel, onOpenModelPicker = onOpenModelPicker)
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
             )
@@ -283,6 +296,38 @@ private fun ThreadContent(
                     Text("Cancel")
                 }
             },
+        )
+    }
+
+    // F07-R4 — the same picker as F03's, reached from the overflow menu.
+    loaded?.modelPicker?.let { picker ->
+        ModelPickerSheet(
+            services = picker.services,
+            remoteModels = picker.remoteModels,
+            remoteModelsConfigured = picker.remoteModelsConfigured,
+            selectedRef = loaded.conversation.modelRef,
+            onSelect = onSwitchModel,
+            onDismiss = onCloseModelPicker,
+        )
+    }
+}
+
+@Composable
+private fun ThreadOverflowMenu(canSwitchModel: Boolean, onOpenModelPicker: () -> Unit) {
+    val colors = LlmTheme.colors
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }, modifier = Modifier.testTag("thread_overflow")) {
+        Text("⋮", color = colors.fg, style = MaterialTheme.typography.titleLarge)
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenuItem(
+            text = { Text(if (canSwitchModel) "Switch model" else "Switch model (run active)") },
+            enabled = canSwitchModel,
+            onClick = {
+                expanded = false
+                onOpenModelPicker()
+            },
+            modifier = Modifier.testTag("thread_switch_model"),
         )
     }
 }
@@ -697,6 +742,7 @@ private fun ThreadStreamingPreview() {
             onDismissError = {}, onAddAttachment = {}, onRemoveAttachment = {}, onAttachmentFailed = {},
             onRequestDelete = {}, onCancelDelete = {}, onConfirmDelete = {},
             onBeginEdit = {}, onCancelEdit = {}, onRequestEditConfirm = {}, onCancelEditConfirm = {}, onConfirmEdit = {},
+            onOpenModelPicker = {}, onCloseModelPicker = {}, onSwitchModel = {},
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
@@ -3,7 +3,9 @@ package com.hpz.llmdockchat.feature.thread
 import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
+import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ParseWarning
+import com.hpz.llmdockchat.data.model.ServiceSummary
 
 /** What the user typed, shown before the server has a message id for it. */
 data class PendingUserMessage(val content: String, val images: List<String> = emptyList())
@@ -91,6 +93,19 @@ data class PendingEdit(
     val discardCount: Int,
 )
 
+/**
+ * The "switch model" sheet (F07-R4), open only while [ThreadUiState.Loaded.modelPicker]
+ * is non-null — unlike [NewChatUiState.Loaded]'s `services`, this is not kept
+ * live for the whole time a thread is open (a thread can stay open far longer
+ * than a new-chat sheet does); the stream is subscribed only while the sheet
+ * is up, via [ThreadViewModel.openModelPicker]/[ThreadViewModel.closeModelPicker].
+ */
+data class ModelPickerState(
+    val services: List<ServiceSummary> = emptyList(),
+    val remoteModels: List<ModelOption.Remote> = emptyList(),
+    val remoteModelsConfigured: Boolean = false,
+)
+
 sealed interface ThreadUiState {
     data object Loading : ThreadUiState
 
@@ -115,6 +130,8 @@ sealed interface ThreadUiState {
         val editingMessage: ChatMessage? = null,
         /** Confirm-before-edit-and-resend, holding the exact discard count. */
         val pendingEdit: PendingEdit? = null,
+        /** Non-null exactly while the "switch model" sheet (F07-R4) is open. */
+        val modelPicker: ModelPickerState? = null,
     ) : ThreadUiState {
 
         /**
@@ -130,6 +147,10 @@ sealed interface ThreadUiState {
 
         val canSend: Boolean
             get() = !runActive && (composer.isNotBlank() || attachments.isNotEmpty())
+
+        /** F07-R4's third criterion — switching is unavailable while a run is active. */
+        val canSwitchModel: Boolean
+            get() = !runActive
 
         /**
          * A run that failed — including one that failed while the app was

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
@@ -7,11 +7,15 @@ import com.hpz.llmdockchat.core.net.RunEvent
 import com.hpz.llmdockchat.core.net.appError
 import com.hpz.llmdockchat.core.prefs.DraftStore
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
 import com.hpz.llmdockchat.data.model.MessageRole
+import com.hpz.llmdockchat.data.model.ModelRef
 import com.hpz.llmdockchat.data.model.ParseWarning
+import com.hpz.llmdockchat.data.model.wireValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -33,6 +37,8 @@ class ThreadViewModel(
     private val conversationId: String,
     private val repository: ChatRepository,
     private val drafts: DraftStore,
+    private val servicesStreamRepository: ServicesStreamRepository,
+    private val openRouterModelsRepository: OpenRouterModelsRepository,
     private val coalesceWindowMs: Long = DEFAULT_COALESCE_WINDOW_MS,
     private val titleSettleDelayMs: Long = DEFAULT_TITLE_SETTLE_DELAY_MS,
 ) : ViewModel() {
@@ -41,6 +47,9 @@ class ThreadViewModel(
     val state: StateFlow<ThreadUiState> = _state.asStateFlow()
 
     private var streamJob: Job? = null
+
+    /** The model picker's own live subscription — separate from [streamJob], which is the chat run's. */
+    private var modelPickerJob: Job? = null
 
     /** What the composer held before [beginEdit] overwrote it, restored by [cancelEdit]. */
     private var composerBeforeEdit: String = ""
@@ -170,6 +179,66 @@ class ThreadViewModel(
 
     fun reportAttachmentFailure(message: String) {
         loaded()?.let { _state.value = it.copy(actionError = message) }
+    }
+
+    // -- switch model (F07-R4) --------------------------------------------------
+
+    /**
+     * Opens the sheet and starts its own live services subscription — separate
+     * from [streamJob] (the chat run's), and unlike [NewChatViewModel]'s, not
+     * kept open for the whole time the screen is: a thread stays open far
+     * longer than a new-chat sheet does, so the SSE connection is scoped to the
+     * sheet being visible, cancelled the moment it closes ([closeModelPicker]).
+     */
+    fun openModelPicker() {
+        val current = loaded() ?: return
+        if (current.runActive) return
+        _state.value = current.copy(modelPicker = ModelPickerState())
+        modelPickerJob?.cancel()
+        modelPickerJob = viewModelScope.launch {
+            val openRouter = openRouterModelsRepository.list().getOrNull()
+            loaded()?.let {
+                _state.value = it.copy(
+                    modelPicker = it.modelPicker?.copy(
+                        remoteModels = openRouter?.models.orEmpty(),
+                        remoteModelsConfigured = openRouter?.configured ?: false,
+                    ),
+                )
+            }
+            servicesStreamRepository.stream().collect { services ->
+                loaded()?.let {
+                    _state.value = it.copy(modelPicker = it.modelPicker?.copy(services = services))
+                }
+            }
+        }
+    }
+
+    fun closeModelPicker() {
+        modelPickerJob?.cancel()
+        modelPickerJob = null
+        loaded()?.let { _state.value = it.copy(modelPicker = null) }
+    }
+
+    /**
+     * `PUT /api/chat/conversations/<id>` with the new `main_service`. Earlier
+     * messages are untouched server-side — each already carries its own
+     * `model_service` — only the next turn is affected. The reload afterwards
+     * is what updates the thread header (F07-R4's first criterion).
+     */
+    fun switchModel(ref: ModelRef) {
+        val current = loaded() ?: return
+        if (current.runActive) return
+        viewModelScope.launch {
+            repository.updateMainService(conversationId, ref.wireValue).fold(
+                onSuccess = {
+                    closeModelPicker()
+                    reloadConversation()
+                },
+                onFailure = { failure ->
+                    loaded()?.let { _state.value = it.copy(actionError = failure.appError.displayMessage) }
+                },
+            )
+        }
     }
 
     // -- delete (F06-R2) -------------------------------------------------------

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -124,6 +124,8 @@ fun AppNavHost(
                             conversationId = conversationId,
                             repository = container.chatRepository,
                             drafts = container.draftStore,
+                            servicesStreamRepository = container.servicesStreamRepository,
+                            openRouterModelsRepository = container.openRouterModelsRepository,
                         )
                     }
                 },
@@ -142,6 +144,7 @@ fun AppNavHost(
                             openRouterModelsRepository = container.openRouterModelsRepository,
                             conversationsRepository = container.conversationsRepository,
                             preferences = container.newChatPreferences,
+                            servicesStreamRepository = container.servicesStreamRepository,
                         )
                     }
                 },

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/ServiceStreamEventParserTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/ServiceStreamEventParserTest.kt
@@ -1,0 +1,93 @@
+package com.hpz.llmdockchat.core.net
+
+import com.hpz.llmdockchat.data.dto.ServiceDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [parseServiceStreamFrame] against the shapes `services_stream` actually
+ * sends (`dashboard/routes/services.py:services_stream`) — a snapshot on
+ * connect, then deltas, mirrored from the real payload shapes documented
+ * there rather than guessed.
+ */
+class ServiceStreamEventParserTest {
+
+    @Test
+    fun `a snapshot carries every service row, api_key and all, but api_key never survives decoding`() {
+        val event = parseServiceStreamFrame(
+            """
+            {"type": "snapshot", "data": {"services": [
+                {"name": "llamacpp-gemma-4-26b-a4b-it-q8", "status": "running", "kind": "chat",
+                 "host_port": 3301, "favorite": true, "api_key": "llmd-super-secret-value"},
+                {"name": "vllm-bge-m3", "status": "not-created", "kind": "embedding",
+                 "host_port": 3370, "favorite": false, "api_key": "llmd-another-secret"}
+            ], "total": 2, "running": 1, "stopped": 1}, "timestamp": "2026-07-25T00:00:00Z"}
+            """.trimIndent(),
+        )
+        val snapshot = event as ServiceStreamEvent.Snapshot
+        assertEquals(2, snapshot.services.size)
+        assertEquals("llamacpp-gemma-4-26b-a4b-it-q8", snapshot.services[0].name)
+        assertEquals(3301, snapshot.services[0].hostPort)
+        assertTrue(snapshot.services[0].favorite)
+        assertEquals("embedding", snapshot.services[1].kind)
+        // ServiceDto has no api_key property at all — there is nowhere for the
+        // value to have landed, which is exactly F07-R6's point.
+        val fields = ServiceDto::class.java.declaredFields.map { it.name }
+        assertTrue(fields.none { it.contains("api_key", ignoreCase = true) || it.equals("apiKey", ignoreCase = true) })
+    }
+
+    @Test
+    fun `a delta updates status and favorite for the one named service`() {
+        val event = parseServiceStreamFrame(
+            """{"type": "delta", "service_name": "llamacpp-gemma-4-26b-a4b-it-q8", "status": "exited",
+                "action": "die", "container_id": "abc123", "timestamp": "2026-07-25T00:00:01Z",
+                "metadata": {"favorite": true}}""",
+        )
+        assertEquals(
+            ServiceStreamEvent.Delta(serviceName = "llamacpp-gemma-4-26b-a4b-it-q8", status = "exited", favorite = true),
+            event,
+        )
+    }
+
+    @Test
+    fun `a delta with no metadata carries a null favorite, not false`() {
+        val event = parseServiceStreamFrame(
+            """{"type": "delta", "service_name": "vllm-qwen3-6-27b-fp8", "status": "running",
+                "action": "start", "container_id": "def456", "timestamp": "2026-07-25T00:00:02Z"}""",
+        )
+        assertEquals(
+            ServiceStreamEvent.Delta(serviceName = "vllm-qwen3-6-27b-fp8", status = "running", favorite = null),
+            event,
+        )
+    }
+
+    @Test
+    fun `an error frame carries the server's message`() {
+        val event = parseServiceStreamFrame("""{"type": "error", "message": "Docker socket unavailable"}""")
+        assertEquals(ServiceStreamEvent.Error("Docker socket unavailable"), event)
+    }
+
+    @Test
+    fun `a keepalive comment line is not valid JSON and is Unknown, not a crash`() {
+        val event = parseServiceStreamFrame(": keepalive")
+        assertTrue(event is ServiceStreamEvent.Unknown)
+    }
+
+    @Test
+    fun `an unrecognised type is Unknown rather than dropped silently`() {
+        val payload = """{"type": "future_frame_type", "stuff": 1}"""
+        assertEquals(ServiceStreamEvent.Unknown(payload), parseServiceStreamFrame(payload))
+    }
+
+    @Test
+    fun `a delta missing service_name is Unknown, since nothing can be updated with it`() {
+        val payload = """{"type": "delta", "status": "running"}"""
+        assertEquals(ServiceStreamEvent.Unknown(payload), parseServiceStreamFrame(payload))
+    }
+
+    @Test
+    fun `garbage that is not JSON at all never throws`() {
+        assertEquals(ServiceStreamEvent.Unknown("not json"), parseServiceStreamFrame("not json"))
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ChatRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ChatRepositoryTest.kt
@@ -304,4 +304,30 @@ class ChatRepositoryTest {
 
         assertEquals("{}", server.takeRequest().body?.utf8())
     }
+
+    // -- switch model (F07-R4) ------------------------------------------------
+
+    @Test
+    fun `updateMainService PUTs the conversation with the new main_service`() = runTest {
+        server.enqueue(MockResponse.Builder().body("""{"id": "c1"}""").build())
+
+        repository.updateMainService("c1", "vllm-qwen3-6-27b-fp8").getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("PUT", request.method)
+        assertEquals("/api/chat/conversations/c1", request.url.encodedPath)
+        assertEquals("""{"main_service":"vllm-qwen3-6-27b-fp8"}""", request.body?.utf8())
+    }
+
+    @Test
+    fun `updateMainService with an openrouter ref sends the openrouter- prefixed wire value`() = runTest {
+        server.enqueue(MockResponse.Builder().body("""{"id": "c1"}""").build())
+
+        repository.updateMainService("c1", "openrouter:anthropic/claude-sonnet-5").getOrThrow()
+
+        assertEquals(
+            """{"main_service":"openrouter:anthropic/claude-sonnet-5"}""",
+            server.takeRequest().body?.utf8(),
+        )
+    }
 }

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesStreamRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesStreamRepositoryTest.kt
@@ -1,0 +1,84 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.ServiceStreamEvent
+import com.hpz.llmdockchat.data.dto.ServiceDto
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [mergeServiceEvent] (pure — the reduce step) and [ServicesStreamRepository.stream]
+ * (the transport wiring) separately, same split as [core.net.RunEventParserTest]
+ * versus [ChatRepositoryTest].
+ */
+class ServicesStreamRepositoryTest {
+
+    private val running = ServiceSummary("llamacpp-a", "running", "chat", port = 3301, favorite = false)
+    private val stopped = ServiceSummary("vllm-b", "exited", "chat", port = 3302, favorite = true)
+
+    @Test
+    fun `a snapshot replaces the list wholesale`() {
+        val snapshot = ServiceStreamEvent.Snapshot(
+            listOf(
+                ServiceDto("llamacpp-a", "running", "chat", 3301, false),
+                ServiceDto("vllm-b", "exited", "chat", 3302, true),
+            ),
+        )
+        val result = mergeServiceEvent(emptyList(), snapshot)
+        assertEquals(listOf(running, stopped), result)
+    }
+
+    @Test
+    fun `a delta updates only the named service, leaving the rest untouched`() {
+        val delta = ServiceStreamEvent.Delta(serviceName = "llamacpp-a", status = "exited", favorite = null)
+        val result = mergeServiceEvent(listOf(running, stopped), delta)
+        assertEquals(listOf(running.copy(status = "exited"), stopped), result)
+    }
+
+    @Test
+    fun `a delta's favorite overrides the stored flag when present`() {
+        val delta = ServiceStreamEvent.Delta(serviceName = "llamacpp-a", status = null, favorite = true)
+        val result = mergeServiceEvent(listOf(running, stopped), delta)
+        assertEquals(running.copy(favorite = true), result[0])
+    }
+
+    @Test
+    fun `a delta for an unknown service name changes nothing`() {
+        val delta = ServiceStreamEvent.Delta(serviceName = "does-not-exist", status = "running", favorite = null)
+        assertEquals(listOf(running, stopped), mergeServiceEvent(listOf(running, stopped), delta))
+    }
+
+    @Test
+    fun `an error or unknown frame leaves the current list exactly as it was`() {
+        val current = listOf(running, stopped)
+        assertEquals(current, mergeServiceEvent(current, ServiceStreamEvent.Error("boom")))
+        assertEquals(current, mergeServiceEvent(current, ServiceStreamEvent.Unknown("garbage")))
+    }
+
+    // -- the transport wiring --------------------------------------------------
+
+    @Test
+    fun `stream emits the mapped list for a snapshot then a delta, in order`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf(
+            """{"type":"snapshot","data":{"services":[
+                {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+            ],"total":1,"running":1,"stopped":0}}""",
+            """{"type":"delta","service_name":"llamacpp-a","status":"exited"}""",
+        )
+        val repository = ServicesStreamRepository(transport)
+
+        // `take(2)` cancels the upstream right after the second emission,
+        // before the fake transport's flow would complete and the reconnect
+        // loop would open a second, empty connection.
+        val emissions = withTimeout(5_000) { repository.stream().take(2).toList() }
+
+        assertEquals("running", emissions[0][0].status)
+        assertEquals("exited", emissions[1][0].status)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/NewChatMapperTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/NewChatMapperTest.kt
@@ -1,0 +1,33 @@
+package com.hpz.llmdockchat.data.mapper
+
+import com.hpz.llmdockchat.data.dto.ServiceDto
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** [ServiceDto.toDomain] — F07 added `host_port`/`favorite` on top of F03's `name`/`status`/`kind`. */
+class NewChatMapperTest {
+
+    @Test
+    fun `host_port and favorite map straight through, and api_key has no field to map from`() {
+        val dto = ServiceDto(
+            name = "llamacpp-a",
+            status = "running",
+            kind = "chat",
+            hostPort = 3301,
+            favorite = true,
+        )
+        assertEquals(
+            ServiceSummary(name = "llamacpp-a", status = "running", kind = "chat", port = 3301, favorite = true),
+            dto.toDomain(),
+        )
+    }
+
+    @Test
+    fun `defaults are zero and false when the server omits the fields`() {
+        val dto = ServiceDto(name = "llamacpp-a", status = "running", kind = "chat")
+        val summary = dto.toDomain()
+        assertEquals(0, summary.port)
+        assertEquals(false, summary.favorite)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/ServiceSummaryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/ServiceSummaryTest.kt
@@ -1,0 +1,58 @@
+package com.hpz.llmdockchat.data.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [ServiceSummary.isChatCapable] against the dashboard's own filter
+ * (`dashboard/frontend/src/hooks/useRunningServices.js`): a recognised engine
+ * prefix AND `(kind || 'chat') === 'chat'`. F07's brief called out checking
+ * this rather than trusting F03's build of it — the blank-kind case here is
+ * exactly the gap that check found: F03's `kind == "chat"` rejected a blank
+ * `kind`, where the web treats it as `"chat"`.
+ */
+class ServiceSummaryTest {
+
+    @Test
+    fun `a running llamacpp service with an explicit chat kind is chat-capable`() {
+        val service = ServiceSummary("llamacpp-a", "running", "chat")
+        assertTrue(service.isChatCapable)
+    }
+
+    @Test
+    fun `a blank kind is treated as chat, matching the web's (kind or chat) === chat`() {
+        val service = ServiceSummary("vllm-a", "running", "")
+        assertTrue(service.isChatCapable)
+    }
+
+    @Test
+    fun `an embedding-kind service is never chat-capable, running or stopped`() {
+        val runningEmbedding = ServiceSummary("vllm-bge-m3", "running", "embedding")
+        val stoppedEmbedding = ServiceSummary("vllm-bge-m3", "not-created", "embedding")
+        assertFalse(runningEmbedding.isChatCapable)
+        assertFalse(stoppedEmbedding.isChatCapable)
+    }
+
+    @Test
+    fun `open-webui is never chat-capable, even with kind chat, since its name has no engine prefix`() {
+        val service = ServiceSummary("open-webui", "running", "chat")
+        assertFalse(service.isChatCapable)
+    }
+
+    @Test
+    fun `isRunning is only true for the running status, not exited or not-created`() {
+        assertTrue(ServiceSummary("llamacpp-a", "running", "chat").isRunning)
+        assertFalse(ServiceSummary("llamacpp-a", "exited", "chat").isRunning)
+        assertFalse(ServiceSummary("llamacpp-a", "not-created", "chat").isRunning)
+    }
+
+    @Test
+    fun `a stopped chat-capable service is still chat-capable, just not running`() {
+        // F07-R2 needs the stopped row to remain visible in the picker's
+        // filter — only selectability (isRunning) is meant to gate it.
+        val service = ServiceSummary("ds4-a", "exited", "chat")
+        assertTrue(service.isChatCapable)
+        assertFalse(service.isRunning)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModelTest.kt
@@ -11,9 +11,11 @@ import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.PromptsRepository
 import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.testing.FakeNewChatPreferences
 import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.MainDispatcherRule
 import com.hpz.llmdockchat.testing.readFixture
@@ -50,6 +52,8 @@ class NewChatViewModelTest {
     private lateinit var promptsRepository: PromptsRepository
     private lateinit var mcpServersRepository: McpServersRepository
     private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var servicesStreamTransport: FakeSseTransport
     private lateinit var preferences: FakeNewChatPreferences
 
     @Before
@@ -68,6 +72,10 @@ class NewChatViewModelTest {
         promptsRepository = PromptsRepository(api)
         mcpServersRepository = McpServersRepository(api)
         openRouterModelsRepository = OpenRouterModelsRepository(api)
+        // No payloads by default: most tests never open a picker, and an
+        // empty FakeSseTransport just never emits rather than erroring.
+        servicesStreamTransport = FakeSseTransport()
+        servicesStreamRepository = ServicesStreamRepository(servicesStreamTransport)
         preferences = FakeNewChatPreferences()
     }
 
@@ -83,6 +91,7 @@ class NewChatViewModelTest {
         openRouterModelsRepository = openRouterModelsRepository,
         conversationsRepository = conversationsRepository,
         preferences = preferences,
+        servicesStreamRepository = servicesStreamRepository,
     )
 
     /** Load order in [NewChatViewModel.load]: services, openrouter, prompts, mcp-servers. */
@@ -239,6 +248,43 @@ class NewChatViewModelTest {
         assertNull(state.selectedModel)
         assertFalse(state.rememberedModelUnavailable) // nothing was remembered — not "unavailable"
         assertFalse(state.canStart)
+    }
+
+    /**
+     * F07-R1's third criterion: a container started or stopped elsewhere
+     * reaches an open picker with no manual refresh. `MainDispatcherRule`
+     * runs `viewModelScope` unconfined, so the stream's snapshot and delta
+     * are queued before [NewChatViewModel.load] runs — under Unconfined
+     * dispatch both land, in order, before [settled] ever gets to observe an
+     * intermediate state.
+     */
+    @Test
+    fun `a services-stream delta updates the picker's live list with no manual refresh`() {
+        enqueueLoadResponses()
+        servicesStreamTransport.payloads = listOf(
+            """{"type":"snapshot","data":{"services":[
+                {"name":"llamacpp-gemma-4-31b-it-q8","status":"exited","kind":"chat","host_port":3303,"favorite":false}
+            ],"total":1,"running":0,"stopped":1}}""",
+            """{"type":"delta","service_name":"llamacpp-gemma-4-31b-it-q8","status":"running"}""",
+        )
+        val viewModel = viewModel()
+
+        viewModel.load()
+        // Not `settled()`: that only waits for the *first* non-Loading value,
+        // and — since `.value` updates from the load and from the stream both
+        // land before this collector is ever dispatched — could observe
+        // either. Wait for the specific outcome instead.
+        val state = runBlocking {
+            withTimeout(10_000) {
+                viewModel.state.first {
+                    it is NewChatUiState.Loaded &&
+                        it.services.any { s -> s.name == "llamacpp-gemma-4-31b-it-q8" && s.status == "running" }
+                }
+            }
+        } as NewChatUiState.Loaded
+
+        val service = state.services.first { it.name == "llamacpp-gemma-4-31b-it-q8" }
+        assertEquals("running", service.status)
     }
 
     @Test

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
@@ -13,6 +13,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.MessageRole
 import com.hpz.llmdockchat.testing.FakeDraftStore
@@ -57,6 +59,8 @@ class ThreadMessageActionsTest {
     private lateinit var transport: FakeSseTransport
     private lateinit var drafts: FakeDraftStore
     private lateinit var repository: ChatRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "actions-main") }
 
@@ -74,6 +78,8 @@ class ThreadMessageActionsTest {
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .build()
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+        servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
+        openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -95,6 +101,8 @@ class ThreadMessageActionsTest {
                     conversationId = CONVERSATION_ID,
                     repository = repository,
                     drafts = drafts,
+                    servicesStreamRepository = servicesStreamRepository,
+                    openRouterModelsRepository = openRouterModelsRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = 1,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
@@ -11,6 +11,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.testing.FakeDraftStore
 import com.hpz.llmdockchat.testing.FakeServerUrlStore
 import com.hpz.llmdockchat.testing.FakeSseTransport
@@ -57,6 +59,8 @@ class ThreadStreamingEdgeTest {
     private lateinit var transport: FakeSseTransport
     private lateinit var drafts: FakeDraftStore
     private lateinit var repository: ChatRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "probe-main") }
 
@@ -76,6 +80,8 @@ class ThreadStreamingEdgeTest {
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .build()
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+        servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
+        openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -100,6 +106,8 @@ class ThreadStreamingEdgeTest {
                     conversationId = CONVERSATION_ID,
                     repository = repository,
                     drafts = drafts,
+                    servicesStreamRepository = servicesStreamRepository,
+                    openRouterModelsRepository = openRouterModelsRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = titleSettleDelayMs,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
@@ -11,6 +11,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.testing.FakeDraftStore
 import com.hpz.llmdockchat.testing.FakeServerUrlStore
 import com.hpz.llmdockchat.testing.FakeSseTransport
@@ -59,6 +61,8 @@ class ThreadTerminalPathTest {
     private lateinit var server: MockWebServer
     private lateinit var transport: FakeSseTransport
     private lateinit var repository: ChatRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "terminal-main") }
 
@@ -77,6 +81,8 @@ class ThreadTerminalPathTest {
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .build()
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+        servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
+        openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -101,6 +107,8 @@ class ThreadTerminalPathTest {
                     conversationId = CONVERSATION_ID,
                     repository = repository,
                     drafts = FakeDraftStore(),
+                    servicesStreamRepository = servicesStreamRepository,
+                    openRouterModelsRepository = openRouterModelsRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = 1L,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
@@ -13,7 +13,10 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.MessageRole
+import com.hpz.llmdockchat.data.model.ModelRef
 import com.hpz.llmdockchat.testing.FakeDraftStore
 import com.hpz.llmdockchat.testing.FakeServerUrlStore
 import com.hpz.llmdockchat.testing.FakeSseTransport
@@ -55,8 +58,11 @@ class ThreadViewModelTest {
 
     private lateinit var server: MockWebServer
     private lateinit var transport: FakeSseTransport
+    private lateinit var servicesTransport: FakeSseTransport
     private lateinit var drafts: FakeDraftStore
     private lateinit var repository: ChatRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
     private val store = ViewModelStore()
 
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "test-main") }
@@ -67,6 +73,7 @@ class ThreadViewModelTest {
         server = MockWebServer()
         server.start()
         transport = FakeSseTransport()
+        servicesTransport = FakeSseTransport()
         drafts = FakeDraftStore()
         val urlStore = FakeServerUrlStore(baseUrl(server.url("/").toString()))
         val client = OkHttpClient.Builder()
@@ -75,6 +82,8 @@ class ThreadViewModelTest {
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .build()
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+        servicesStreamRepository = ServicesStreamRepository(servicesTransport)
+        openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -101,6 +110,8 @@ class ThreadViewModelTest {
                     conversationId = CONVERSATION_ID,
                     repository = repository,
                     drafts = drafts,
+                    servicesStreamRepository = servicesStreamRepository,
+                    openRouterModelsRepository = openRouterModelsRepository,
                     // Zero so a flush is still scheduled through the
                     // dispatcher; the window itself is asserted in
                     // ThreadCoalescingTest.
@@ -593,7 +604,15 @@ class ThreadViewModelTest {
         store,
         viewModelFactory {
             initializer {
-                ThreadViewModel(CONVERSATION_ID, repository, drafts, coalesceWindowMs, titleSettleDelayMs = 1)
+                ThreadViewModel(
+                    CONVERSATION_ID,
+                    repository,
+                    drafts,
+                    servicesStreamRepository,
+                    openRouterModelsRepository,
+                    coalesceWindowMs,
+                    titleSettleDelayMs = 1,
+                )
             }
         },
     )[ThreadViewModel::class]
@@ -628,8 +647,104 @@ class ThreadViewModelTest {
         assertEquals("survives a 401", drafts.saved[CONVERSATION_ID])
     }
 
+    // -- switch model (F07-R4) -------------------------------------------------
+
+    @Test
+    fun `openModelPicker subscribes to the live services stream, closeModelPicker cancels it`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(MockResponse.Builder().body("""{"configured": false, "current": []}""").build())
+        servicesTransport.payloads = listOf(SNAPSHOT_ONE_SERVICE)
+        // A real `/api/services/stream` connection never completes on its own —
+        // `stayOpen` matches that, so the only way this test's `cancelled`
+        // assertion below can pass is `closeModelPicker` actually reaching the
+        // collector, not the flow having already finished on its own.
+        servicesTransport.stayOpen = true
+        viewModel.openModelPicker()
+
+        val withServices = viewModel.awaitState { it.modelPicker?.services?.isNotEmpty() == true }
+        assertEquals("llamacpp-a", withServices.modelPicker?.services?.first()?.name)
+
+        viewModel.closeModelPicker()
+        assertNull((viewModel.state.value as ThreadUiState.Loaded).modelPicker)
+
+        // Proof `modelPickerJob.cancel()` reaches all the way down to the
+        // transport, not just flips a state flag while a reconnect loop keeps
+        // polling every `RECONNECT_DELAY_MS` behind the scenes.
+        withTimeout(2_000) { servicesTransport.cancelled.await() }
+        assertEquals(1, servicesTransport.requests.size)
+    }
+
+    @Test
+    fun `switchModel PUTs the new main_service and reloads, updating the header`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(MockResponse.Builder().body("""{"id": "$CONVERSATION_ID"}""").build())
+        conversation(fixture = "conversation_after_switch.json")
+
+        viewModel.switchModel(ModelRef.Local("vllm-qwen3-6-27b-fp8"))
+
+        val updated = viewModel.awaitState { it.conversation.modelRef == ModelRef.Local("vllm-qwen3-6-27b-fp8") }
+        assertNull(updated.modelPicker) // switching closes the sheet on success
+
+        server.takeRequest() // load()'s own GET, issued first
+        val put = server.takeRequest()
+        assertEquals("PUT", put.method)
+        assertEquals("""{"main_service":"vllm-qwen3-6-27b-fp8"}""", put.body?.utf8())
+    }
+
+    @Test
+    fun `switchModel is refused outright while a run is active`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("go")
+        transport.payloads = listOf(RUN_STARTED)
+        transport.stayOpen = true
+        viewModel.send()
+        viewModel.awaitState { it.runActive }
+
+        viewModel.switchModel(ModelRef.Local("vllm-qwen3-6-27b-fp8"))
+
+        // Nothing beyond the load's own GET reached the server — `send` goes
+        // through the fake stream transport, not MockWebServer, and the guard
+        // means switchModel never even tries to PUT.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `switchModel's failure keeps the sheet open and surfaces the server's message`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(MockResponse.Builder().body("""{"configured": false, "current": []}""").build())
+        viewModel.openModelPicker()
+        viewModel.awaitState { it.modelPicker != null }
+
+        server.enqueue(
+            MockResponse.Builder().code(409).body("""{"error": "A run is already active for this conversation"}""").build(),
+        )
+        viewModel.switchModel(ModelRef.Local("vllm-qwen3-6-27b-fp8"))
+
+        val failed = viewModel.awaitState { it.actionError != null }
+        assertEquals("A run is already active for this conversation", failed.actionError)
+        assertTrue(failed.modelPicker != null) // the sheet is not dismissed on failure
+    }
+
     private companion object {
         const val CONVERSATION_ID = "39dc7f47-91da-4a0f-b731-59f507a12c1b"
+        const val SNAPSHOT_ONE_SERVICE = """{"type":"snapshot","data":{"services":[
+            {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+        ],"total":1,"running":1,"stopped":0}}"""
         const val RUN_STARTED = """{"type": "run_started", "run_id": "run-1"}"""
         const val DONE = "[DONE]"
         const val MESSAGE_SAVED = """{"type": "message_saved", "message_id": "m2", "seq": 2}"""

--- a/android/src/app/src/test/resources/fixtures/conversation_after_switch.json
+++ b/android/src/app/src/test/resources/fixtures/conversation_after_switch.json
@@ -1,0 +1,42 @@
+{
+  "id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+  "title": "Testing Specific Greeting Request",
+  "main_service": "vllm-qwen3-6-27b-fp8",
+  "sidekick_service": null,
+  "parent_conversation_id": null,
+  "selected_text": null,
+  "project_id": null,
+  "mcp_servers": [],
+  "active_run": null,
+  "last_run": {
+    "id": "035d944d-5105-451c-96d6-0d84d831a128",
+    "status": "completed",
+    "error": null
+  },
+  "created_at": "2026-07-25T05:54:19Z",
+  "updated_at": "2026-07-25T05:56:02Z",
+  "messages": [
+    {
+      "id": "cc05c037-b794-4a5c-a7ac-160c75004e70",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "user",
+      "content": "Reply with exactly: hello there",
+      "reasoning_content": null,
+      "model_service": null,
+      "images": [],
+      "seq": 1,
+      "created_at": "2026-07-25T05:54:27Z"
+    },
+    {
+      "id": "9b755560-aab9-42b9-9eba-289e5aaa1727",
+      "conversation_id": "39dc7f47-91da-4a0f-b731-59f507a12c1b",
+      "role": "assistant",
+      "content": "hello there",
+      "reasoning_content": null,
+      "model_service": "llamacpp-gemma-4-26b-a4b-it-q8",
+      "images": [],
+      "seq": 2,
+      "created_at": "2026-07-25T05:54:28Z"
+    }
+  ]
+}


### PR DESCRIPTION
A shared model picker (screen 07a) for both New Chat and an open thread, backed by a live services stream so the list reflects what can actually answer right now.

## What landed

- **`core/net/ServiceStreamEvent.kt`** — pure parser for `/api/services/stream`, written against `dashboard/routes/services.py` rather than the docs. The delta frame is flat with `service_name`, and `favorite` arrives only nested under `metadata` — never as a top-level field, which is what a guess would have assumed.
- **`data/ServicesStreamRepository.kt`** — snapshot on connect, deltas merged in place by name, reconnect on transport failure. Rethrows `CancellationException` so closing the picker tears the connection down instead of leaving a 2 s reconnect loop spinning per open.
- **`feature/modelpicker/ModelPickerSheet.kt`** — Running / Stopped / OpenRouter sections, favourites first, stopped rows greyed and inert. Replaces the private sheet F03 had inlined in `NewChatScreen`.
- **Switch a thread's model mid-conversation** (PUT `main_service`), disabled while a run is active, plus a per-message model chip so it stays clear which model produced which answer.

## Two things worth a reviewer's attention

**The engine-prefix filter is load-bearing.** `open-webui` is genuinely `running` with `kind: "chat"` on this rig, so filtering on `kind` alone would list Open WebUI as a selectable model. `isChatCapable` is `engine != Engine.UNKNOWN && (kind.isBlank() || kind == "chat")` — the `Engine.UNKNOWN` half is what excludes it, and it is pinned by a named test. It should not be "simplified" away later.

**F07-R6 holds structurally.** `GET /api/services` returns an `api_key` on every row. No DTO these endpoints decode into declares such a field, so there is nowhere for one to land — verified by a reflection test that feeds a payload with keys present and asserts none survives decoding.

## Verification

348 unit tests pass; `assembleDebug` clean. R1 (first two criteria), R2, R4 and R6 verified on device against the live dashboard; R3 and R5 verified apart from the sub-criteria below.

**Left [WIP] deliberately.** Two R1 criteria need a container transition no agent on this project is permitted to perform:

- live add when a container starts elsewhere — JVM evidence only
- the "nothing is running" empty state — no test at all, and the rig's only running chat model cannot be stopped to force the branch

One owner action closes both: open the picker, stop the running model, watch the row grey out and the empty state appear, then start it again.