### PR TITLE
F08: per-conversation tools

### DIFF
--- a/android/docs/F07-model-selection.md
+++ b/android/docs/F07-model-selection.md
@@ -142,9 +142,9 @@ rendered anywhere in the app, or written to logs.
 
 ## Verification notes
 
-**Two R1 criteria are outstanding, both needing a container transition
-this project's agents are forbidden to make.** Everything else in R1,
-R4 and R6 is verified on device; R3 and R5 are verified apart from the
+**One R1 criterion is outstanding**, needing a container transition this
+project's agents are forbidden to make. Everything else in R1, R4 and R6
+is verified on device; R3 and R5 are verified apart from the
 sub-criteria named below.
 
 R2's original criteria were verified on device *before* the requirement
@@ -155,8 +155,17 @@ revised R2 asserts the opposite, that they do not render at all.
 | Outstanding | Why it could not be closed |
 |---|---|
 | R1 · live add on start elsewhere | No agent may start or stop a container. JVM evidence only: `ServicesStreamRepositoryTest` (merge + reconnect) and `NewChatViewModelTest`'s delta-updates-the-list test. |
-| R1 · empty state on screen | `llamacpp-mimo-v2-5-q4` is the rig's only running chat-capable service and cannot be stopped to force the branch. The **string** is unit-tested; how the branch *looks* is not, and cannot be — this project has no Compose UI test infrastructure. |
 | R3 · group hidden when unconfigured | Needs a dashboard with no `OPENROUTER_API_KEY`. |
+
+**R1's empty state is now CLOSED** (2026-07-25), verified on device rather
+than only by unit test. It could not be forced — no agent may stop the
+rig's last running model — but the owner stopped
+`llamacpp-mimo-v2-5-q4` while working on something else, and the branch
+was screenshotted in that window: the exact string, in amber, with no
+Stopped section and the OpenRouter group still listed beneath it.
+
+That leaves **one** outstanding R1 criterion, the live add on a container
+starting elsewhere.
 
 **The empty state matters more since R2 was revised.** With stopped
 models no longer listed, a picker with nothing running is now completely
@@ -164,10 +173,11 @@ empty apart from the OpenRouter group — so that one string is the entire
 local half of the screen. It was a rare corner when stopped rows filled
 the sheet; it is the normal appearance of an idle rig now.
 
-**One owner action closes both R1 items:** open the model picker, stop
-`llamacpp-mimo-v2-5-q4`, watch the row grey out and the empty state
-appear, then start it again and watch it return — all without touching
-refresh.
+**What closes the last R1 item:** with the model picker open, start any
+chat-capable container and watch it appear in the list without touching
+refresh. Since the revised R2 hides stopped services, a stop/start is now
+a *clearer* test than it was — the sheet goes from empty to populated,
+rather than one row changing shade.
 
 **The engine-prefix filter is load-bearing, not redundant with `kind`.**
 `open-webui` is genuinely `running` with `kind: "chat"` on this rig, so

--- a/android/docs/F08-conversation-tools.md
+++ b/android/docs/F08-conversation-tools.md
@@ -98,6 +98,60 @@ is needed for them, and nothing must break on them.
 
 None.
 
+## Verification notes
+
+**A stale-write race was found in review and fixed.** Toggling three
+tools at ordinary tapping speed left the server holding an *earlier*
+selection than the sheet showed, and a tool the user never chose
+(`browser-fetch`) appeared enabled on reopening. Reproduced through
+normal use, not a stress case.
+
+Cause: `toggleTool` PUT the **whole** id array optimistically and
+cancelled the previous write. But `ApiClient.request` uses a blocking
+`client.newCall(...).execute()` that is not cancellation-aware, so
+cancelling the coroutine did not recall a request already on the wire —
+it landed whenever it landed, in any order, and `apiCall` rethrows
+`CancellationException`, so the outcome was discarded silently.
+
+Fixed by **serialising the writes** behind a `Mutex` in `ThreadViewModel`
+with a monotonic toggle counter. Ordering alone suffices because each PUT
+carries the absolute list, not a delta: the last one queued is the last
+one sent and is authoritative. The counter preserves the old `cancel()`'s
+intent — only the newest toggle's own failure reverts the sheet, so a
+stale failure cannot fight a newer write that is about to set the right
+value anyway.
+
+The mutex is per-ViewModel, deliberately. `ConversationsRepository` is an
+app-wide singleton, so locking there would serialise unrelated
+conversations.
+
+**Cancellation-awareness in `ApiClient` was considered and rejected**, and
+would not have fixed this anyway — cancellation always races delivery.
+It is also not free: `stop()` fires `cancelActiveRun` in `viewModelScope`,
+so an abortable one-shot client would mean tapping Stop and immediately
+navigating back kills the cancel POST in flight, leaving the run alive
+server-side — a regression in already-verified F04-R6. The streaming path
+is already cancellation-aware where it needed to be
+(`OkHttpSseTransport` holds and cancels its own `Call`). If F09 wants
+this, it should be opt-in per call site, since each needs its own answer
+to F04-R10's "navigation is not cancellation".
+
+**Outstanding**
+
+| Item | Why |
+|---|---|
+| R4 during a real run | Verified by JVM test (the guard blocks both open and toggle; the server is never contacted) and by inspection (`enabled = canOpenTools`, not merely relabelled). Not caught on screen: turns on this rig finish in under a second, too fast to screenshot a stable generating state. |
+| R1 · dynamic registry reload | Requires editing `mcp_servers.json` and reloading the registry — a dashboard configuration action, out of scope for the app and for its agents. |
+| R5 · project file tools (Should) | No project-scoped conversation on hand. F04's `ToolCallCard` special-cases no server id, so a project-files call renders like any other; confirmed by inspection only. |
+
+**MockWebServer cannot express the write race.** It replies in the order
+responses were queued and both requests arrive in send order, so the
+reordering never occurs. The regression test uses a repository subclass
+whose writes park on per-call gates, plus a main-executor drain so
+"has the next write been sent yet?" is a settled question rather than a
+timing accident. An earlier gate-only version of that test passed even
+against the broken code.
+
 ## Out of scope
 
 - Editing the MCP registry (`/api/chat/mcp-registry/*`). Dashboard only.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -181,7 +181,7 @@ Mark completed features `[DONE]` in the Status column.
 | F05 | Rendering assistant output | [F05-message-rendering.md](F05-message-rendering.md) | 05 | [DONE] |
 | F06 | Message actions | [F06-message-actions.md](F06-message-actions.md) | 06b | [DONE] |
 | F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [WIP] — two R1 criteria need a container transition, see the feature file |
