### PR TITLE
F07: show only running models in the picker

### DIFF
--- a/android/docs/F07-model-selection.md
+++ b/android/docs/F07-model-selection.md
@@ -28,23 +28,36 @@ its port.
 - [ ] An embedding service never appears, running or not.
 - [ ] Starting a container elsewhere makes it appear in an open picker
       without a manual refresh.
-- [ ] With nothing running, the picker says so and points at the Models
-      tab.
+- [ ] With nothing running, the picker shows exactly
+      `No LLM-Dock models are running at this time.`
 
-## F07-R2 · Stopped models are visible but not selectable (Must)
+## F07-R2 · Stopped models are not shown at all (Must) — *revised*
 
-Stopped containers appear greyed, so it is obvious why a favourite is
-missing rather than it just being absent.
+Stopped containers do **not** appear in the picker. Only what can answer
+right now is listed.
 
-Whether the picker can start one is F11 — it is the same guarded action,
-reached from here.
+This reverses the original requirement, at the owner's direction on
+2026-07-25, after using the picker on a real rig: *"only show running
+models. don't show grayed out models — that is just noise."* This rig
+carries far more stopped services than running ones (typically one
+running against half a dozen stopped), so the greyed rows dominated the
+sheet while none of them could be tapped.
+
+The original rationale — that a greyed row explains why a favourite is
+missing, rather than it just being absent — did not survive contact with
+that ratio. Seeing every stopped model is the **Models tab**'s job
+(F10/F11), which is where starting one belongs anyway.
+
+Absent is also strictly safer than disabled: an unselectable row cannot
+be mis-tapped if it does not exist.
 
 **Acceptance criteria**
 
-- [ ] A stopped service is listed, visibly disabled, and cannot be chosen
-      as a thread's model.
-- [ ] Its state (`exited`, `not-created`) is distinguishable from
-      `running`.
+- [ ] A stopped service (`exited` or `not-created`) never appears in the
+      picker.
+- [ ] Filtering is in the picker UI only — `ServicesStreamRepository`,
+      `ServiceSummary` and the stream parser still carry stopped services,
+      because F10's Models tab needs them.
 
 ## F07-R3 · OpenRouter models (Should)
 
@@ -117,7 +130,9 @@ rendered anywhere in the app, or written to logs.
 
 ## Deviations from the mockup
 
-None.
+- **No stopped-models section.** Screen 07a draws stopped services as
+  greyed rows beneath the running ones. They are not rendered at all —
+  see the revised F07-R2 for why. The mockup is otherwise followed.
 
 ## Out of scope
 
@@ -128,15 +143,26 @@ None.
 ## Verification notes
 
 **Two R1 criteria are outstanding, both needing a container transition
-this project's agents are forbidden to make.** Everything else in R1, R2,
+this project's agents are forbidden to make.** Everything else in R1,
 R4 and R6 is verified on device; R3 and R5 are verified apart from the
 sub-criteria named below.
+
+R2's original criteria were verified on device *before* the requirement
+was revised — stopped services did render greyed, inert and with `exited`
+distinguishable from `not created`. That evidence is now obsolete: the
+revised R2 asserts the opposite, that they do not render at all.
 
 | Outstanding | Why it could not be closed |
 |---|---|
 | R1 · live add on start elsewhere | No agent may start or stop a container. JVM evidence only: `ServicesStreamRepositoryTest` (merge + reconnect) and `NewChatViewModelTest`'s delta-updates-the-list test. |
-| R1 · "nothing is running" empty state | `llamacpp-mimo-v2-5-q4` is the rig's only running chat-capable service and cannot be stopped to force the branch. **No test at all** — a Compose `if (running.isEmpty())` branch with no Compose UI test infrastructure in this project. |
+| R1 · empty state on screen | `llamacpp-mimo-v2-5-q4` is the rig's only running chat-capable service and cannot be stopped to force the branch. The **string** is unit-tested; how the branch *looks* is not, and cannot be — this project has no Compose UI test infrastructure. |
 | R3 · group hidden when unconfigured | Needs a dashboard with no `OPENROUTER_API_KEY`. |
+
+**The empty state matters more since R2 was revised.** With stopped
+models no longer listed, a picker with nothing running is now completely
+empty apart from the OpenRouter group — so that one string is the entire
+local half of the screen. It was a rare corner when stopped rows filled
+the sheet; it is the normal appearance of an idle rig now.
 
 **One owner action closes both R1 items:** open the model picker, stop
 `llamacpp-mimo-v2-5-q4`, watch the row grey out and the empty state

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheet.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheet.kt
@@ -50,6 +50,13 @@ import com.hpz.llmdockchat.data.model.engine
  * this composable only by the caller doing it right; this filters for itself
  * too, so a picker instantiated against the raw list can never show one
  * (F07-R1's second criterion, belt-and-suspenders with [ServiceSummary.isChatCapable]).
+ *
+ * Local rows are further filtered to running services only (F07-RO, a
+ * later owner-requested deviation from F07-R2's original grey-and-disabled
+ * "Stopped" section): a service that isn't running is noise here, not a
+ * choice — starting one is F11's guarded action, reached from the Models
+ * tab, not this sheet. The OpenRouter group is unaffected — those models
+ * are always reachable, so there is no "stopped" state to filter.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -62,11 +69,9 @@ fun ModelPickerSheet(
     selectedRef: ModelRef? = null,
 ) {
     val colors = LlmTheme.colors
-    val chatCapable = services.filter { it.isChatCapable }
     // Favourites first; sortedByDescending is stable, so the server's own
-    // host-port ordering holds within each group otherwise (F07-R5).
-    val running = chatCapable.filter { it.isRunning }.sortedByDescending { it.favorite }
-    val stopped = chatCapable.filter { !it.isRunning }.sortedByDescending { it.favorite }
+    // host-port ordering holds otherwise (F07-R5).
+    val running = runningChatCapable(services)
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
@@ -82,7 +87,7 @@ fun ModelPickerSheet(
             if (running.isEmpty()) {
                 item {
                     Text(
-                        "Nothing is running. Start a model from the Models tab.",
+                        NOTHING_RUNNING_TEXT,
                         color = colors.amber,
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
@@ -96,15 +101,6 @@ fun ModelPickerSheet(
                     selected = selectedRef == ModelRef.Local(service.name),
                     onClick = { onSelect(ModelOption.LocalService(service.name, service.status)) },
                 )
-            }
-
-            if (stopped.isNotEmpty()) {
-                item { ModelPickerSectionHeader("Stopped") }
-                items(stopped, key = { "stopped:${it.name}" }) { service ->
-                    // F07-R2: visible, greyed, and not clickable — starting one
-                    // is F11's guarded action, reached from there, not here.
-                    LocalServiceRow(service = service, selected = false, onClick = null)
-                }
             }
 
             if (remoteModelsConfigured && remoteModels.isNotEmpty()) {
@@ -123,49 +119,38 @@ fun ModelPickerSheet(
     }
 }
 
+/** Only ever called with a running service (F07-RO removed the stopped/disabled row state). */
 @Composable
-private fun LocalServiceRow(service: ServiceSummary, selected: Boolean, onClick: (() -> Unit)?) {
+private fun LocalServiceRow(service: ServiceSummary, selected: Boolean, onClick: () -> Unit) {
     val colors = LlmTheme.colors
-    val enabled = onClick != null
-    val rowAlpha = if (enabled) 1f else 0.5f
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(if (selected) colors.accentDeep.copy(alpha = 0.25f) else colors.surface)
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp)
             .testTag("model_option_${service.name}"),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Box(
-            Modifier.size(8.dp).clip(CircleShape)
-                .background(if (service.isRunning) colors.green else colors.subtle.copy(alpha = rowAlpha)),
-        )
+        Box(Modifier.size(8.dp).clip(CircleShape).background(colors.green))
         Column(Modifier.weight(1f)) {
             Text(
                 service.name,
-                color = colors.fg.copy(alpha = rowAlpha),
+                color = colors.fg,
                 fontFamily = FontFamily.Monospace,
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                "${service.engine.label()} · :${service.port}${service.statusSuffix()}",
-                color = colors.subtle.copy(alpha = rowAlpha),
+                "${service.engine.label()} · :${service.port}",
+                color = colors.subtle,
                 style = MaterialTheme.typography.bodySmall,
             )
         }
         if (selected) Text("✓", color = colors.accent, style = MaterialTheme.typography.titleMedium)
     }
-}
-
-/** `running`/`exited`/`not-created` — R2's second criterion: the two stopped states read differently. */
-private fun ServiceSummary.statusSuffix(): String = when (status) {
-    "running" -> ""
-    "not-created" -> " · not created"
-    else -> " · $status"
 }
 
 @Composable
@@ -196,6 +181,17 @@ private fun RemoteModelRow(option: ModelOption.Remote, selected: Boolean, onClic
         if (selected) Text("✓", color = colors.accent, style = MaterialTheme.typography.titleMedium)
     }
 }
+
+/** F07-RO: the owner's exact wording for the local-only empty state. */
+internal const val NOTHING_RUNNING_TEXT = "No LLM-Dock models are running at this time."
+
+/**
+ * Chat-capable AND currently running — the only local services the picker
+ * ever renders since F07-RO dropped the "Stopped" section. Pulled out of
+ * the composable so it's testable on the JVM without Compose.
+ */
+internal fun runningChatCapable(services: List<ServiceSummary>): List<ServiceSummary> =
+    services.filter { it.isChatCapable && it.isRunning }.sortedByDescending { it.favorite }
 
 @Composable
 private fun ModelPickerSectionHeader(title: String) {

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/ServiceSummaryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/ServiceSummaryTest.kt
@@ -49,8 +49,10 @@ class ServiceSummaryTest {
 
     @Test
     fun `a stopped chat-capable service is still chat-capable, just not running`() {
-        // F07-R2 needs the stopped row to remain visible in the picker's
-        // filter — only selectability (isRunning) is meant to gate it.
+        // Data-model level only: isChatCapable is a static property of the
+        // service, independent of its current status. Since F07-RO, the
+        // picker itself additionally requires isRunning before a local
+        // service is shown at all — see ModelPickerSheetTest.
         val service = ServiceSummary("ds4-a", "exited", "chat")
         assertTrue(service.isChatCapable)
         assertFalse(service.isRunning)

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheetTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/modelpicker/ModelPickerSheetTest.kt
@@ -1,0 +1,53 @@
+package com.hpz.llmdockchat.feature.modelpicker
+
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * F07-RO (owner-requested deviation from F07-R2): the picker no longer has a
+ * "Stopped" section, so [runningChatCapable] and [NOTHING_RUNNING_TEXT] are
+ * pulled out of [ModelPickerSheet] to be testable without Compose — there is
+ * no on-device way to see the empty state, since the dev rig always has at
+ * least one chat-capable service running.
+ */
+class ModelPickerSheetTest {
+
+    @Test
+    fun `a stopped service never appears in the running list`() {
+        val running = ServiceSummary("llamacpp-a", "running", "chat")
+        val exited = ServiceSummary("llamacpp-b", "exited", "chat")
+        val notCreated = ServiceSummary("llamacpp-c", "not-created", "chat")
+
+        val result = runningChatCapable(listOf(running, exited, notCreated))
+
+        assertEquals(listOf(running), result)
+    }
+
+    @Test
+    fun `a non chat-capable running service never appears, even though it is running`() {
+        val embedding = ServiceSummary("vllm-bge-m3", "running", "embedding")
+        val openWebui = ServiceSummary("open-webui", "running", "chat")
+
+        val result = runningChatCapable(listOf(embedding, openWebui))
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `running favourites sort first, ties otherwise kept in server order`() {
+        val a = ServiceSummary("llamacpp-a", "running", "chat", favorite = false)
+        val b = ServiceSummary("llamacpp-b", "running", "chat", favorite = true)
+        val c = ServiceSummary("llamacpp-c", "running", "chat", favorite = false)
+
+        val result = runningChatCapable(listOf(a, b, c))
+
+        assertEquals(listOf(b, a, c), result)
+    }
+
+    @Test
+    fun `the empty-state text matches the owner's wording exactly`() {
+        assertEquals("No LLM-Dock models are running at this time.", NOTHING_RUNNING_TEXT)
+    }
+}


### PR DESCRIPTION
Owner's call after using the picker on the real rig: *"only show running models. don't show grayed out models — that is just noise."*

This rig runs about one model against half a dozen stopped ones, so the greyed rows dominated a sheet in which none of them could be tapped. Seeing every model is the Models tab's job (F10/F11), which is where starting one belongs anyway.

**This reverses F07-R2**, which asked for stopped services rendered greyed and disabled, and deviates from mockup 07a. Both are recorded in the feature file with the reasoning rather than left as silent drift.

## Changes

- The "Stopped" section is gone entirely — not greyed, not disabled, **absent**. Absent is also safer than disabled: a row that does not exist cannot be mis-tapped.
- Empty state is now exactly `No LLM-Dock models are running at this time.`, held in `NOTHING_RUNNING_TEXT` so the wording is assertable rather than a literal buried in a `Text()`.
- `LocalServiceRow`'s `onClick` goes from nullable to required, making the disabled-row state structurally impossible rather than merely unused. `statusSuffix()` went with it — it could only ever return `""`.
- The filter is `runningChatCapable()`, a pure top-level function, so it is JVM-testable without Compose (this project has no Compose UI test infrastructure).

**Filtering stays in the picker UI.** `ServicesStreamRepository`, `ServiceDto`, `ServiceSummary` and the stream parser still carry stopped services, because F10's Models tab needs them. Filtering at the source would look tidier today and quietly break F10.

**OpenRouter is untouched** — those models are always reachable, so there is no stopped state to filter, and the group still renders when no local model is running.

## Verification

352 tests pass (was 348; +4, nothing removed or weakened). `assembleDebug` clean.

The empty state is now **verified on device** rather than only by unit test — the rig happened to have nothing chat-capable running, which is the state that could not be forced earlier because no agent may stop a container.