-| F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [ ] |
+| F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [DONE] — R5 (Should) unexercised, see the feature file |
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [ ] |
 | F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [ ] |
 | F11 | Model detail, start and stop | [F11-model-detail-and-control.md](F11-model-detail-and-control.md) | 10b, 10d | [ ] |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ConversationsRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ConversationsRepository.kt
@@ -27,7 +27,7 @@ import kotlinx.serialization.encodeToString
  * thread count, so the simplicity of one request wins (see F02's
  * *Deviations*).
  */
-class ConversationsRepository(private val api: ApiClient) {
+open class ConversationsRepository(private val api: ApiClient) {
 
     suspend fun list(): Result<List<ConversationSummary>> = apiCall {
         api.get(
@@ -77,8 +77,12 @@ class ConversationsRepository(private val api: ApiClient) {
      * `PUT /api/chat/conversations/<id>` with `mcp_servers_json` (F03-R3) —
      * the only way to set tools on a thread just created via [create], which
      * does not accept the field.
+     *
+     * `open` so a test can stand in a write whose completion order it
+     * controls — the lost-update race this replaces was invisible to a
+     * MockWebServer test, which answers in the order it was handed responses.
      */
-    suspend fun setMcpServers(id: String, serverIds: List<String>): Result<Unit> = apiCall {
+    open suspend fun setMcpServers(id: String, serverIds: List<String>): Result<Unit> = apiCall {
         api.request(
             method = "PUT",
             path = Endpoints.conversation(id),

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapper.kt
@@ -29,6 +29,7 @@ fun ConversationDetailDto.toDomain(): ConversationDetail = ConversationDetail(
     activeRun = activeRun?.toActiveRun(),
     lastRun = lastRun?.toLastRun(),
     updatedAt = updatedAt,
+    mcpServers = mcpServers,
 )
 
 private fun ChatMessageDto.toDomain(artifacts: List<ArtifactDto>): ChatMessage = ChatMessage(

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ChatMessage.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ChatMessage.kt
@@ -78,6 +78,13 @@ data class ConversationDetail(
     val activeRun: ActiveRun?,
     val lastRun: LastRun?,
     val updatedAt: String?,
+    /**
+     * The enabled MCP server ids (F08). Read-only here — `mcp_servers` on the
+     * wire is a read-only array; changing it goes through
+     * `ConversationsRepository.setMcpServers`'s `mcp_servers_json` PUT
+     * (Architecture D6), never a write to this field.
+     */
+    val mcpServers: List<String> = emptyList(),
 ) {
     val isGenerating: Boolean
         get() = activeRun != null && activeRun.status in GENERATING_STATUSES

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -44,9 +42,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.data.model.ManagedPrompt
-import com.hpz.llmdockchat.data.model.McpServerInfo
 import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.feature.modelpicker.ModelPickerSheet
+import com.hpz.llmdockchat.feature.toolspicker.ToolsPickerSheet
 
 /**
  * Screen 03 · New chat sheet (F03). A pushed screen rather than a modal, as
@@ -396,64 +394,6 @@ private fun PromptPickerSheet(
                 )
             }
             item { Spacer(Modifier.height(16.dp)) }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ToolsPickerSheet(
-    servers: List<McpServerInfo>,
-    selectedIds: Set<String>,
-    onToggle: (String) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val colors = LlmTheme.colors
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = colors.surface,
-        modifier = Modifier.testTag("tools_picker_sheet"),
-    ) {
-        // C3: the sheet draws behind the navigation bar, so without
-        // this its last row is unreachable under the 44 dp button bar.
-        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
-            items(servers, key = { it.id }) { server ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onToggle(server.id) }
-                        .padding(horizontal = 16.dp, vertical = 10.dp)
-                        .testTag("tool_option_${server.id}"),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Checkbox(
-                        checked = server.id in selectedIds,
-                        onCheckedChange = { onToggle(server.id) },
-                        colors = CheckboxDefaults.colors(checkedColor = colors.accent, uncheckedColor = colors.subtle),
-                    )
-                    Column(Modifier.weight(1f)) {
-                        Text(server.name, color = colors.fg, style = MaterialTheme.typography.bodyLarge)
-                        Text(
-                            server.description,
-                            color = colors.muted,
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-            }
-            item {
-                TextButton(
-                    onClick = onDismiss,
-                    modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("tools_picker_done"),
-                ) {
-                    Text("Done", color = colors.accent)
-                }
-            }
         }
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadScreen.kt
@@ -74,6 +74,7 @@ import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ModelRef
 import com.hpz.llmdockchat.data.model.displayName
 import com.hpz.llmdockchat.feature.modelpicker.ModelPickerSheet
+import com.hpz.llmdockchat.feature.toolspicker.ToolsPickerSheet
 import kotlinx.coroutines.launch
 
 /**
@@ -119,6 +120,9 @@ fun ThreadScreen(
         onOpenModelPicker = viewModel::openModelPicker,
         onCloseModelPicker = viewModel::closeModelPicker,
         onSwitchModel = { viewModel.switchModel(it.ref) },
+        onOpenToolsPicker = viewModel::openToolsPicker,
+        onCloseToolsPicker = viewModel::closeToolsPicker,
+        onToggleTool = viewModel::toggleTool,
         modifier = modifier,
     )
 }
@@ -148,6 +152,9 @@ private fun ThreadContent(
     onOpenModelPicker: () -> Unit,
     onCloseModelPicker: () -> Unit,
     onSwitchModel: (ModelOption) -> Unit,
+    onOpenToolsPicker: () -> Unit,
+    onCloseToolsPicker: () -> Unit,
+    onToggleTool: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LlmTheme.colors
@@ -207,7 +214,14 @@ private fun ThreadContent(
                     }
                 },
                 actions = {
-                    if (loaded != null) ThreadOverflowMenu(canSwitchModel = loaded.canSwitchModel, onOpenModelPicker = onOpenModelPicker)
+                    if (loaded != null) {
+                        ThreadOverflowMenu(
+                            canSwitchModel = loaded.canSwitchModel,
+                            onOpenModelPicker = onOpenModelPicker,
+                            canOpenTools = loaded.canOpenTools,
+                            onOpenToolsPicker = onOpenToolsPicker,
+                        )
+                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
             )
@@ -310,10 +324,29 @@ private fun ThreadContent(
             onDismiss = onCloseModelPicker,
         )
     }
+
+    // F08 — the same picker as F03's (screen 07b), reached from the overflow
+    // menu. Selected ids come from the conversation itself, not local sheet
+    // state: `mcpServers` is the server's own array, and `toggleTool` updates
+    // it optimistically the instant a row is tapped (F08-R2).
+    loaded?.toolsPicker?.let { picker ->
+        ToolsPickerSheet(
+            servers = picker.servers,
+            selectedIds = loaded.conversation.mcpServers.toSet(),
+            onToggle = onToggleTool,
+            onDismiss = onCloseToolsPicker,
+            hint = "Changes apply to the next message you send.",
+        )
+    }
 }
 
 @Composable
-private fun ThreadOverflowMenu(canSwitchModel: Boolean, onOpenModelPicker: () -> Unit) {
+private fun ThreadOverflowMenu(
+    canSwitchModel: Boolean,
+    onOpenModelPicker: () -> Unit,
+    canOpenTools: Boolean,
+    onOpenToolsPicker: () -> Unit,
+) {
     val colors = LlmTheme.colors
     var expanded by remember { mutableStateOf(false) }
     IconButton(onClick = { expanded = true }, modifier = Modifier.testTag("thread_overflow")) {
@@ -328,6 +361,15 @@ private fun ThreadOverflowMenu(canSwitchModel: Boolean, onOpenModelPicker: () ->
                 onOpenModelPicker()
             },
             modifier = Modifier.testTag("thread_switch_model"),
+        )
+        DropdownMenuItem(
+            text = { Text(if (canOpenTools) "Tools" else "Tools (run active)") },
+            enabled = canOpenTools,
+            onClick = {
+                expanded = false
+                onOpenToolsPicker()
+            },
+            modifier = Modifier.testTag("thread_tools"),
         )
     }
 }
@@ -743,6 +785,7 @@ private fun ThreadStreamingPreview() {
             onRequestDelete = {}, onCancelDelete = {}, onConfirmDelete = {},
             onBeginEdit = {}, onCancelEdit = {}, onRequestEditConfirm = {}, onCancelEditConfirm = {}, onConfirmEdit = {},
             onOpenModelPicker = {}, onCloseModelPicker = {}, onSwitchModel = {},
+            onOpenToolsPicker = {}, onCloseToolsPicker = {}, onToggleTool = {},
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadState.kt
@@ -3,6 +3,7 @@ package com.hpz.llmdockchat.feature.thread
 import com.hpz.llmdockchat.data.model.ArtifactRecord
 import com.hpz.llmdockchat.data.model.ChatMessage
 import com.hpz.llmdockchat.data.model.ConversationDetail
+import com.hpz.llmdockchat.data.model.McpServerInfo
 import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ParseWarning
 import com.hpz.llmdockchat.data.model.ServiceSummary
@@ -106,6 +107,17 @@ data class ModelPickerState(
     val remoteModelsConfigured: Boolean = false,
 )
 
+/**
+ * The "tools for this chat" sheet (F08), open only while
+ * [ThreadUiState.Loaded.toolsPicker] is non-null. Unlike [ModelPickerState],
+ * which subscribes to a live stream for the sheet's whole time on screen,
+ * [servers] is a one-shot fetch on open ([ThreadViewModel.openToolsPicker]) —
+ * the registry doesn't change often enough mid-session to warrant a
+ * subscription, and re-fetching on every open already satisfies F08-R1's
+ * "reloading the registry makes it appear without an app update".
+ */
+data class ToolsPickerState(val servers: List<McpServerInfo> = emptyList())
+
 sealed interface ThreadUiState {
     data object Loading : ThreadUiState
 
@@ -132,6 +144,8 @@ sealed interface ThreadUiState {
         val pendingEdit: PendingEdit? = null,
         /** Non-null exactly while the "switch model" sheet (F07-R4) is open. */
         val modelPicker: ModelPickerState? = null,
+        /** Non-null exactly while the "tools for this chat" sheet (F08) is open. */
+        val toolsPicker: ToolsPickerState? = null,
     ) : ThreadUiState {
 
         /**
@@ -150,6 +164,10 @@ sealed interface ThreadUiState {
 
         /** F07-R4's third criterion — switching is unavailable while a run is active. */
         val canSwitchModel: Boolean
+            get() = !runActive
+
+        /** F08-R4 — the sheet is unavailable while a run is active, so a toggle can never race a turn that already started. */
+        val canOpenTools: Boolean
             get() = !runActive
 
         /**

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/thread/ThreadViewModel.kt
@@ -7,6 +7,8 @@ import com.hpz.llmdockchat.core.net.RunEvent
 import com.hpz.llmdockchat.core.net.appError
 import com.hpz.llmdockchat.core.prefs.DraftStore
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ArtifactRecord
@@ -24,6 +26,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * One thread: load it, send a turn, render the stream, stop it (F04).
@@ -39,6 +43,8 @@ class ThreadViewModel(
     private val drafts: DraftStore,
     private val servicesStreamRepository: ServicesStreamRepository,
     private val openRouterModelsRepository: OpenRouterModelsRepository,
+    private val conversationsRepository: ConversationsRepository,
+    private val mcpServersRepository: McpServersRepository,
     private val coalesceWindowMs: Long = DEFAULT_COALESCE_WINDOW_MS,
     private val titleSettleDelayMs: Long = DEFAULT_TITLE_SETTLE_DELAY_MS,
 ) : ViewModel() {
@@ -50,6 +56,26 @@ class ThreadViewModel(
 
     /** The model picker's own live subscription — separate from [streamJob], which is the chat run's. */
     private var modelPickerJob: Job? = null
+
+    /**
+     * Serialises the tools writes (F08-R2). Every toggle PUTs the **whole**
+     * server-id array, so two writes in flight at once is a lost-update race:
+     * the earlier one can reach the server last and leave it holding a list
+     * the sheet no longer shows. Cancelling the earlier coroutine does not
+     * help — `ApiClient` runs a blocking call, and a request already handed
+     * to the server cannot be recalled — so the writes are ordered instead.
+     * The last one queued is the last one sent, and it carries the newest
+     * selection, so the server deterministically ends up agreeing with the UI.
+     */
+    private val toolsWriteLock = Mutex()
+
+    /**
+     * Which toggle is the newest, so a *stale* write's failure is not acted
+     * on: a later write carries the whole array and will establish the right
+     * state on its own, and reverting to a superseded selection would fight
+     * it. Only the most recent toggle's own outcome reverts the sheet.
+     */
+    private var latestToolsToggle = 0L
 
     /** What the composer held before [beginEdit] overwrote it, restored by [cancelEdit]. */
     private var composerBeforeEdit: String = ""
@@ -238,6 +264,72 @@ class ThreadViewModel(
                     loaded()?.let { _state.value = it.copy(actionError = failure.appError.displayMessage) }
                 },
             )
+        }
+    }
+
+    // -- tools for this chat (F08) ----------------------------------------------
+
+    /**
+     * Opens the sheet and fetches the registry once (unlike [openModelPicker],
+     * no live subscription — see [ToolsPickerState]'s doc for why a one-shot
+     * fetch already satisfies F08-R1's "no app update needed" criterion).
+     * Guarded by [ThreadUiState.Loaded.canOpenTools] the same way
+     * [openModelPicker] guards on [ThreadUiState.Loaded.canSwitchModel]
+     * (F08-R4): with the sheet unreachable during a run, a toggle can never
+     * race the turn already in flight.
+     */
+    fun openToolsPicker() {
+        val current = loaded() ?: return
+        if (!current.canOpenTools) return
+        _state.value = current.copy(toolsPicker = ToolsPickerState())
+        viewModelScope.launch {
+            val servers = mcpServersRepository.list().getOrNull().orEmpty()
+            val stillOpen = loaded() ?: return@launch
+            if (stillOpen.toolsPicker != null) {
+                _state.value = stillOpen.copy(toolsPicker = ToolsPickerState(servers = servers))
+            }
+        }
+    }
+
+    fun closeToolsPicker() {
+        loaded()?.let { _state.value = it.copy(toolsPicker = null) }
+    }
+
+    /**
+     * `PUT /api/chat/conversations/<id>` with `mcp_servers_json` (F08-R2) —
+     * the same call [com.hpz.llmdockchat.feature.newchat.NewChatViewModel]
+     * uses for a brand-new thread, reused here for an existing one.
+     *
+     * Applied optimistically — the switch in the sheet must flip the instant
+     * it's tapped, not after a round trip — and rolled back to exactly what
+     * it was before this toggle if the write fails, so the UI never claims a
+     * state the server doesn't have (F08-R2's fourth criterion). No refetch
+     * on success: the writes are ordered by [toolsWriteLock], so the array
+     * this client wrote last is already what the server has — a refetch
+     * would cost a round trip to learn what it just told the server.
+     */
+    fun toggleTool(serverId: String) {
+        val current = loaded() ?: return
+        if (!current.canOpenTools) return
+        val previous = current.conversation.mcpServers
+        val next = if (serverId in previous) previous - serverId else previous + serverId
+        _state.value = current.copy(conversation = current.conversation.copy(mcpServers = next))
+
+        val toggle = ++latestToolsToggle
+        viewModelScope.launch {
+            toolsWriteLock.withLock {
+                conversationsRepository.setMcpServers(conversationId, next).fold(
+                    onSuccess = {},
+                    onFailure = { failure ->
+                        if (toggle != latestToolsToggle) return@fold
+                        val latest = loaded() ?: return@fold
+                        _state.value = latest.copy(
+                            conversation = latest.conversation.copy(mcpServers = previous),
+                            actionError = failure.appError.displayMessage,
+                        )
+                    },
+                )
+            }
         }
     }
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/toolspicker/ToolsPickerSheet.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/toolspicker/ToolsPickerSheet.kt
@@ -1,0 +1,115 @@
+package com.hpz.llmdockchat.feature.toolspicker
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.McpServerInfo
+
+/**
+ * Which MCP servers a thread may call (F03-R3, F08), shared by
+ * [com.hpz.llmdockchat.feature.newchat.NewChatScreen] (picking a default for
+ * a brand-new thread — the batched, not-yet-persisted selection) and
+ * [com.hpz.llmdockchat.feature.thread.ThreadScreen] (F08's in-thread sheet,
+ * where each [onToggle] is the caller's cue to persist immediately). Grown
+ * out of F03's own private composable once F08 needed the same list and row
+ * shape for an existing conversation — see F08's report for why sharing it
+ * cost nothing: the list of servers, the checkbox row and the Done button are
+ * identical in both places, only what a toggle *does* differs, and that
+ * belongs to the caller's [onToggle], not to this composable.
+ *
+ * [hint], when non-null, renders above the list — F08 uses it for the
+ * mockup's "Changes apply to the next message you send" (screen 07b); F03
+ * passes none, since nothing has been sent yet for that to be true of.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToolsPickerSheet(
+    servers: List<McpServerInfo>,
+    selectedIds: Set<String>,
+    onToggle: (String) -> Unit,
+    onDismiss: () -> Unit,
+    hint: String? = null,
+) {
+    val colors = LlmTheme.colors
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = colors.surface,
+        modifier = Modifier.testTag("tools_picker_sheet"),
+    ) {
+        // C3: the sheet draws behind the navigation bar, so without
+        // this its last row is unreachable under the 44 dp button bar.
+        LazyColumn(Modifier.fillMaxWidth().navigationBarsPadding()) {
+            if (hint != null) {
+                item {
+                    Text(
+                        hint,
+                        color = colors.subtle,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                            .testTag("tools_picker_hint"),
+                    )
+                }
+            }
+            items(servers, key = { it.id }) { server ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onToggle(server.id) }
+                        .padding(horizontal = 16.dp, vertical = 10.dp)
+                        .testTag("tool_option_${server.id}"),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Checkbox(
+                        checked = server.id in selectedIds,
+                        onCheckedChange = { onToggle(server.id) },
+                        colors = CheckboxDefaults.colors(checkedColor = colors.accent, uncheckedColor = colors.subtle),
+                    )
+                    Column(Modifier.weight(1f)) {
+                        Text(server.name, color = colors.fg, style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            server.description,
+                            color = colors.muted,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+            item {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("tools_picker_done"),
+                ) {
+                    Text("Done", color = colors.accent)
+                }
+            }
+        }
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -126,6 +126,8 @@ fun AppNavHost(
                             drafts = container.draftStore,
                             servicesStreamRepository = container.servicesStreamRepository,
                             openRouterModelsRepository = container.openRouterModelsRepository,
+                            conversationsRepository = container.conversationsRepository,
+                            mcpServersRepository = container.mcpServersRepository,
                         )
                     }
                 },

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapperTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/mapper/ChatThreadMapperTest.kt
@@ -53,4 +53,24 @@ class ChatThreadMapperTest {
 
         assertEquals(emptyList<Any>(), domain.messages.single().artifacts)
     }
+
+    /** F08 reads the enabled tool set through this same mapper (Architecture D6). */
+    @Test
+    fun `mcp_servers is carried through to the domain model`() {
+        val dto = ConversationDetailDto(
+            id = "c1",
+            title = "t",
+            mainService = "llamacpp-laguna-s-2.1-q4",
+            mcpServers = listOf("sympy-math", "websearch"),
+        )
+
+        assertEquals(listOf("sympy-math", "websearch"), dto.toDomain().mcpServers)
+    }
+
+    @Test
+    fun `a missing mcp_servers key maps to an empty list`() {
+        val dto = ConversationDetailDto(id = "c1", title = "t", mainService = "llamacpp-laguna-s-2.1-q4")
+
+        assertEquals(emptyList<String>(), dto.toDomain().mcpServers)
+    }
 }

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
@@ -13,6 +13,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.ChatMessage
@@ -61,6 +63,8 @@ class ThreadMessageActionsTest {
     private lateinit var repository: ChatRepository
     private lateinit var servicesStreamRepository: ServicesStreamRepository
     private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var mcpServersRepository: McpServersRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "actions-main") }
 
@@ -80,6 +84,8 @@ class ThreadMessageActionsTest {
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
         servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
         openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        conversationsRepository = ConversationsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        mcpServersRepository = McpServersRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -103,6 +109,8 @@ class ThreadMessageActionsTest {
                     drafts = drafts,
                     servicesStreamRepository = servicesStreamRepository,
                     openRouterModelsRepository = openRouterModelsRepository,
+                    conversationsRepository = conversationsRepository,
+                    mcpServersRepository = mcpServersRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = 1,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
@@ -11,6 +11,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.testing.FakeDraftStore
@@ -61,6 +63,8 @@ class ThreadStreamingEdgeTest {
     private lateinit var repository: ChatRepository
     private lateinit var servicesStreamRepository: ServicesStreamRepository
     private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var mcpServersRepository: McpServersRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "probe-main") }
 
@@ -82,6 +86,8 @@ class ThreadStreamingEdgeTest {
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
         servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
         openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        conversationsRepository = ConversationsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        mcpServersRepository = McpServersRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -108,6 +114,8 @@ class ThreadStreamingEdgeTest {
                     drafts = drafts,
                     servicesStreamRepository = servicesStreamRepository,
                     openRouterModelsRepository = openRouterModelsRepository,
+                    conversationsRepository = conversationsRepository,
+                    mcpServersRepository = mcpServersRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = titleSettleDelayMs,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
@@ -11,6 +11,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.testing.FakeDraftStore
@@ -63,6 +65,8 @@ class ThreadTerminalPathTest {
     private lateinit var repository: ChatRepository
     private lateinit var servicesStreamRepository: ServicesStreamRepository
     private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var mcpServersRepository: McpServersRepository
     private val store = ViewModelStore()
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "terminal-main") }
 
@@ -83,6 +87,8 @@ class ThreadTerminalPathTest {
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
         servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
         openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        conversationsRepository = ConversationsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        mcpServersRepository = McpServersRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -109,6 +115,8 @@ class ThreadTerminalPathTest {
                     drafts = FakeDraftStore(),
                     servicesStreamRepository = servicesStreamRepository,
                     openRouterModelsRepository = openRouterModelsRepository,
+                    conversationsRepository = conversationsRepository,
+                    mcpServersRepository = mcpServersRepository,
                     coalesceWindowMs = 0,
                     titleSettleDelayMs = 1L,
                 )

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadToolsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadToolsTest.kt
@@ -1,0 +1,389 @@
+package com.hpz.llmdockchat.feature.thread
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.hpz.llmdockchat.core.auth.Reauthenticator
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.SessionAuthenticator
+import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
+import com.hpz.llmdockchat.data.OpenRouterModelsRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.testing.FakeDraftStore
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import com.hpz.llmdockchat.testing.readFixture
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The "tools for this chat" sheet (F08) — the in-thread half of F03-R3's
+ * server list, and the toggle-with-optimistic-revert shape that
+ * `mcp_servers`/`mcp_servers_json`'s read/write asymmetry (Architecture D6)
+ * forces on every write here.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThreadToolsTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var transport: FakeSseTransport
+    private lateinit var drafts: FakeDraftStore
+    private lateinit var repository: ChatRepository
+    private lateinit var servicesStreamRepository: ServicesStreamRepository
+    private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var conversationsApi: ApiClient
+    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var mcpServersRepository: McpServersRepository
+    private val store = ViewModelStore()
+    private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "tools-main") }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainExecutor.asCoroutineDispatcher())
+        server = MockWebServer()
+        server.start()
+        transport = FakeSseTransport()
+        drafts = FakeDraftStore()
+        val urlStore = FakeServerUrlStore(baseUrl(server.url("/").toString()))
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .authenticator(SessionAuthenticator(FakeTokenStore("totp-test"), SessionState(), Reauthenticator.NoCredential))
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+        repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
+        servicesStreamRepository = ServicesStreamRepository(FakeSseTransport())
+        openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        conversationsApi = ApiClient(client, urlStore, ApiJson, Dispatchers.IO)
+        conversationsRepository = ConversationsRepository(conversationsApi)
+        mcpServersRepository = McpServersRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+    }
+
+    @After
+    fun tearDown() {
+        store.clear()
+        server.close()
+        Dispatchers.resetMain()
+        mainExecutor.shutdownNow()
+    }
+
+    private fun conversation(fixture: String = "conversation_completed.json") =
+        server.enqueue(MockResponse.Builder().body(readFixture(fixture)).build())
+
+    private fun mcpServers() =
+        server.enqueue(MockResponse.Builder().body(readFixture("mcp_servers.json")).build())
+
+    private fun viewModel(
+        conversations: ConversationsRepository = conversationsRepository,
+    ): ThreadViewModel = ViewModelProvider.create(
+        store,
+        viewModelFactory {
+            initializer {
+                ThreadViewModel(
+                    conversationId = CONVERSATION_ID,
+                    repository = repository,
+                    drafts = drafts,
+                    servicesStreamRepository = servicesStreamRepository,
+                    openRouterModelsRepository = openRouterModelsRepository,
+                    conversationsRepository = conversations,
+                    mcpServersRepository = mcpServersRepository,
+                    coalesceWindowMs = 0,
+                    titleSettleDelayMs = 1,
+                )
+            }
+        },
+    )[ThreadViewModel::class]
+
+    private fun threadTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }
+
+    /**
+     * Runs the main dispatcher's queue dry. [mainExecutor] is single-threaded
+     * and FIFO, so a task submitted now cannot finish before everything queued
+     * ahead of it has run to its next suspension point — which makes "has the
+     * next write gone out yet?" a settled question rather than a race.
+     */
+    private fun drainMain() {
+        mainExecutor.submit { }.get(10, TimeUnit.SECONDS)
+    }
+
+    private suspend fun ThreadViewModel.awaitLoaded(): ThreadUiState.Loaded =
+        withTimeout(10_000) { state.first { it is ThreadUiState.Loaded } as ThreadUiState.Loaded }
+
+    private suspend fun ThreadViewModel.awaitState(
+        predicate: (ThreadUiState.Loaded) -> Boolean,
+    ): ThreadUiState.Loaded = withTimeout(10_000) {
+        state.first { it is ThreadUiState.Loaded && predicate(it) } as ThreadUiState.Loaded
+    }
+
+    // -- F08-R1 · listing --------------------------------------------------
+
+    @Test
+    fun `openToolsPicker fetches the registry and populates the sheet`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        mcpServers()
+        viewModel.openToolsPicker()
+
+        val state = viewModel.awaitState { it.toolsPicker?.servers?.isNotEmpty() == true }
+        assertEquals(8, state.toolsPicker?.servers?.size)
+        assertEquals("sympy-math", state.toolsPicker?.servers?.first()?.id)
+    }
+
+    @Test
+    fun `closeToolsPicker dismisses the sheet`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        mcpServers()
+        viewModel.openToolsPicker()
+        viewModel.awaitState { it.toolsPicker != null }
+
+        viewModel.closeToolsPicker()
+        assertNull((viewModel.state.value as ThreadUiState.Loaded).toolsPicker)
+    }
+
+    @Test
+    fun `openToolsPicker is refused outright while a run is active`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("go")
+        transport.payloads = listOf(RUN_STARTED)
+        transport.stayOpen = true
+        viewModel.send()
+        viewModel.awaitState { it.runActive }
+
+        viewModel.openToolsPicker()
+
+        // Only the load's own GET reached the server — the guard means
+        // openToolsPicker never even tries the mcp-servers fetch.
+        assertEquals(1, server.requestCount)
+        assertNull((viewModel.state.value as ThreadUiState.Loaded).toolsPicker)
+    }
+
+    // -- F08-R2 · toggle persists, with optimistic revert on failure -------
+
+    @Test
+    fun `toggling an unset server PUTs mcp_servers_json and reflects it immediately`() = threadTest {
+        conversation() // mcp_servers: []
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(MockResponse.Builder().body("""{"id": "$CONVERSATION_ID"}""").build())
+        viewModel.toggleTool("sympy-math")
+
+        val state = viewModel.awaitState { "sympy-math" in it.conversation.mcpServers }
+        assertEquals(listOf("sympy-math"), state.conversation.mcpServers)
+
+        server.takeRequest() // load()'s own GET, issued first
+        val put = server.takeRequest()
+        assertEquals("PUT", put.method)
+        assertEquals("""{"mcp_servers_json":"[\"sympy-math\"]"}""", put.body?.utf8())
+    }
+
+    @Test
+    fun `toggling an already-enabled server removes it and PUTs the shorter array`() = threadTest {
+        conversation("conversation_tool_calls.json") // recorded with tools already enabled
+        val viewModel = viewModel()
+        viewModel.load()
+        val loaded = viewModel.awaitLoaded()
+        val enabled = loaded.conversation.mcpServers
+        assertTrue("fixture must already carry an enabled server for this test", enabled.isNotEmpty())
+        val target = enabled.first()
+
+        server.enqueue(MockResponse.Builder().body("""{"id": "$CONVERSATION_ID"}""").build())
+        viewModel.toggleTool(target)
+
+        val state = viewModel.awaitState { target !in it.conversation.mcpServers }
+        assertFalse(target in state.conversation.mcpServers)
+    }
+
+    @Test
+    fun `toggling several servers before closing the sheet persists all of them`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(MockResponse.Builder().body("""{"id": "$CONVERSATION_ID"}""").build())
+        viewModel.toggleTool("sympy-math")
+        viewModel.awaitState { it.conversation.mcpServers == listOf("sympy-math") }
+
+        server.enqueue(MockResponse.Builder().body("""{"id": "$CONVERSATION_ID"}""").build())
+        viewModel.toggleTool("websearch")
+
+        val state = viewModel.awaitState { it.conversation.mcpServers.toSet() == setOf("sympy-math", "websearch") }
+        assertEquals(2, state.conversation.mcpServers.size)
+
+        server.takeRequest() // the load
+        val firstPut = server.takeRequest()
+        assertEquals("""{"mcp_servers_json":"[\"sympy-math\"]"}""", firstPut.body?.utf8())
+        val secondPut = server.takeRequest()
+        assertEquals("""{"mcp_servers_json":"[\"sympy-math\",\"websearch\"]"}""", secondPut.body?.utf8())
+    }
+
+    @Test
+    fun `a failed write reverts the toggle and surfaces the server's message`() = threadTest {
+        conversation() // mcp_servers: []
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+
+        server.enqueue(
+            MockResponse.Builder().code(500).body("""{"error": "Conversation not found"}""").build(),
+        )
+        viewModel.toggleTool("sympy-math")
+
+        val state = viewModel.awaitState { it.actionError != null }
+        assertEquals("Conversation not found", state.actionError)
+        // The failed write must not leave the UI claiming a state the server
+        // doesn't have — the toggle reverts to what it was before.
+        assertTrue(state.conversation.mcpServers.isEmpty())
+    }
+
+    /**
+     * The lost-update race the sheet was shipped with. Every toggle PUTs the
+     * whole array, so two writes outstanding at once is a last-writer-wins
+     * fight the *earlier* one can win — which is how a server ended up
+     * holding a selection the user had already moved past, and how a tool
+     * they never tapped appeared to switch itself on.
+     *
+     * Nothing here waits on the clock: the fake parks each write on its own
+     * gate and the test opens them in the order it wants them to settle.
+     */
+    @Test
+    fun `two toggles whose writes settle out of order still leave the server holding the final selection`() =
+        threadTest {
+            conversation() // mcp_servers: []
+            val writes = OutOfOrderMcpWrites(conversationsApi)
+            val viewModel = viewModel(conversations = writes)
+            viewModel.load()
+            viewModel.awaitLoaded()
+
+            viewModel.toggleTool("sympy-math")
+            drainMain() // the first write is out and parked on its gate, unsettled
+            viewModel.toggleTool("websearch")
+            drainMain() // whatever the second toggle was going to send, it has now been sent
+
+            // Let the later write settle first and the earlier one afterwards —
+            // exactly the reordering that left the server behind the sheet.
+            // Serialised, the second write has not been sent yet, so releasing
+            // its gate up front simply lets it through when its turn comes.
+            writes.release(1)
+            writes.release(0)
+            writes.awaitSettled(2)
+
+            val shown = viewModel.awaitLoaded().conversation.mcpServers
+            assertEquals(listOf("sympy-math", "websearch"), shown)
+            assertEquals("the server must end up holding what the sheet shows", shown, writes.stored)
+        }
+
+    @Test
+    fun `toggleTool is refused outright while a run is active`() = threadTest {
+        conversation()
+        val viewModel = viewModel()
+        viewModel.load()
+        viewModel.awaitLoaded()
+        viewModel.onComposerChange("go")
+        transport.payloads = listOf(RUN_STARTED)
+        transport.stayOpen = true
+        viewModel.send()
+        viewModel.awaitState { it.runActive }
+
+        viewModel.toggleTool("sympy-math")
+
+        // Only the load's own GET reached the server — send() goes through
+        // the fake stream transport, so the guard means toggleTool never
+        // even tries the PUT.
+        assertEquals(1, server.requestCount)
+    }
+
+    private companion object {
+        const val CONVERSATION_ID = "39dc7f47-91da-4a0f-b731-59f507a12c1b"
+        const val RUN_STARTED = """{"type": "run_started", "run_id": "run-1"}"""
+    }
+}
+
+/**
+ * A [ConversationsRepository] whose `mcp_servers_json` writes settle only when
+ * the test opens their gate, so completion order is chosen rather than raced.
+ * [stored] is the server's copy: written when a call *settles*, which is the
+ * whole point — the array that lands last is the one the server keeps.
+ *
+ * The write is [NonCancellable] deliberately. `ApiClient` runs a blocking
+ * OkHttp call, so cancelling the coroutine around a PUT already on the wire
+ * does not recall it — the server still applies it. A fake that let
+ * cancellation abort the write would model a client this app does not have,
+ * and would hide the race being exercised.
+ */
+private class OutOfOrderMcpWrites(api: ApiClient) : ConversationsRepository(api) {
+    private val gates = List(GATE_COUNT) { CompletableDeferred<Unit>() }
+    private val settled = Channel<Int>(Channel.UNLIMITED)
+    private val nextIndex = AtomicInteger(0)
+
+    @Volatile
+    var stored: List<String> = emptyList()
+        private set
+
+    override suspend fun setMcpServers(id: String, serverIds: List<String>): Result<Unit> =
+        withContext(NonCancellable) {
+            val index = nextIndex.getAndIncrement()
+            gates[index].await()
+            stored = serverIds
+            settled.send(index)
+            Result.success(Unit)
+        }
+
+    /** Lets write [index] complete. Safe to call before that write has arrived. */
+    fun release(index: Int) {
+        gates[index].complete(Unit)
+    }
+
+    suspend fun awaitSettled(count: Int) {
+        withTimeout(AWAIT_TIMEOUT_MS) { repeat(count) { settled.receive() } }
+    }
+
+    private companion object {
+        const val GATE_COUNT = 8
+        /** A deadlock guard, not a timing assumption — every await here is signalled, not slept on. */
+        const val AWAIT_TIMEOUT_MS = 10_000L
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
@@ -13,6 +13,8 @@ import com.hpz.llmdockchat.core.net.ApiJson
 import com.hpz.llmdockchat.core.net.AuthInterceptor
 import com.hpz.llmdockchat.core.net.SessionAuthenticator
 import com.hpz.llmdockchat.data.ChatRepository
+import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
 import com.hpz.llmdockchat.data.ServicesStreamRepository
 import com.hpz.llmdockchat.data.model.MessageRole
@@ -63,6 +65,8 @@ class ThreadViewModelTest {
     private lateinit var repository: ChatRepository
     private lateinit var servicesStreamRepository: ServicesStreamRepository
     private lateinit var openRouterModelsRepository: OpenRouterModelsRepository
+    private lateinit var conversationsRepository: ConversationsRepository
+    private lateinit var mcpServersRepository: McpServersRepository
     private val store = ViewModelStore()
 
     private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "test-main") }
@@ -84,6 +88,8 @@ class ThreadViewModelTest {
         repository = ChatRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO), transport)
         servicesStreamRepository = ServicesStreamRepository(servicesTransport)
         openRouterModelsRepository = OpenRouterModelsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        conversationsRepository = ConversationsRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        mcpServersRepository = McpServersRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
     }
 
     @After
@@ -112,6 +118,8 @@ class ThreadViewModelTest {
                     drafts = drafts,
                     servicesStreamRepository = servicesStreamRepository,
                     openRouterModelsRepository = openRouterModelsRepository,
+                    conversationsRepository = conversationsRepository,
+                    mcpServersRepository = mcpServersRepository,
                     // Zero so a flush is still scheduled through the
                     // dispatcher; the window itself is asserted in
                     // ThreadCoalescingTest.
@@ -610,6 +618,8 @@ class ThreadViewModelTest {
                     drafts,
                     servicesStreamRepository,
                     openRouterModelsRepository,
+                    conversationsRepository,
+                    mcpServersRepository,
                     coalesceWindowMs,
                     titleSettleDelayMs = 1,
                 )


### PR DESCRIPTION
Which MCP servers a thread may call, from the thread's overflow menu (screen 07b). The sheet is shared with New Chat, following F07's precedent — extracted from `NewChatScreen` into `feature/toolspicker/` with an optional hint line the thread passes and New Chat does not.

## The wire gotcha

Reads come from the conversation's `mcp_servers` **array**; writes must go back as `mcp_servers_json`, a **JSON-encoded string**. Writing the array field has no effect, so getting this wrong yields a UI that looks entirely correct and persists nothing.

Also fixes a pre-existing gap: `ConversationDetailDto` already parsed `mcp_servers` off the wire, but the mapper dropped it, so the domain model never carried the set at all.

## A real race, found in review and fixed here

Toggling three tools at ordinary tapping speed left the server holding an **earlier** selection than the sheet showed — and a tool the user never chose (`browser-fetch`) turned up enabled on reopening. Reproduced through normal use, on the first real test, not a stress case.

Each toggle PUT the whole array and cancelled the previous write. But `ApiClient.request` uses a blocking `client.newCall(...).execute()` that is not cancellation-aware, so cancelling the coroutine never recalled a request already on the wire — it landed whenever it landed, in any order, and `apiCall` rethrows `CancellationException`, so the outcome was discarded silently.

**Fix: serialise the writes** behind a per-ViewModel `Mutex` with a monotonic toggle counter. Ordering alone suffices because each PUT carries the absolute list, not a delta — the last queued is the last sent and is authoritative. The counter preserves the old `cancel()`'s intent: only the newest toggle's own failure reverts the sheet, so a stale failure cannot fight a newer write that is about to set the right value anyway.

The mutex is per-ViewModel deliberately — `ConversationsRepository` is an app-wide singleton, so locking there would serialise unrelated conversations.

**`ApiClient` is deliberately untouched.** Cancellation-awareness would not have fixed this (cancellation always races delivery) and is not free: `stop()` fires `cancelActiveRun` in `viewModelScope`, so an abortable one-shot client would mean Stop followed by an immediate back kills the cancel POST in flight, leaving the run alive server-side — a regression in verified F04-R6. The streaming path is already cancellation-aware where it needed to be (`OkHttpSseTransport` holds and cancels its own `Call`). If F09 wants this, it should be opt-in per call site.

## Verification

**363 tests pass**, including a regression test confirmed to fail against the old cancel-and-replace code with exactly the reported symptom:

```
expected:<[sympy-math, websearch]> but was:<[sympy-math]>
```

MockWebServer cannot express this race — it replies in queue order and both requests arrive in send order. The test instead parks writes on per-call gates and drains the main executor, so "has the next write been sent yet?" is a settled question rather than a timing accident. An earlier gate-only version passed even against the broken code. Runs in 4 ms; no wall clock anywhere.

R1–R3 were verified independently against the live dashboard (not just by re-running the implementer's tests), including confirming the F03 new-chat flow still works end to end after the shared-sheet extraction.

**Outstanding:** R4 during a real run (guard verified by test and inspection; turns on this rig finish too fast to screenshot a stable generating state), R1's dynamic registry reload (a dashboard config action, out of scope), and R5 (Should, no project-scoped conversation on hand).