### PR TITLE
F10: Models tab — list and GPU header

### DIFF
--- a/android/docs/F10-models-list.md
+++ b/android/docs/F10-models-list.md
@@ -138,3 +138,47 @@ renames, deletes or reconfigures a service.
 
 - Benchmarks, metrics panels, Open WebUI registration, key rotation,
   compose rebuilds. All exist on the dashboard; none belong here.
+
+## Verification notes
+
+All Must criteria verified; R5 was deferred to F11 by design (it depends
+on F11's start/stop path).
+
+**The stream teardown was a real bug, found and fixed during F10.** Both
+the services and GPU streams were launched in `viewModelScope`, and
+Navigation Compose's tab-switch idiom (`popUpTo … saveState` +
+`restoreState`) keeps the ViewModel alive across a switch — so both SSE
+connections survived leaving the tab, confirmed as `ESTAB` in `ss -tnp`.
+A leaked GPU stream polls the host every 3 s forever. They are now
+collected by `LaunchedEffect`s in `ModelsScreen`, which Compose disposes
+when the destination stops being current; independently re-verified in
+review (both sockets to `:3399` reach `FIN-WAIT-2` and vanish within ~3 s
+of switching to Chats).
+
+To see those sockets, filter `ss -tnp` on the **`qemu-system-x86`**
+process — the emulator's host-side connections are NAT'd through it.
+
+**Added beyond the spec, at the owner's request:** favourites sort first
+within each group, and a name/port filter appears once there are 8 or
+more services. The spec described a list, not a searchable one, which is
+why neither was there. Favouriting itself stays on the dashboard —
+F10-R7 forbids this tab any mutating call but start/stop.
+
+### Known issue — GPU header can stick on "unavailable" after a blip
+
+After a network drop and restore while the Models tab is open, the GPU
+card can stay on "GPU stats unavailable" indefinitely even though
+`/api/gpu/stream` is healthy. Leaving the tab and returning fixes it.
+
+The services list recovers from the same blip, so this is specific to the
+GPU stream. Likely cause: the SSE client uses `readTimeout(0)` — correct
+for a long-lived stream, but it means a half-open socket left by the drop
+can hang inside `transport.open()` rather than throwing, so the reconnect
+loop never runs and the backoff never gets a chance to retry.
+
+Not a criterion failure — R3's "unavailable state" criterion is about a
+missing GPU or a failing `nvidia-smi`, not this — and remounting recovers
+it. Recorded rather than fixed: the honest fix is a read timeout slightly
+longer than the stream's own tick interval, which is a change to shared
+SSE plumbing that every feature uses, and F09 already documented why
+touching that plumbing casually is risky.

--- a/android/docs/F11-model-detail-and-control.md
+++ b/android/docs/F11-model-detail-and-control.md
@@ -1,6 +1,7 @@
 # F11 · Model detail, start and stop
 
-**Mockup:** screens 10b (detail) and 10d (start conflict) · **Depends on:** F10
+**Mockup:** screen 10b (detail). Screen 10d (start conflict) is not
+implemented — see the dropped F11-R5. · **Depends on:** F10
 
 The one place the app touches the rig. Everything shares one GPU, so a
 start that does not fit is the app's single genuinely dangerous action.
@@ -72,38 +73,29 @@ it. The confirm's job is to make sure they know, not to argue.
 - [ ] The button shows a pending state while the request is in flight and
       cannot be double-fired.
 
-## F11-R5 · The VRAM guard (Must)
+## F11-R5 · The VRAM guard (DROPPED)
 
-Everything shares one ~96 GB GPU. Before starting a service, the app
-checks whether it plausibly fits:
+**Dropped at the owner's direction, 2026-07-25:** *"no vram guard. let it
+fail if it fails. i'll see it in the logs."*
 
-- free VRAM from `GET /api/gpu` (`memory.free`), and
-- the target's `model_size` from the services payload.
+The guard was to compare `memory.free` from `GET /api/gpu` against the
+target's `model_size` and show screen 10d's conflict dialog before
+starting. It is not built.
 
-If it does not plausibly fit, show the conflict dialog from screen 10d.
-It must name **what is currently running**, **what stopping each would
-free**, and **that in-flight chats on those models will die**. It offers
-the compound action: stop the named services, then start the target.
+The reasoning holds up: the estimate was necessarily rough — `model_size`
+is weights on disk, with KV cache and CUDA graphs extra — so it would
+have blocked starts that would have fit and waved through starts that did
+not. On a single-user rig the owner watches, a failed start is visible in
+`docker logs` within seconds and costs nothing but a retry. A dialog that
+guesses wrong in both directions is worse than the honest failure.
 
-The estimate is necessarily rough — `model_size` is weights on disk, and
-KV cache and CUDA graphs are extra (see F10-R4). The dialog must be
-framed as a warning based on an estimate, not a guarantee either way.
-The server has no admission control; nothing stops an oversubscribed
-start except this dialog.
+**Consequence to keep in mind:** the server has no admission control, so
+nothing now prevents an oversubscribed start. Starting a large model
+while another large one runs will fail at the container, not in the app.
+The app must surface that failure clearly (F11-R4) rather than appearing
+to succeed.
 
-**Acceptance criteria**
-
-- [ ] Starting a large model while another large one runs shows the
-      conflict dialog before any request is sent.
-- [ ] The dialog lists the running services by name with what each would
-      free.
-- [ ] "Stop both, then start" performs the stops, waits for them, then
-      starts the target — and reports which step failed if one does.
-- [ ] Cancelling sends no request at all.
-- [ ] Starting a small service when there is plenty of free VRAM does not
-      show the dialog.
-- [ ] If GPU stats are unavailable, the start is still possible, with a
-      warning that the check could not run.
+Screen 10d (the start-conflict dialog) is therefore not implemented.
 
 ## F11-R6 · Restart (Should)
 
@@ -163,8 +155,9 @@ app must not call them. A bad tap must not be able to corrupt
 
 ## Deviations from the mockup
 
-- **The VRAM guard is an estimate**, not a measurement — see F11-R5 and
-  F10-R4. Screen 10d reads as though the numbers are exact.
+- **No start-conflict dialog.** Screen 10d reads as though the VRAM
+  numbers are exact; they never could be (F10-R4). The guard was dropped
+  outright rather than shipped as a confident-looking guess — see F11-R5.
 
 ## Out of scope
 

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -183,7 +183,7 @@ Mark completed features `[DONE]` in the Status column.
 | F07 | Model selection | [F07-model-selection.md](F07-model-selection.md) | 07a | [WIP] — two R1 criteria need a container transition, see the feature file |
 | F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [DONE] — R5 (Should) unexercised, see the feature file |
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [DONE] — R5's failed-while-away is fixture-only, see the feature file |
-| F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [ ] |
+| F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [DONE] — R5 carried forward to F11 |
 | F11 | Model detail, start and stop | [F11-model-detail-and-control.md](F11-model-detail-and-control.md) | 10b, 10d | [ ] |
 | F12 | Container logs | [F12-container-logs.md](F12-container-logs.md) | 10c | [ ] |
 | F13 | Settings | [F13-settings.md](F13-settings.md) | 09 | [ ] |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
@@ -31,6 +31,7 @@ import com.hpz.llmdockchat.core.prefs.DraftStore
 import com.hpz.llmdockchat.core.prefs.NewChatPreferences
 import com.hpz.llmdockchat.data.ChatRepository
 import com.hpz.llmdockchat.data.ConversationsRepository
+import com.hpz.llmdockchat.data.GpuStreamRepository
 import com.hpz.llmdockchat.data.HealthRepository
 import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
@@ -112,6 +113,7 @@ class AppContainer(
     val chatRepository = ChatRepository(apiClient, sseTransport)
     val servicesRepository = ServicesRepository(apiClient)
     val servicesStreamRepository = ServicesStreamRepository(sseTransport)
+    val gpuStreamRepository = GpuStreamRepository(sseTransport)
     val promptsRepository = PromptsRepository(apiClient)
     val mcpServersRepository = McpServersRepository(apiClient)
     val openRouterModelsRepository = OpenRouterModelsRepository(apiClient)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
@@ -35,6 +35,9 @@ object Endpoints {
     /** F07-R1's third criterion — a snapshot, then deltas as containers start/stop. */
     const val SERVICES_STREAM = "/api/services/stream"
 
+    /** F10-R3's GPU header — one `data:` frame per tick, no `type` envelope. */
+    const val GPU_STREAM = "/api/gpu/stream"
+
     /** Read-only from the phone (F03) — editing the curated list is desktop Tools-page work. */
     const val OPENROUTER_MODELS_SETTINGS = "/api/chat/settings/openrouter-models"
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/GpuStreamEvent.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/GpuStreamEvent.kt
@@ -1,0 +1,39 @@
+package com.hpz.llmdockchat.core.net
+
+import com.hpz.llmdockchat.data.dto.GpuDto
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * One frame of `GET /api/gpu/stream` (`dashboard/routes/gpu.py:gpu_stream`). Unlike
+ * `services_stream` this endpoint has no `type` envelope — every tick is either
+ * `{"gpus": […], "timestamp": …}` or, when `nvidia-smi` itself failed that tick,
+ * `{"error": …}`. Pure and total, same contract as [parseServiceStreamFrame]:
+ * nothing here ever throws.
+ */
+sealed interface GpuStreamEvent {
+    data class Frame(val gpus: List<GpuDto>) : GpuStreamEvent
+    data class Error(val message: String) : GpuStreamEvent
+    data class Unknown(val raw: String) : GpuStreamEvent
+}
+
+private val GpuStreamJson = Json { ignoreUnknownKeys = true }
+
+fun parseGpuStreamFrame(payload: String): GpuStreamEvent {
+    val root = runCatching { GpuStreamJson.parseToJsonElement(payload.trim()) }.getOrNull() as? JsonObject
+        ?: return GpuStreamEvent.Unknown(payload)
+
+    // Checked before "gpus": an error tick carries no gpus key at all
+    // (`gpu_stream`'s except branch yields only `{"error": str(e)}`).
+    (root["error"] as? JsonPrimitive)?.takeIf { it.isString }?.let {
+        return GpuStreamEvent.Error(it.content)
+    }
+
+    val gpusElement = root["gpus"] ?: return GpuStreamEvent.Unknown(payload)
+    val gpus = runCatching {
+        GpuStreamJson.decodeFromJsonElement(ListSerializer(GpuDto.serializer()), gpusElement)
+    }.getOrNull() ?: return GpuStreamEvent.Unknown(payload)
+    return GpuStreamEvent.Frame(gpus)
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/GpuStreamRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/GpuStreamRepository.kt
@@ -1,0 +1,69 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.Endpoints
+import com.hpz.llmdockchat.core.net.GpuStreamEvent
+import com.hpz.llmdockchat.core.net.ReconnectBackoff
+import com.hpz.llmdockchat.core.net.SseTransport
+import com.hpz.llmdockchat.core.net.StreamRequest
+import com.hpz.llmdockchat.core.net.parseGpuStreamFrame
+import com.hpz.llmdockchat.data.mapper.toDomain
+import com.hpz.llmdockchat.data.model.GpuState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * The live `GET /api/gpu/stream` (F10-R3): one frame per tick, no snapshot/delta
+ * split — every frame is the full, current GPU list, so there is nothing to
+ * merge (unlike [ServicesStreamRepository]).
+ *
+ * Reconnects with [ReconnectBackoff] rather than a flat delay, deliberately
+ * unlike [ServicesStreamRepository.RECONNECT_DELAY_MS]: the Models tab can sit
+ * open for as long as the screen is, the same reasoning
+ * [com.hpz.llmdockchat.core.net.ReconnectBackoff] itself gives for a thread's
+ * chat stream.
+ */
+class GpuStreamRepository(private val transport: SseTransport) {
+
+    /**
+     * Emits [GpuState.Unavailable] immediately on connect (F10-R3's fourth
+     * criterion: a header that has not heard from the server yet must not look
+     * "available" with stale zeros), then whatever the stream reports. Never
+     * completes on its own — a dropped connection is retried, not surfaced as
+     * a flow failure, same posture as [ServicesStreamRepository.stream].
+     */
+    fun stream(interval: Double = DEFAULT_INTERVAL_S, backoff: ReconnectBackoff = ReconnectBackoff()): Flow<GpuState> = flow {
+        emit(GpuState.Unavailable(null))
+        while (true) {
+            try {
+                transport.open(
+                    StreamRequest(path = Endpoints.GPU_STREAM, query = mapOf("interval" to interval.toString())),
+                ).collect { payload ->
+                    when (val event = parseGpuStreamFrame(payload)) {
+                        is GpuStreamEvent.Frame -> {
+                            backoff.reset()
+                            val gpus = event.gpus.map { it.toDomain() }
+                            emit(if (gpus.isEmpty()) GpuState.Unavailable(null) else GpuState.Available(gpus))
+                        }
+                        is GpuStreamEvent.Error -> emit(GpuState.Unavailable(event.message))
+                        // An unrecognised frame is left alone rather than blanking
+                        // the header over a payload shape this client doesn't know yet.
+                        is GpuStreamEvent.Unknown -> Unit
+                    }
+                }
+            } catch (e: CancellationException) {
+                // The screen went away — propagate, never treated as "reconnect"
+                // (same reasoning as ServicesStreamRepository.stream).
+                throw e
+            } catch (e: Throwable) {
+                emit(GpuState.Unavailable(null))
+            }
+            delay(backoff.next())
+        }
+    }
+
+    companion object {
+        const val DEFAULT_INTERVAL_S = 3.0
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesStreamRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesStreamRepository.kt
@@ -55,10 +55,44 @@ class ServicesStreamRepository(private val transport: SseTransport) {
         }
     }
 
+    /**
+     * Same reconnecting loop as [stream], but surfaces connection health
+     * alongside the list (F10-R1's fifth criterion): [ServicesStreamState.stale]
+     * flips true the moment a connection attempt fails, so the Models tab can
+     * show "reconnecting" instead of going quiet, and flips back to false as
+     * soon as the retry lands — which, since `services_stream` always opens
+     * with a fresh snapshot, *is* the "falls back to a snapshot fetch" the
+     * requirement asks for; a second, separate REST call would read the same
+     * `get_docker_services()` data over again for no benefit.
+     *
+     * Additive on purpose — [stream] is untouched, so F03/F07/F09's callers
+     * see no behaviour change.
+     */
+    fun streamWithStatus(reconnectDelayMs: Long = RECONNECT_DELAY_MS): Flow<ServicesStreamState> = flow {
+        var current = emptyList<ServiceSummary>()
+        while (true) {
+            try {
+                transport.open(StreamRequest(path = Endpoints.SERVICES_STREAM))
+                    .collect { payload ->
+                        current = mergeServiceEvent(current, parseServiceStreamFrame(payload))
+                        emit(ServicesStreamState(current, stale = false))
+                    }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                emit(ServicesStreamState(current, stale = true))
+            }
+            delay(reconnectDelayMs)
+        }
+    }
+
     companion object {
         const val RECONNECT_DELAY_MS = 2_000L
     }
 }
+
+/** [services] is the last list known, [stale] true while a dropped connection is being retried. */
+data class ServicesStreamState(val services: List<ServiceSummary>, val stale: Boolean)
 
 /**
  * Pure and separately tested. A [ServiceStreamEvent.Snapshot] replaces

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/GpuDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/GpuDto.kt
@@ -1,0 +1,46 @@
+package com.hpz.llmdockchat.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One GPU from `GET /api/gpu` / `GET /api/gpu/stream` (`dashboard/docker_utils.py:get_gpu_stats`).
+ * The real payload also carries clocks, fan speed and a performance state —
+ * F10-R3 only asks for VRAM, utilisation, temperature and power, so those are
+ * the only fields modelled here; anything else is ignored by
+ * `ignoreUnknownKeys` rather than given a place to go unused.
+ */
+@Serializable
+data class GpuDto(
+    val index: Int = 0,
+    val name: String = "",
+    val memory: GpuMemoryDto = GpuMemoryDto(),
+    val temperature: GpuTemperatureDto = GpuTemperatureDto(),
+    val utilization: GpuUtilizationDto = GpuUtilizationDto(),
+    val power: GpuPowerDto = GpuPowerDto(),
+)
+
+@Serializable
+data class GpuMemoryDto(
+    val total: Int = 0,
+    val used: Int = 0,
+)
+
+@Serializable
+data class GpuTemperatureDto(val current: Int = 0)
+
+@Serializable
+data class GpuUtilizationDto(@SerialName("gpu_percent") val gpuPercent: Int = 0)
+
+@Serializable
+data class GpuPowerDto(
+    val draw: Double = 0.0,
+    val limit: GpuPowerLimitDto = GpuPowerLimitDto(),
+)
+
+/** Only [enforced] is shown — the actual cap in effect, not the card's factory default/max. */
+@Serializable
+data class GpuPowerLimitDto(val enforced: Double = 0.0)
+
+@Serializable
+data class GpuListResponseDto(val gpus: List<GpuDto> = emptyList())

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
@@ -4,11 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * One row of `GET /api/services` (`dashboard/docker_utils.py:get_docker_services`). Only the
- * fields F03's and F07's model pickers need — in particular, no `api_key` field:
- * the server includes one on every row, and the fastest way to guarantee it
- * never reaches a screen or a log line (F07-R6) is to never give it a place
- * to land.
+ * One row of `GET /api/services` (`dashboard/docker_utils.py:get_docker_services`). F03's and
+ * F07's model pickers only need the first five fields; F10's models list also
+ * needs [exitCode], [modelSizeStr] and [created] to show an exited service's
+ * code and a size/created-ago label (F10-R1, F10-R4's Deviations). Still no
+ * `api_key` field: the server includes one on every row, and the fastest way
+ * to guarantee it never reaches a screen or a log line (F07-R6/F10-R7) is to
+ * never give it a place to land.
  */
 @Serializable
 data class ServiceDto(
@@ -17,6 +19,9 @@ data class ServiceDto(
     val kind: String = "",
     @SerialName("host_port") val hostPort: Int = 0,
     val favorite: Boolean = false,
+    @SerialName("exit_code") val exitCode: Int? = null,
+    @SerialName("model_size_str") val modelSizeStr: String? = null,
+    val created: String? = null,
 )
 
 @Serializable

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/GpuMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/GpuMapper.kt
@@ -1,0 +1,15 @@
+package com.hpz.llmdockchat.data.mapper
+
+import com.hpz.llmdockchat.data.dto.GpuDto
+import com.hpz.llmdockchat.data.model.GpuSummary
+
+fun GpuDto.toDomain(): GpuSummary = GpuSummary(
+    index = index,
+    name = name,
+    memoryUsedMiB = memory.used,
+    memoryTotalMiB = memory.total,
+    utilizationPercent = utilization.gpuPercent,
+    temperatureC = temperature.current,
+    powerDrawW = power.draw,
+    powerLimitW = power.limit.enforced,
+)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/NewChatMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/NewChatMapper.kt
@@ -10,7 +10,16 @@ import com.hpz.llmdockchat.data.model.ModelOption
 import com.hpz.llmdockchat.data.model.ServiceSummary
 
 fun ServiceDto.toDomain(): ServiceSummary =
-    ServiceSummary(name = name, status = status, kind = kind, port = hostPort, favorite = favorite)
+    ServiceSummary(
+        name = name,
+        status = status,
+        kind = kind,
+        port = hostPort,
+        favorite = favorite,
+        exitCode = exitCode,
+        modelSizeStr = modelSizeStr,
+        createdAt = created,
+    )
 
 fun PromptDto.toDomain(): ManagedPrompt = ManagedPrompt(id = id, name = name, sortOrder = sortOrder)
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/GpuSummary.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/GpuSummary.kt
@@ -1,0 +1,38 @@
+package com.hpz.llmdockchat.data.model
+
+/** One GPU, as F10-R3's header shows it — real numbers only, no per-container split (F10-R4). */
+data class GpuSummary(
+    val index: Int,
+    val name: String,
+    val memoryUsedMiB: Int,
+    val memoryTotalMiB: Int,
+    val utilizationPercent: Int,
+    val temperatureC: Int,
+    val powerDrawW: Double,
+    val powerLimitW: Double,
+) {
+    /**
+     * [name] without the boilerplate every card in a range repeats — this host
+     * reports "NVIDIA RTX PRO 6000 Blackwell Workstation Edition", of which
+     * only "RTX PRO 6000 Blackwell" identifies anything. On a phone the full
+     * string crowds out the VRAM figure, which is what the header is for.
+     */
+    val shortName: String
+        get() = name
+            .removePrefix("NVIDIA ")
+            .removeSuffix(" Workstation Edition")
+            .removeSuffix(" Laptop GPU")
+            .trim()
+}
+
+/**
+ * What the GPU header shows, live from `GET /api/gpu/stream`. [Unavailable]
+ * covers both shapes the endpoint can hand back for "nothing to show": an
+ * `{"error": …}` frame (`nvidia-smi` failed) and a `{"gpus": []}` frame (no
+ * GPU present) — the service list must keep working in either case (F10-R3's
+ * fourth criterion).
+ */
+sealed interface GpuState {
+    data class Available(val gpus: List<GpuSummary>) : GpuState
+    data class Unavailable(val message: String?) : GpuState
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceSummary.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceSummary.kt
@@ -9,6 +9,12 @@ data class ServiceSummary(
     val port: Int = 0,
     /** Set on the dashboard; the phone only ever reads it (F07-R5). */
     val favorite: Boolean = false,
+    /** Only set when [status] is `"exited"` (F10-R1's third criterion). */
+    val exitCode: Int? = null,
+    /** Weights-on-disk size, pre-formatted server-side (e.g. `"25.74 GB"`). Null when unknown. */
+    val modelSizeStr: String? = null,
+    /** The container's creation time, ISO-8601 UTC. Not a start time — see [[F10-models-list.md]]'s Deviations. */
+    val createdAt: String? = null,
 ) {
     val engine: Engine get() = ModelRef.Local(name).engine
 
@@ -27,4 +33,6 @@ data class ServiceSummary(
     val isChatCapable: Boolean get() = engine != Engine.UNKNOWN && (kind.isBlank() || kind == "chat")
 
     val isRunning: Boolean get() = status == "running"
+    val isExited: Boolean get() = status == "exited"
+    val isNotCreated: Boolean get() = status == "not-created"
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsFormatting.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsFormatting.kt
@@ -1,0 +1,55 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.core.time.Timestamps
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.math.roundToInt
+
+/**
+ * Pure formatting, split out of the Compose layer so it can be unit tested
+ * without Robolectric (Architecture Part IV — logic criteria need only a JVM
+ * test).
+ */
+
+/** F10-R1: "not-created" distinguishable from "exited", which carries its exit code. */
+fun ServiceSummary.statusLabel(): String = when {
+    isRunning -> "Running"
+    isExited -> exitCode?.let { "Exited (code $it)" } ?: "Exited"
+    isNotCreated -> "Not created"
+    else -> status.ifBlank { "Unknown" }
+}
+
+/**
+ * The row's second line. Deliberately never says "uptime" — the payload only
+ * carries the container's creation time, not its last start, so a restarted
+ * container would show a wrong number under that name (F10's Deviations).
+ * "created … ago" is honest about what the timestamp actually is.
+ */
+fun ServiceSummary.subtitle(now: Instant, zone: ZoneId): String = buildList {
+    if (port > 0) add(":$port")
+    when {
+        isRunning -> {
+            modelSizeStr?.let(::add)
+            createdAt?.let { add("created ${Timestamps.relative(it, now, zone)}") }
+        }
+        isExited -> {
+            modelSizeStr?.let(::add)
+            add(exitCode?.let { "exited (code $it)" } ?: "exited")
+        }
+        isNotCreated -> {
+            if (modelSizeStr != null) add("needs ~$modelSizeStr") else add("not created")
+        }
+        else -> {
+            modelSizeStr?.let(::add)
+            add(status.ifBlank { "unknown" })
+        }
+    }
+}.joinToString(" · ")
+
+/** MiB -> GiB, one decimal — the same unit `nvidia-smi` reports, just relabelled GB for the header. */
+fun mibToGb(mib: Int): String {
+    val gb = mib / 1024.0
+    val rounded = (gb * 10).roundToInt() / 10.0
+    return if (rounded == rounded.toLong().toDouble()) "${rounded.toLong()}" else rounded.toString()
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -78,6 +79,7 @@ fun ModelsScreen(
         state = state,
         onRetry = viewModel::retry,
         onNewChatFromModel = onNewChatFromModel,
+        onQueryChange = viewModel::onQueryChange,
         modifier = modifier,
     )
 }
@@ -88,6 +90,7 @@ private fun ModelsContent(
     state: ModelsUiState,
     onRetry: () -> Unit,
     onNewChatFromModel: (String) -> Unit,
+    onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LlmTheme.colors
@@ -105,14 +108,18 @@ private fun ModelsContent(
             when (state) {
                 is ModelsUiState.Loading -> LoadingState()
                 is ModelsUiState.Failed -> FailedState(state.message, onRetry)
-                is ModelsUiState.Loaded -> ModelsList(state, onNewChatFromModel)
+                is ModelsUiState.Loaded -> ModelsList(state, onNewChatFromModel, onQueryChange)
             }
         }
     }
 }
 
 @Composable
-private fun ModelsList(state: ModelsUiState.Loaded, onNewChatFromModel: (String) -> Unit) {
+private fun ModelsList(
+    state: ModelsUiState.Loaded,
+    onNewChatFromModel: (String) -> Unit,
+    onQueryChange: (String) -> Unit,
+) {
     val now = remember { Instant.now() }
     val zone = remember { ZoneId.systemDefault() }
 
@@ -128,15 +135,28 @@ private fun ModelsList(state: ModelsUiState.Loaded, onNewChatFromModel: (String)
             return@LazyColumn
         }
 
-        if (state.running.isNotEmpty()) {
-            item(key = "running_header") { SectionHeader("Running", state.running.size) }
-            items(state.running, key = { "running_${it.name}" }) { service ->
+        // Only worth the vertical space once the list is long enough to need
+        // it — this rig has ~20 services, a fresh one may have two.
+        if (state.running.size + state.stopped.size >= SEARCH_THRESHOLD) {
+            item(key = "search") { SearchField(state.query, onQueryChange) }
+        }
+
+        if (state.noMatches) {
+            item(key = "no_matches") { NoMatches(state.query) }
+            return@LazyColumn
+        }
+
+        val running = state.visibleRunning
+        val stopped = state.visibleStopped
+        if (running.isNotEmpty()) {
+            item(key = "running_header") { SectionHeader("Running", running.size) }
+            items(running, key = { "running_${it.name}" }) { service ->
                 ServiceRow(service, now, zone, onNewChatFromModel)
             }
         }
-        if (state.stopped.isNotEmpty()) {
-            item(key = "stopped_header") { SectionHeader("Stopped", state.stopped.size) }
-            items(state.stopped, key = { "stopped_${it.name}" }) { service ->
+        if (stopped.isNotEmpty()) {
+            item(key = "stopped_header") { SectionHeader("Stopped", stopped.size) }
+            items(stopped, key = { "stopped_${it.name}" }) { service ->
                 ServiceRow(service, now, zone, onNewChatFromModel = null)
             }
         }
@@ -366,6 +386,41 @@ private fun LoadingState() {
 }
 
 @Composable
+private fun SearchField(query: String, onQueryChange: (String) -> Unit) {
+    val colors = LlmTheme.colors
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        singleLine = true,
+        placeholder = { Text("Filter by name or port", color = colors.muted) },
+        leadingIcon = { Text("  \uD83D\uDD0D", color = colors.muted) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                TextButton(onClick = { onQueryChange("") }) { Text("Clear", color = colors.accent) }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .testTag("models_search"),
+    )
+}
+
+@Composable
+private fun NoMatches(query: String) {
+    val colors = LlmTheme.colors
+    Text(
+        "No service matches \"$query\".",
+        color = colors.muted,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp).testTag("models_no_matches"),
+    )
+}
+
+/** Below this many services the filter costs more screen than it saves. */
+private const val SEARCH_THRESHOLD = 8
+
+@Composable
 private fun EmptyState() {
     val colors = LlmTheme.colors
     Column(
@@ -414,6 +469,7 @@ private fun ModelsPopulatedPreview() {
             ),
             onRetry = {},
             onNewChatFromModel = {},
+            onQueryChange = {},
         )
     }
 }
@@ -430,6 +486,7 @@ private fun ModelsGpuUnavailablePreview() {
             ),
             onRetry = {},
             onNewChatFromModel = {},
+            onQueryChange = {},
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
@@ -1,0 +1,435 @@
+package com.hpz.llmdockchat.feature.models
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LLMDockChatTheme
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.Engine
+import com.hpz.llmdockchat.data.model.GpuState
+import com.hpz.llmdockchat.data.model.GpuSummary
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Screen 10a · Models (F10). Read-and-observe only: F10-R5 (start/stop from a
+ * row, tap-to-detail) is deferred to F11 — a row here does nothing when
+ * tapped, and carries no power/play icon, unlike the mockup. The one action a
+ * row *does* carry is F10-R6's "New chat from this model", which is in scope
+ * and is not a control over the container.
+ */
+@Composable
+fun ModelsScreen(
+    viewModel: ModelsViewModel,
+    onNewChatFromModel: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    LaunchedEffect(Unit) { viewModel.start() }
+
+    // F10-R3's third criterion: these two run only while this composable is
+    // part of the composition. Navigation Compose disposes it — cancelling
+    // both `LaunchedEffect`s and, with them, the underlying SSE connections —
+    // the moment this destination stops being current, even though the
+    // ViewModel itself survives a tab switch (see the class doc on
+    // ModelsViewModel for why viewModelScope was the wrong owner for these).
+    LaunchedEffect(Unit) {
+        viewModel.observeServicesStream().collect { viewModel.applyServicesUpdate(it) }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.observeGpuStream().collect { viewModel.applyGpuUpdate(it) }
+    }
+
+    ModelsContent(
+        state = state,
+        onRetry = viewModel::retry,
+        onNewChatFromModel = onNewChatFromModel,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModelsContent(
+    state: ModelsUiState,
+    onRetry: () -> Unit,
+    onNewChatFromModel: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LlmTheme.colors
+    Scaffold(
+        modifier = modifier.testTag("models_screen"),
+        containerColor = colors.app,
+        topBar = {
+            TopAppBar(
+                title = { Text("Models", color = colors.fg) },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when (state) {
+                is ModelsUiState.Loading -> LoadingState()
+                is ModelsUiState.Failed -> FailedState(state.message, onRetry)
+                is ModelsUiState.Loaded -> ModelsList(state, onNewChatFromModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModelsList(state: ModelsUiState.Loaded, onNewChatFromModel: (String) -> Unit) {
+    val now = remember { Instant.now() }
+    val zone = remember { ZoneId.systemDefault() }
+
+    LazyColumn(Modifier.fillMaxSize().testTag("models_list")) {
+        item(key = "gpu_header") { GpuHeaderCard(state.gpu) }
+
+        if (state.stale) {
+            item(key = "stale_indicator") { StaleBanner() }
+        }
+
+        if (state.running.isEmpty() && state.stopped.isEmpty()) {
+            item(key = "empty") { EmptyState() }
+            return@LazyColumn
+        }
+
+        if (state.running.isNotEmpty()) {
+            item(key = "running_header") { SectionHeader("Running", state.running.size) }
+            items(state.running, key = { "running_${it.name}" }) { service ->
+                ServiceRow(service, now, zone, onNewChatFromModel)
+            }
+        }
+        if (state.stopped.isNotEmpty()) {
+            item(key = "stopped_header") { SectionHeader("Stopped", state.stopped.size) }
+            items(state.stopped, key = { "stopped_${it.name}" }) { service ->
+                ServiceRow(service, now, zone, onNewChatFromModel = null)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GpuHeaderCard(gpu: GpuState) {
+    val colors = LlmTheme.colors
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .padding(16.dp)
+            .testTag("gpu_header"),
+    ) {
+        when (gpu) {
+            is GpuState.Available -> gpu.gpus.forEachIndexed { index, card ->
+                if (index > 0) Spacer(Modifier.height(12.dp))
+                GpuCard(card)
+            }
+            is GpuState.Unavailable -> Column(Modifier.testTag("gpu_unavailable")) {
+                Text("GPU stats unavailable", color = colors.muted, style = MaterialTheme.typography.bodyMedium)
+                gpu.message?.let {
+                    Spacer(Modifier.height(4.dp))
+                    Text(it, color = colors.subtle, style = MaterialTheme.typography.labelSmall)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * F10-R4: one total VRAM bar, not per-container segments. The API has no
+ * per-process breakdown, and the only per-service number is weights-on-disk
+ * size — drawing segments from it would present an estimate as a measured
+ * figure, which the requirement rules out outright. The used/total number
+ * itself is the real one from `/api/gpu`.
+ */
+@Composable
+private fun GpuCard(gpu: GpuSummary) {
+    val colors = LlmTheme.colors
+    val usedFraction = if (gpu.memoryTotalMiB > 0) (gpu.memoryUsedMiB.toFloat() / gpu.memoryTotalMiB).coerceIn(0f, 1f) else 0f
+
+    // The VRAM figure is the point of this card, so it is laid out first and
+    // never allowed to shrink or wrap: `softWrap = false` plus no weight. The
+    // name takes what is left with `weight(1f)` — without a weight a `maxLines
+    // = 1` Text still *measures* at full intrinsic width, so a long name (this
+    // host reports "NVIDIA RTX PRO 6000 Blackwell Workstation Edition") pushed
+    // the number off the edge and left it wrapping one character per line.
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            gpu.shortName,
+            color = colors.subtle,
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            "${mibToGb(gpu.memoryUsedMiB)} / ${mibToGb(gpu.memoryTotalMiB)} GB",
+            color = colors.fg,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+    Spacer(Modifier.height(8.dp))
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(6.dp)
+            .clip(RoundedCornerShape(3.dp))
+            .background(colors.sunken),
+    ) {
+        Box(
+            Modifier
+                .fillMaxWidth(usedFraction)
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(if (usedFraction > 0.9f) colors.red else colors.accent),
+        )
+    }
+    Spacer(Modifier.height(8.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Stat("util", "${gpu.utilizationPercent}%")
+        Stat("temp", "${gpu.temperatureC} °C")
+        Stat("power", "${gpu.powerDrawW.toInt()} / ${gpu.powerLimitW.toInt()} W")
+    }
+}
+
+@Composable
+private fun Stat(label: String, value: String) {
+    val colors = LlmTheme.colors
+    Row {
+        Text("$label ", color = colors.subtle, style = MaterialTheme.typography.labelSmall)
+        Text(value, color = colors.muted, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun StaleBanner() {
+    val colors = LlmTheme.colors
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(colors.amber.copy(alpha = 0.15f))
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("stale_indicator"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Reconnecting… showing the last known state", color = colors.amber, style = MaterialTheme.typography.labelMedium)
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, count: Int) {
+    val colors = LlmTheme.colors
+    Text(
+        "$title · $count",
+        color = colors.subtle,
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun ServiceRow(
+    service: ServiceSummary,
+    now: Instant,
+    zone: ZoneId,
+    onNewChatFromModel: ((String) -> Unit)?,
+) {
+    val colors = LlmTheme.colors
+    // F10-R5 is deferred to F11: the row body has no click handler at all —
+    // there is no detail screen yet to navigate to.
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("service_row_${service.name}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            Modifier
+                .size(8.dp)
+                .background(if (service.isRunning) colors.green else colors.subtle, CircleShape)
+                .testTag("service_dot_${service.name}"),
+        )
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    service.name,
+                    color = colors.fg,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                EngineChip(service.engine)
+            }
+            Text(
+                service.subtitle(now, zone),
+                color = colors.muted,
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        // F10-R6: offered only for a running, chat-capable service.
+        if (onNewChatFromModel != null && service.isRunning && service.isChatCapable) {
+            TextButton(
+                onClick = { onNewChatFromModel(service.name) },
+                modifier = Modifier.testTag("new_chat_from_model_${service.name}"),
+            ) {
+                Text("New chat", color = colors.accent, style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EngineChip(engine: Engine) {
+    val colors = LlmTheme.colors
+    val chip = when (engine) {
+        Engine.LLAMA_CPP -> colors.engineLlamaCpp
+        Engine.VLLM -> colors.engineVllm
+        Engine.DS4 -> colors.engineDs4
+        Engine.OPEN_ROUTER -> colors.engineOpenRouter
+        Engine.UNKNOWN -> colors.engineUnknown
+    }
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(chip.background)
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+    ) {
+        Text(
+            engineLabel(engine),
+            color = chip.foreground,
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+private fun engineLabel(engine: Engine): String = when (engine) {
+    Engine.LLAMA_CPP -> "llama.cpp"
+    Engine.VLLM -> "vLLM"
+    Engine.DS4 -> "ds4"
+    Engine.OPEN_ROUTER -> "OpenRouter"
+    Engine.UNKNOWN -> "?"
+}
+
+@Composable
+private fun LoadingState() {
+    Box(Modifier.fillMaxSize().testTag("models_loading"), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(color = LlmTheme.colors.accent)
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    val colors = LlmTheme.colors
+    Column(
+        Modifier.fillMaxWidth().padding(32.dp).testTag("models_empty"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("No services configured", color = colors.fg, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+@Composable
+private fun FailedState(message: String, onRetry: () -> Unit) {
+    val colors = LlmTheme.colors
+    Column(
+        Modifier.fillMaxSize().padding(32.dp).testTag("models_failed"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text("Couldn't load models", color = colors.red, style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+        Text(message, color = colors.muted, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = onRetry, modifier = Modifier.testTag("models_retry")) {
+            Text("Retry", color = colors.accent)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ModelsPopulatedPreview() {
+    LLMDockChatTheme(darkTheme = true) {
+        ModelsContent(
+            state = ModelsUiState.Loaded(
+                running = listOf(
+                    ServiceSummary("llamacpp-qwen3.6-27b-mtp-q8", "running", "chat", port = 3301, modelSizeStr = "26.1 GB", createdAt = Instant.now().minusSeconds(15120).toString()),
+                    ServiceSummary("vllm-qwen3.6-35b-a3b-fp8", "running", "chat", port = 3310, modelSizeStr = "35.3 GB", createdAt = Instant.now().minusSeconds(3060).toString()),
+                ),
+                stopped = listOf(
+                    ServiceSummary("ds4-deepseek-v4-flash", "not-created", "chat", port = 3315, modelSizeStr = "80.76 GB"),
+                    ServiceSummary("llamacpp-gemma-4-31b-it-q8", "exited", "chat", port = 3303, modelSizeStr = "33.73 GB", exitCode = 1),
+                ),
+                gpu = GpuState.Available(
+                    listOf(GpuSummary(0, "RTX PRO 6000 Blackwell", memoryUsedMiB = 62873, memoryTotalMiB = 97887, utilizationPercent = 84, temperatureC = 71, powerDrawW = 318.0, powerLimitW = 300.0)),
+                ),
+            ),
+            onRetry = {},
+            onNewChatFromModel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ModelsGpuUnavailablePreview() {
+    LLMDockChatTheme(darkTheme = false) {
+        ModelsContent(
+            state = ModelsUiState.Loaded(
+                running = emptyList(),
+                stopped = listOf(ServiceSummary("llamacpp-a", "not-created", "chat", port = 3301)),
+                gpu = GpuState.Unavailable("nvidia-smi command failed"),
+            ),
+            onRetry = {},
+            onNewChatFromModel = {},
+        )
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
@@ -31,14 +31,48 @@ sealed interface ModelsUiState {
         /** True while the services stream is down and being retried (F10-R1's fifth criterion). */
         val stale: Boolean = false,
         val gpu: GpuState = GpuState.Unavailable(null),
-    ) : ModelsUiState
+        /** Free-text name filter. Empty means "show everything". */
+        val query: String = "",
+    ) : ModelsUiState {
+        val visibleRunning: List<ServiceSummary> get() = running.matching(query)
+        val visibleStopped: List<ServiceSummary> get() = stopped.matching(query)
+
+        /** A query that matches nothing at all, so the screen can say so rather than look empty. */
+        val noMatches: Boolean
+            get() = query.isNotBlank() && visibleRunning.isEmpty() && visibleStopped.isEmpty()
+    }
 
     data class Failed(val message: String) : ModelsUiState
 }
 
-/** Running first, stopped second — the payload's own `host_port` order preserved within each. */
+/**
+ * Running first, stopped second, favourites first within each.
+ *
+ * `sortedByDescending` is stable, so the server's own `host_port` order still
+ * holds between two rows of the same favourite-ness — the same guarantee
+ * F07's picker relies on. Only a row's `status` changes underneath the list,
+ * never its position, so a service that stops moves group without shuffling
+ * its neighbours (F10-R2's second criterion).
+ *
+ * Favouriting itself stays on the dashboard: this tab never writes
+ * (F10-R7), and `POST /api/services/<name>/favorite` is a configuration
+ * endpoint no agent or screen here may call.
+ */
 fun List<ServiceSummary>.splitByRunning(): Pair<List<ServiceSummary>, List<ServiceSummary>> =
-    filter { it.isRunning } to filterNot { it.isRunning }
+    filter { it.isRunning }.sortedByDescending { it.favorite } to
+        filterNot { it.isRunning }.sortedByDescending { it.favorite }
+
+/**
+ * Substring match on the service name, case-insensitive. Deliberately not
+ * fuzzy: with ~20 services on one rig, typing "qwen" or "3307" should narrow
+ * the list predictably rather than cleverly. The port is searchable too — it
+ * is on screen, so it is fair game to type.
+ */
+fun List<ServiceSummary>.matching(query: String): List<ServiceSummary> {
+    val q = query.trim()
+    if (q.isEmpty()) return this
+    return filter { it.name.contains(q, ignoreCase = true) || it.port.toString().contains(q) }
+}
 
 /**
  * F10-R3's third criterion — "closing the tab stops the stream" — turned out
@@ -85,6 +119,8 @@ class ModelsViewModel(
             _state.value = ModelsUiState.Loaded(running = running, stopped = stopped)
         }
     }
+    fun onQueryChange(query: String) = updateLoaded { it.copy(query = query) }
+
 
     fun retry() {
         started = false

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
@@ -1,0 +1,111 @@
+package com.hpz.llmdockchat.feature.models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.data.GpuStreamRepository
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.data.ServicesStreamState
+import com.hpz.llmdockchat.data.model.GpuState
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * F00-R5's Loading/Loaded/Failed. [Loaded] is already split running-above-stopped
+ * (F10-R2) — the ordering within each group is whatever [ServiceSummary] arrived
+ * in, which is stable because the server sorts by `host_port` and only a row's
+ * `status` field changes underneath it, never its position.
+ */
+sealed interface ModelsUiState {
+    data object Loading : ModelsUiState
+
+    data class Loaded(
+        val running: List<ServiceSummary>,
+        val stopped: List<ServiceSummary>,
+        /** True while the services stream is down and being retried (F10-R1's fifth criterion). */
+        val stale: Boolean = false,
+        val gpu: GpuState = GpuState.Unavailable(null),
+    ) : ModelsUiState
+
+    data class Failed(val message: String) : ModelsUiState
+}
+
+/** Running first, stopped second — the payload's own `host_port` order preserved within each. */
+fun List<ServiceSummary>.splitByRunning(): Pair<List<ServiceSummary>, List<ServiceSummary>> =
+    filter { it.isRunning } to filterNot { it.isRunning }
+
+/**
+ * F10-R3's third criterion — "closing the tab stops the stream" — turned out
+ * not to hold for anything launched from `viewModelScope`: Navigation
+ * Compose's tab-switch idiom (`popUpTo(...) { saveState = true }` +
+ * `restoreState = true`, the same one [com.hpz.llmdockchat.navigation.AppNavHost]
+ * uses for both tabs) keeps this ViewModel's instance — and therefore
+ * anything running in its scope — alive while the Chats tab is showing.
+ * Confirmed live: switching to Chats left both the services and GPU SSE
+ * sockets in `ss -tnp`'s output, still `ESTAB`.
+ *
+ * So the two live subscriptions are *not* owned by this ViewModel's own
+ * scope. [observeServicesStream]/[observeGpuStream] hand back the bare
+ * [Flow]s; [ModelsScreen] collects them from a `LaunchedEffect` tied to its
+ * own composition, which Navigation Compose disposes the moment this
+ * destination stops being current (the same disposal
+ * [com.hpz.llmdockchat.feature.conversations.ConversationListScreen] already
+ * relies on for its own re-fetch-on-return). [start] keeps only the cheap,
+ * one-shot initial REST fetch — that one is fine to leave cached.
+ */
+class ModelsViewModel(
+    private val servicesRepository: ServicesRepository,
+    private val servicesStreamRepository: ServicesStreamRepository,
+    private val gpuStreamRepository: GpuStreamRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<ModelsUiState>(ModelsUiState.Loading)
+    val state: StateFlow<ModelsUiState> = _state.asStateFlow()
+
+    /** One-shot, same guard as [com.hpz.llmdockchat.feature.newchat.NewChatViewModel.load]. */
+    private var started = false
+
+    fun start() {
+        if (started) return
+        started = true
+        _state.value = ModelsUiState.Loading
+        viewModelScope.launch {
+            val services = servicesRepository.list().getOrElse { failure ->
+                started = false
+                _state.value = ModelsUiState.Failed(failure.appError.displayMessage)
+                return@launch
+            }
+            val (running, stopped) = services.splitByRunning()
+            _state.value = ModelsUiState.Loaded(running = running, stopped = stopped)
+        }
+    }
+
+    fun retry() {
+        started = false
+        start()
+    }
+
+    /** Collected by [ModelsScreen] from a composition-scoped `LaunchedEffect` — see the class doc. */
+    fun observeServicesStream(): Flow<ServicesStreamState> = servicesStreamRepository.streamWithStatus()
+
+    /** Collected by [ModelsScreen] from a composition-scoped `LaunchedEffect` — see the class doc. */
+    fun observeGpuStream(): Flow<GpuState> = gpuStreamRepository.stream()
+
+    fun applyServicesUpdate(live: ServicesStreamState) {
+        val (running, stopped) = live.services.splitByRunning()
+        updateLoaded { it.copy(running = running, stopped = stopped, stale = live.stale) }
+    }
+
+    fun applyGpuUpdate(gpu: GpuState) = updateLoaded { it.copy(gpu = gpu) }
+
+    private inline fun updateLoaded(transform: (ModelsUiState.Loaded) -> ModelsUiState.Loaded) {
+        val current = _state.value
+        if (current is ModelsUiState.Loaded) _state.value = transform(current)
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModel.kt
@@ -76,6 +76,13 @@ class NewChatViewModel(
     private val conversationsRepository: ConversationsRepository,
     private val preferences: NewChatPreferences,
     private val servicesStreamRepository: ServicesStreamRepository,
+    /**
+     * F10-R6's "New chat from a model": the Models tab preselects a specific
+     * running service, taking priority over whatever [preferences] last
+     * remembered. Null for every other entry into this sheet (F02's FAB,
+     * F07-R4's mid-thread switch does not use this screen at all).
+     */
+    private val preselectedServiceName: String? = null,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<NewChatUiState>(NewChatUiState.Loading)
@@ -119,7 +126,20 @@ class NewChatViewModel(
 
             var selectedModel: ModelOption? = null
             var unavailable = false
-            if (rememberedRaw != null) {
+
+            // F10-R6: a preselected service wins outright over whatever was
+            // remembered — that is the entire point of tapping "New chat"
+            // from a specific row on the Models tab. If it stopped running
+            // between the tap and this load (unlikely, but possible), fall
+            // through to the ordinary remembered-model resolution below
+            // rather than silently landing on a dead service.
+            val preselectedMatch = preselectedServiceName
+                ?.let { name -> localServices.find { it.serviceName == name } }
+                ?.takeIf { it.isRunning }
+
+            if (preselectedMatch != null) {
+                selectedModel = preselectedMatch
+            } else if (rememberedRaw != null) {
                 when (val ref = parseModelRef(rememberedRaw)) {
                     is ModelRef.Local -> {
                         val match = localServices.find { it.serviceName == ref.serviceName }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -17,18 +17,21 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.hpz.llmdockchat.core.AppContainer
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.feature.connect.ConnectScreen
 import com.hpz.llmdockchat.feature.connect.ConnectViewModel
 import com.hpz.llmdockchat.feature.conversations.ConversationListScreen
 import com.hpz.llmdockchat.feature.conversations.ConversationListViewModel
-import com.hpz.llmdockchat.feature.models.ModelsPlaceholderScreen
+import com.hpz.llmdockchat.feature.models.ModelsScreen
+import com.hpz.llmdockchat.feature.models.ModelsViewModel
 import com.hpz.llmdockchat.feature.newchat.NewChatScreen
 import com.hpz.llmdockchat.feature.newchat.NewChatViewModel
 import com.hpz.llmdockchat.feature.thread.ThreadScreen
@@ -101,13 +104,31 @@ fun AppNavHost(
                         onOpenConversation = { conversation ->
                             navController.navigate(Destinations.thread(conversation.id))
                         },
-                        onNewConversation = { navController.navigate(Destinations.NEW_CHAT) },
+                        onNewConversation = { navController.navigate(Destinations.newChat()) },
                     )
                 }
             }
 
             composable(Destinations.MODELS) {
-                TabScaffold(navController) { ModelsPlaceholderScreen() }
+                TabScaffold(navController) {
+                    val viewModel: ModelsViewModel = viewModel(
+                        factory = viewModelFactory {
+                            initializer {
+                                ModelsViewModel(
+                                    servicesRepository = container.servicesRepository,
+                                    servicesStreamRepository = container.servicesStreamRepository,
+                                    gpuStreamRepository = container.gpuStreamRepository,
+                                )
+                            }
+                        },
+                    )
+                    ModelsScreen(
+                        viewModel = viewModel,
+                        onNewChatFromModel = { serviceName ->
+                            navController.navigate(Destinations.newChatWithService(serviceName))
+                        },
+                    )
+                }
             }
         }
 
@@ -135,7 +156,11 @@ fun AppNavHost(
             ThreadScreen(viewModel = viewModel, onBack = { navController.popBackStack() })
         }
 
-        composable(Destinations.NEW_CHAT) {
+        composable(
+            Destinations.NEW_CHAT,
+            arguments = listOf(navArgument("service") { type = NavType.StringType; nullable = true; defaultValue = null }),
+        ) { backStackEntry ->
+            val preselectedServiceName = backStackEntry.arguments?.getString("service")
             val viewModel: NewChatViewModel = viewModel(
                 factory = viewModelFactory {
                     initializer {
@@ -147,6 +172,7 @@ fun AppNavHost(
                             conversationsRepository = container.conversationsRepository,
                             preferences = container.newChatPreferences,
                             servicesStreamRepository = container.servicesStreamRepository,
+                            preselectedServiceName = preselectedServiceName,
                         )
                     }
                 },

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
@@ -20,8 +20,20 @@ object Destinations {
     const val THREAD = "$THREAD_ROUTE/{conversationId}"
     fun thread(conversationId: String) = "$THREAD_ROUTE/$conversationId"
 
-    /** F02-R8's primary action, built out in F03. */
-    const val NEW_CHAT = "new_chat"
+    /**
+     * F02-R8's primary action, built out in F03. [NEW_CHAT] is the route
+     * *pattern* registered with `composable(...)` — it must be the string
+     * passed there and to `popUpTo(...)`, never navigated to directly (its
+     * `{service}` is a literal placeholder, not a real path segment). Callers
+     * navigate with [newChat] (no preselected model, F02/F03's original path)
+     * or [newChatWithService] (F10-R6 — the query argument is optional and
+     * nullable, so [newChat]'s plain route still matches the same
+     * destination with `service` defaulting to null).
+     */
+    private const val NEW_CHAT_ROUTE = "new_chat"
+    const val NEW_CHAT = "$NEW_CHAT_ROUTE?service={service}"
+    fun newChat() = NEW_CHAT_ROUTE
+    fun newChatWithService(serviceName: String) = "$NEW_CHAT_ROUTE?service=$serviceName"
 }
 
 /**

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/GpuStreamEventParserTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/GpuStreamEventParserTest.kt
@@ -1,0 +1,61 @@
+package com.hpz.llmdockchat.core.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [parseGpuStreamFrame] against the shapes `gpu_stream` actually sends
+ * (`dashboard/routes/gpu.py:gpu_stream`) — a bare `{"gpus": […]}` tick, or
+ * `{"error": …}` when that tick's `nvidia-smi` call itself failed. Unlike
+ * `services_stream` there is no `type` envelope at all.
+ */
+class GpuStreamEventParserTest {
+
+    @Test
+    fun `a normal tick decodes every gpu's memory, utilisation, temperature and power`() {
+        val event = parseGpuStreamFrame(
+            """
+            {"gpus": [{"index": 0, "name": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+              "memory": {"total": 97887, "used": 95312, "free": 1935, "unit": "MiB", "utilization_percent": 11},
+              "temperature": {"current": 37, "unit": "C"},
+              "utilization": {"gpu_percent": 5, "memory_percent": 11},
+              "power": {"draw": 20.72, "limit": {"current": 300.0, "default": 600.0, "min": 150.0, "max": 600.0, "enforced": 300.0}, "unit": "W"}
+            }], "timestamp": "2026-07-25T00:00:00Z"}
+            """.trimIndent(),
+        )
+        val frame = event as GpuStreamEvent.Frame
+        assertEquals(1, frame.gpus.size)
+        val gpu = frame.gpus[0]
+        assertEquals("NVIDIA RTX PRO 6000 Blackwell Workstation Edition", gpu.name)
+        assertEquals(97887, gpu.memory.total)
+        assertEquals(95312, gpu.memory.used)
+        assertEquals(37, gpu.temperature.current)
+        assertEquals(5, gpu.utilization.gpuPercent)
+        assertEquals(20.72, gpu.power.draw, 0.001)
+        assertEquals(300.0, gpu.power.limit.enforced, 0.001)
+    }
+
+    @Test
+    fun `an error tick with no gpus key is Error, not Unknown`() {
+        val event = parseGpuStreamFrame("""{"error": "GPU stats unavailable: nvidia-smi command failed"}""")
+        assertEquals(GpuStreamEvent.Error("GPU stats unavailable: nvidia-smi command failed"), event)
+    }
+
+    @Test
+    fun `no GPU present is an empty gpus list, a Frame not an Error`() {
+        val event = parseGpuStreamFrame("""{"gpus": [], "timestamp": "2026-07-25T00:00:00Z"}""")
+        assertEquals(GpuStreamEvent.Frame(emptyList()), event)
+    }
+
+    @Test
+    fun `garbage that is not JSON at all never throws`() {
+        assertEquals(GpuStreamEvent.Unknown("not json"), parseGpuStreamFrame("not json"))
+    }
+
+    @Test
+    fun `a payload with neither gpus nor error is Unknown rather than a crash`() {
+        val payload = """{"something_else": 1}"""
+        assertTrue(parseGpuStreamFrame(payload) is GpuStreamEvent.Unknown)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/GpuStreamRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/GpuStreamRepositoryTest.kt
@@ -1,0 +1,108 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.ReconnectBackoff
+import com.hpz.llmdockchat.data.model.GpuState
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [GpuStreamRepository.stream] — the transport wiring and the
+ * available/unavailable mapping (F10-R3). The teardown test is the one that
+ * matters most here: F10-R3's third criterion is "closing the tab stops the
+ * stream", and a test that only checks a UI flag would prove nothing — see
+ * `ThreadReconnectTeardownTest` and `OkHttpSseTransportTest`'s "abandoning a
+ * quiet stream" for the same pattern on other streams.
+ */
+class GpuStreamRepositoryTest {
+
+    @Test
+    fun `stream opens unavailable, then available once a frame with gpus lands`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf(
+            """{"gpus": [{"index": 0, "name": "RTX PRO 6000", "memory": {"total": 97887, "used": 61440},
+                "temperature": {"current": 71}, "utilization": {"gpu_percent": 84},
+                "power": {"draw": 318.0, "limit": {"enforced": 300.0}}}]}""",
+        )
+        val repository = GpuStreamRepository(transport)
+
+        val emissions = withTimeout(5_000) { repository.stream().take(2).toList() }
+
+        assertTrue("first emission is unavailable before any frame arrives", emissions[0] is GpuState.Unavailable)
+        val available = emissions[1] as GpuState.Available
+        assertEquals(1, available.gpus.size)
+        assertEquals(61440, available.gpus[0].memoryUsedMiB)
+        assertEquals(97887, available.gpus[0].memoryTotalMiB)
+        assertEquals(84, available.gpus[0].utilizationPercent)
+        assertEquals(71, available.gpus[0].temperatureC)
+    }
+
+    @Test
+    fun `an empty gpus list is treated as unavailable, not an available card with nothing in it`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf("""{"gpus": []}""")
+        val repository = GpuStreamRepository(transport)
+
+        val emissions = withTimeout(5_000) { repository.stream().take(2).toList() }
+
+        assertTrue(emissions[0] is GpuState.Unavailable)
+        assertTrue(emissions[1] is GpuState.Unavailable)
+    }
+
+    @Test
+    fun `an error tick is surfaced as unavailable with the server's message`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf("""{"error": "nvidia-smi command failed"}""")
+        val repository = GpuStreamRepository(transport)
+
+        val emissions = withTimeout(5_000) { repository.stream().take(2).toList() }
+
+        assertEquals(GpuState.Unavailable("nvidia-smi command failed"), emissions[1])
+    }
+
+    /**
+     * The mechanism, not a flag: a collector going away must actually cancel
+     * the underlying [com.hpz.llmdockchat.core.net.SseTransport.open] call.
+     * [FakeSseTransport.cancelled] only completes if the fake's flow was
+     * really cancelled, which only happens if [Job.cancel] genuinely
+     * propagates through [GpuStreamRepository.stream]'s reconnect loop — a
+     * fake that "completed on its own" (F09's post-mortem on the F07 bug)
+     * would let this pass without proving anything.
+     */
+    @Test
+    fun `cancelling the collector actually tears down the open connection`() = runTest {
+        val transport = FakeSseTransport()
+        transport.stayOpen = true
+        val repository = GpuStreamRepository(transport)
+
+        val job: Job = launch { repository.stream().collect { } }
+        withTimeout(5_000) { transport.parked.await() }
+
+        job.cancel()
+        withTimeout(5_000) { transport.cancelled.await() }
+    }
+
+    @Test
+    fun `a dropped connection keeps retrying rather than giving up after the first attempt`() = runTest {
+        val transport = FakeSseTransport()
+        transport.failWith = RuntimeException("connection reset")
+        val backoff = ReconnectBackoff(initialMs = 1L, maxMs = 1L)
+        val repository = GpuStreamRepository(transport)
+
+        // Every failed attempt is caught and re-emitted as Unavailable before
+        // the next retry, so four emissions (the initial one plus three
+        // failed attempts) is proof of three separate `open()` calls —
+        // no busy-wait needed, same `take(n).toList()` idiom as the rest of
+        // this suite.
+        withTimeout(5_000) { repository.stream(backoff = backoff).take(4).toList() }
+
+        assertEquals(3, transport.requests.size)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesStreamRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesStreamRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.hpz.llmdockchat.core.net.ServiceStreamEvent
 import com.hpz.llmdockchat.data.dto.ServiceDto
 import com.hpz.llmdockchat.data.model.ServiceSummary
 import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.ScriptedSseTransport
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -80,5 +81,60 @@ class ServicesStreamRepositoryTest {
 
         assertEquals("running", emissions[0][0].status)
         assertEquals("exited", emissions[1][0].status)
+    }
+
+    // -- streamWithStatus (F10-R1's fifth criterion) ----------------------------
+
+    @Test
+    fun `streamWithStatus is not stale while the connection is up`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf(
+            """{"type":"snapshot","data":{"services":[
+                {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+            ],"total":1,"running":1,"stopped":0}}""",
+        )
+        val repository = ServicesStreamRepository(transport)
+
+        val emission = withTimeout(5_000) { repository.streamWithStatus().take(1).toList() }.single()
+
+        assertEquals(false, emission.stale)
+        assertEquals(listOf(running), emission.services)
+    }
+
+    /**
+     * A dropped connection must not freeze the last-known list — it is
+     * re-emitted immediately with `stale = true` carrying the last snapshot
+     * forward, rather than the collector hearing nothing until the next
+     * successful reconnect (F10-R1's fifth criterion: "falls back to a
+     * snapshot fetch and shows a stale indicator rather than freezing").
+     * Against a `stream()`-only design (before `streamWithStatus` existed)
+     * this drop would simply never be observed at all — no emission, no
+     * indicator, exactly the "freezing" the requirement rules out. A single
+     * [ScriptedSseTransport.Leg] carries both halves of one real connection:
+     * a snapshot arrives, then the same connection drops mid-stream.
+     */
+    @Test
+    fun `a dropped connection is re-emitted immediately as stale, with the last known list intact`() = runTest {
+        val transport = ScriptedSseTransport()
+        transport.script(
+            ScriptedSseTransport.Leg(
+                payloads = listOf(
+                    """{"type":"snapshot","data":{"services":[
+                        {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+                    ],"total":1,"running":1,"stopped":0}}""",
+                ),
+                failWith = RuntimeException("connection reset"),
+            ),
+        )
+        transport.whenScriptRunsOut = { ScriptedSseTransport.Leg(park = true) }
+        val repository = ServicesStreamRepository(transport)
+
+        val emissions = withTimeout(5_000) { repository.streamWithStatus(reconnectDelayMs = 1L).take(2).toList() }
+
+        assertEquals(false, emissions[0].stale)
+        assertEquals(listOf(running), emissions[0].services)
+
+        assertEquals("the drop must be surfaced, not swallowed silently", true, emissions[1].stale)
+        assertEquals("the last known list is carried forward, not blanked", listOf(running), emissions[1].services)
     }
 }

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsFormattingTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsFormattingTest.kt
@@ -1,0 +1,78 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * [ServiceSummary.statusLabel] and [ServiceSummary.subtitle] — F10-R1's third
+ * and fourth criteria (an exited service names its exit code; not-created is
+ * distinguishable from exited) and the Deviations note on uptime (never say
+ * "uptime" for a value that is really the container's creation time).
+ */
+class ModelsFormattingTest {
+
+    private val now = Instant.parse("2026-07-25T12:00:00Z")
+    private val zone = ZoneOffset.UTC
+
+    @Test
+    fun `a running service's status label is Running`() {
+        assertEquals("Running", ServiceSummary("llamacpp-a", "running", "chat").statusLabel())
+    }
+
+    @Test
+    fun `an exited service names its exit code`() {
+        val service = ServiceSummary("llamacpp-a", "exited", "chat", exitCode = 137)
+        assertEquals("Exited (code 137)", service.statusLabel())
+    }
+
+    @Test
+    fun `an exited service with no exit code still says exited, not a crash`() {
+        val service = ServiceSummary("llamacpp-a", "exited", "chat", exitCode = null)
+        assertEquals("Exited", service.statusLabel())
+    }
+
+    @Test
+    fun `not-created is its own label, distinguishable from exited`() {
+        val service = ServiceSummary("llamacpp-a", "not-created", "chat")
+        assertEquals("Not created", service.statusLabel())
+    }
+
+    @Test
+    fun `a running service's subtitle shows port, size and created-ago, never the word uptime`() {
+        val service = ServiceSummary(
+            "llamacpp-a", "running", "chat", port = 3301,
+            modelSizeStr = "26.1 GB",
+            createdAt = "2026-07-25T08:00:00Z", // 4 hours before `now`
+        )
+        val subtitle = service.subtitle(now, zone)
+        assertEquals(":3301 · 26.1 GB · created 08:00", subtitle)
+    }
+
+    @Test
+    fun `an exited service's subtitle carries the exit code, not a created-ago figure`() {
+        val service = ServiceSummary("llamacpp-a", "exited", "chat", port = 3303, modelSizeStr = "33.73 GB", exitCode = 1)
+        assertEquals(":3303 · 33.73 GB · exited (code 1)", service.subtitle(now, zone))
+    }
+
+    @Test
+    fun `a not-created service's subtitle shows what it needs, not a blank size`() {
+        val service = ServiceSummary("ds4-a", "not-created", "chat", port = 3315, modelSizeStr = "80.76 GB")
+        assertEquals(":3315 · needs ~80.76 GB", service.subtitle(now, zone))
+    }
+
+    @Test
+    fun `a not-created service with no known size still renders, just without a needs figure`() {
+        val service = ServiceSummary("ds4-a", "not-created", "chat", port = 3315, modelSizeStr = null)
+        assertEquals(":3315 · not created", service.subtitle(now, zone))
+    }
+
+    @Test
+    fun `mibToGb renders up to one decimal place, dropping a trailing zero`() {
+        // Matches the mockup's own style — "61.4 / 96 GB", not "61.4 / 96.0 GB".
+        assertEquals("95.6", mibToGb(97887))
+        assertEquals("60", mibToGb(61440))
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTeardownTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTeardownTest.kt
@@ -1,0 +1,158 @@
+package com.hpz.llmdockchat.feature.models
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.data.GpuStreamRepository
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.baseUrl
+import com.hpz.llmdockchat.testing.quiesceAndRelease
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Executors
+
+/**
+ * F10-R3's third criterion: "closing the tab stops the stream". On device,
+ * switching to the Chats tab was found to leave both SSE sockets `ESTAB` in
+ * `ss -tnp` when the two live streams were launched from
+ * `ModelsViewModel`'s own `viewModelScope` — Navigation Compose's tab-switch
+ * idiom (`popUpTo(...) { saveState = true }` / `restoreState = true`, the same
+ * one used for the Chats tab) keeps a Models-tab `ModelsViewModel` instance
+ * cached across a switch, and anything running in its scope survives right
+ * along with it. That is why [ModelsViewModel.observeServicesStream] /
+ * [ModelsViewModel.observeGpuStream] hand back bare flows instead of
+ * subscribing internally — the real owner of "does this stay connected" is
+ * whoever calls `collect`, which in production is [ModelsScreen]'s own
+ * `LaunchedEffect`s, torn down by Compose the moment the destination stops
+ * being current.
+ *
+ * This test stands in for those `LaunchedEffect`s: it collects both flows
+ * from jobs of its own, then cancels those jobs — not `store.clear()` — and
+ * proves the parked transports were genuinely cancelled. Same
+ * park-on-an-explicit-gate pattern as `ThreadReconnectTeardownTest` and
+ * `GpuStreamRepositoryTest`'s own cancellation test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ModelsViewModelTeardownTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var servicesRepository: ServicesRepository
+    private lateinit var servicesStreamTransport: FakeSseTransport
+    private lateinit var gpuStreamTransport: FakeSseTransport
+    private val store = ViewModelStore()
+    private val mainExecutor = Executors.newSingleThreadExecutor { Thread(it, "probe-main") }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainExecutor.asCoroutineDispatcher())
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(baseUrl(server.url("/").toString()))
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        servicesRepository = ServicesRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        servicesStreamTransport = FakeSseTransport().apply { stayOpen = true }
+        gpuStreamTransport = FakeSseTransport().apply { stayOpen = true }
+    }
+
+    @After
+    fun tearDown() {
+        store.clear()
+        server.close()
+        mainExecutor.quiesceAndRelease()
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(): ModelsViewModel = ViewModelProvider.create(
+        store,
+        viewModelFactory {
+            initializer {
+                ModelsViewModel(
+                    servicesRepository = servicesRepository,
+                    servicesStreamRepository = ServicesStreamRepository(servicesStreamTransport),
+                    gpuStreamRepository = GpuStreamRepository(gpuStreamTransport),
+                )
+            }
+        },
+    )[ModelsViewModel::class]
+
+    @Test
+    fun `cancelling the screen's stream collectors tears down both connections, and neither resubscribes`() = runBlocking {
+        server.enqueue(MockResponse.Builder().body("""{"services": [], "total": 0, "running": 0, "stopped": 0}""").build())
+
+        val viewModel = viewModel()
+        viewModel.start()
+        withTimeout(TIMEOUT_MS) { viewModel.state.first { it is ModelsUiState.Loaded } }
+
+        // What ModelsScreen's two LaunchedEffects do — collect, and feed the
+        // result back into the ViewModel.
+        val servicesJob: Job = launch { viewModel.observeServicesStream().collect { viewModel.applyServicesUpdate(it) } }
+        val gpuJob: Job = launch { viewModel.observeGpuStream().collect { viewModel.applyGpuUpdate(it) } }
+
+        withTimeout(TIMEOUT_MS) { servicesStreamTransport.parked.await() }
+        withTimeout(TIMEOUT_MS) { gpuStreamTransport.parked.await() }
+
+        // What leaving the Models tab does to composition — deliberately NOT
+        // store.clear(): the ViewModel is cached by Navigation Compose's
+        // saveState/restoreState and survives this exactly as it does on device.
+        servicesJob.cancel()
+        gpuJob.cancel()
+
+        withTimeout(TIMEOUT_MS) { servicesStreamTransport.cancelled.await() }
+        withTimeout(TIMEOUT_MS) { gpuStreamTransport.cancelled.await() }
+
+        delay(300)
+        assertEquals("the services stream resubscribed after the screen went away", 1, servicesStreamTransport.requests.size)
+        assertEquals("the GPU stream resubscribed after the screen went away", 1, gpuStreamTransport.requests.size)
+    }
+
+    /**
+     * The regression this class exists to prevent, made explicit: a
+     * [ModelsViewModel] that survives a tab switch (never cleared, no
+     * collector ever attached) must not, on its own, hold either stream open.
+     * `store.clear()` is deliberately never called here — the point is that
+     * the ViewModel stays alive and idle, the same as while the Chats tab is
+     * showing, yet nothing was ever subscribed.
+     */
+    @Test
+    fun `the ViewModel surviving a tab switch does not by itself keep a stream connected`() = runBlocking {
+        server.enqueue(MockResponse.Builder().body("""{"services": [], "total": 0, "running": 0, "stopped": 0}""").build())
+        val viewModel = viewModel()
+        viewModel.start()
+        withTimeout(TIMEOUT_MS) { viewModel.state.first { it is ModelsUiState.Loaded } }
+
+        delay(300)
+        assertEquals("nothing subscribed, so nothing should have connected", 0, servicesStreamTransport.requests.size)
+        assertEquals("nothing subscribed, so nothing should have connected", 0, gpuStreamTransport.requests.size)
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTest.kt
@@ -1,0 +1,202 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.data.GpuStreamRepository
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.data.model.GpuState
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.MainDispatcherRule
+import com.hpz.llmdockchat.testing.ScriptedSseTransport
+import com.hpz.llmdockchat.testing.readFixture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * F10-R1's grouping and initial load (via [ModelsUiState.Loaded]),
+ * F10-R1's fifth criterion (stale on a dropped stream) and F10-R3 (GPU state
+ * flowing through). The teardown mechanism — F10-R3's third criterion — is
+ * covered separately in [ModelsViewModelTeardownTest], which needs real
+ * cancellation rather than [MainDispatcherRule]'s unconfined dispatcher.
+ */
+class ModelsViewModelTest {
+
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    private lateinit var server: MockWebServer
+    private lateinit var servicesRepository: ServicesRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(
+            (BaseUrl.normalize(server.url("/").toString()) as BaseUrlResult.Valid).baseUrl,
+        )
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        val api = ApiClient(client, urlStore, ApiJson, Dispatchers.IO)
+        servicesRepository = ServicesRepository(api)
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun viewModel(
+        servicesStreamTransport: FakeSseTransport = FakeSseTransport(),
+        gpuStreamTransport: FakeSseTransport = FakeSseTransport(),
+    ) = ModelsViewModel(
+        servicesRepository = servicesRepository,
+        servicesStreamRepository = ServicesStreamRepository(servicesStreamTransport),
+        gpuStreamRepository = GpuStreamRepository(gpuStreamTransport),
+    )
+
+    private fun settled(viewModel: ModelsViewModel): ModelsUiState = runBlocking {
+        withTimeout(10_000) { viewModel.state.first { it !is ModelsUiState.Loading } }
+    }
+
+    /**
+     * What [com.hpz.llmdockchat.feature.models.ModelsScreen]'s two
+     * `LaunchedEffect`s do — collect the live streams and feed them back into
+     * the ViewModel. Production owns this at the composition boundary (see
+     * [ModelsViewModel]'s class doc for why); a plain unit test has no
+     * composition, so it wires the same two lines by hand.
+     */
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun ModelsViewModel.startStreamsLikeTheScreenWould() {
+        GlobalScope.launch(Dispatchers.Main) { observeServicesStream().collect { applyServicesUpdate(it) } }
+        GlobalScope.launch(Dispatchers.Main) { observeGpuStream().collect { applyGpuUpdate(it) } }
+    }
+
+    @Test
+    fun `running services are grouped first, stopped second, each in the payload's host-port order`() {
+        server.enqueue(MockResponse.Builder().body(readFixture("services_list.json")).build())
+        val viewModel = viewModel()
+
+        viewModel.start()
+        val state = settled(viewModel) as ModelsUiState.Loaded
+
+        // Fixture: open-webui (3300) and llamacpp-gemma-4-26b-a4b-it-q8 (3301)
+        // are the only two "running" rows; everything else is exited/not-created.
+        assertEquals(listOf("open-webui", "llamacpp-gemma-4-26b-a4b-it-q8"), state.running.map { it.name })
+        assertEquals(19, state.stopped.size)
+        assertEquals("vllm-qwen3-6-27b-fp8", state.stopped.first().name) // host_port 3302, first stopped row
+        assertEquals(false, state.stale)
+    }
+
+    @Test
+    fun `an exited service in the initial load carries its exit code`() {
+        server.enqueue(MockResponse.Builder().body(readFixture("services_list.json")).build())
+        val viewModel = viewModel()
+
+        viewModel.start()
+        val state = settled(viewModel) as ModelsUiState.Loaded
+
+        val crashed = state.stopped.first { it.name == "llamacpp-qwen3-5-397b-a17b-iq4xs" }
+        assertEquals(137, crashed.exitCode)
+        assertTrue(crashed.isExited)
+    }
+
+    @Test
+    fun `a failing initial fetch is the Failed state, not a silent empty list`() {
+        server.enqueue(MockResponse.Builder().code(503).body("""{"error": "Docker socket unavailable"}""").build())
+        val viewModel = viewModel()
+
+        viewModel.start()
+        val state = settled(viewModel)
+
+        assertTrue(state is ModelsUiState.Failed)
+        assertEquals("Docker socket unavailable", (state as ModelsUiState.Failed).message)
+    }
+
+    /**
+     * F10-R1's fifth criterion: the live services stream dropping is surfaced
+     * as `stale = true` on the Models screen's own state, layered on top of
+     * the initial REST load — [ServicesStreamRepositoryTest] already proves
+     * the repository-level mechanism; this proves the ViewModel actually
+     * wires it through rather than discarding the flag.
+     */
+    @Test
+    fun `a dropped services stream marks the state stale without losing the last known list`() {
+        server.enqueue(MockResponse.Builder().body("""{"services": [], "total": 0, "running": 0, "stopped": 0}""").build())
+        val servicesStreamTransport = ScriptedSseTransport()
+        servicesStreamTransport.script(
+            ScriptedSseTransport.Leg(
+                payloads = listOf(
+                    """{"type":"snapshot","data":{"services":[
+                        {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+                    ],"total":1,"running":1,"stopped":0}}""",
+                ),
+                failWith = RuntimeException("connection reset"),
+            ),
+        )
+        servicesStreamTransport.whenScriptRunsOut = { ScriptedSseTransport.Leg(park = true) }
+        val viewModel = ModelsViewModel(
+            servicesRepository = servicesRepository,
+            servicesStreamRepository = ServicesStreamRepository(servicesStreamTransport),
+            gpuStreamRepository = GpuStreamRepository(FakeSseTransport()),
+        )
+
+        viewModel.start()
+        settled(viewModel)
+        viewModel.startStreamsLikeTheScreenWould()
+
+        // First the live snapshot lands (not stale), then the drop (stale).
+        val stale = runBlocking {
+            withTimeout(10_000) {
+                viewModel.state.first { it is ModelsUiState.Loaded && it.stale }
+            }
+        } as ModelsUiState.Loaded
+        assertEquals(listOf("llamacpp-a"), stale.running.map { it.name })
+    }
+
+    @Test
+    fun `GPU frames flow through into the state's gpu field`() {
+        server.enqueue(MockResponse.Builder().body("""{"services": [], "total": 0, "running": 0, "stopped": 0}""").build())
+        val gpuStreamTransport = FakeSseTransport()
+        gpuStreamTransport.payloads = listOf(
+            """{"gpus": [{"index": 0, "name": "RTX PRO 6000", "memory": {"total": 97887, "used": 61440},
+                "temperature": {"current": 71}, "utilization": {"gpu_percent": 84},
+                "power": {"draw": 318.0, "limit": {"enforced": 300.0}}}]}""",
+        )
+        val viewModel = viewModel(gpuStreamTransport = gpuStreamTransport)
+
+        viewModel.start()
+        settled(viewModel)
+        viewModel.startStreamsLikeTheScreenWould()
+
+        val loaded = runBlocking {
+            withTimeout(10_000) {
+                viewModel.state.first { it is ModelsUiState.Loaded && it.gpu is GpuState.Available }
+            }
+        } as ModelsUiState.Loaded
+        val gpu = (loaded.gpu as GpuState.Available).gpus.single()
+        assertEquals(84, gpu.utilizationPercent)
+        assertEquals(71, gpu.temperatureC)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/newchat/NewChatViewModelTest.kt
@@ -85,7 +85,7 @@ class NewChatViewModelTest {
         server.close()
     }
 
-    private fun viewModel() = NewChatViewModel(
+    private fun viewModel(preselectedServiceName: String? = null) = NewChatViewModel(
         servicesRepository = servicesRepository,
         promptsRepository = promptsRepository,
         mcpServersRepository = mcpServersRepository,
@@ -93,6 +93,7 @@ class NewChatViewModelTest {
         conversationsRepository = conversationsRepository,
         preferences = preferences,
         servicesStreamRepository = servicesStreamRepository,
+        preselectedServiceName = preselectedServiceName,
     )
 
     /** Load order in [NewChatViewModel.load]: services, openrouter, prompts, mcp-servers. */
@@ -236,6 +237,44 @@ class NewChatViewModelTest {
         val selected = state.selectedModel as ModelOption.Remote
         assertEquals("someone/retired-model", selected.modelId)
         assertFalse(state.rememberedModelUnavailable)
+    }
+
+    /**
+     * F10-R6: the Models tab's "New chat" action passes a specific running
+     * service, which must win over whatever [preferences] remembered from
+     * last time — that is the entire point of tapping it from a particular row.
+     */
+    @Test
+    fun `a preselected running service wins over whatever was remembered`() {
+        preferences = FakeNewChatPreferences(initialModel = "vllm-qwen3-6-27b-fp8") // exited in the fixture
+        enqueueLoadResponses()
+        val viewModel = viewModel(preselectedServiceName = "llamacpp-gemma-4-26b-a4b-it-q8")
+
+        viewModel.load()
+        val state = settled(viewModel) as NewChatUiState.Loaded
+
+        val selected = state.selectedModel as ModelOption.LocalService
+        assertEquals("llamacpp-gemma-4-26b-a4b-it-q8", selected.serviceName)
+        assertFalse(state.rememberedModelUnavailable) // the preselect resolved cleanly; nothing here was "unavailable"
+    }
+
+    /**
+     * If the tapped service stopped running between the tap and the sheet
+     * loading, the preselect must not land on a dead service — it falls
+     * through to the ordinary remembered-model resolution instead of
+     * crashing or silently picking a stopped row.
+     */
+    @Test
+    fun `a preselected service that stopped running falls back to the remembered-model resolution`() {
+        preferences = FakeNewChatPreferences(initialModel = "llamacpp-gemma-4-26b-a4b-it-q8")
+        enqueueLoadResponses()
+        val viewModel = viewModel(preselectedServiceName = "vllm-qwen3-6-27b-fp8") // exited in the fixture
+
+        viewModel.load()
+        val state = settled(viewModel) as NewChatUiState.Loaded
+
+        val selected = state.selectedModel as ModelOption.LocalService
+        assertEquals("llamacpp-gemma-4-26b-a4b-it-q8", selected.serviceName)
     }
 
     @Test

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadMessageActionsTest.kt
@@ -25,6 +25,7 @@ import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -92,8 +93,8 @@ class ThreadMessageActionsTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String = "conversation_multi_turn.json") =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadReattachTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadReattachTest.kt
@@ -27,6 +27,7 @@ import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.ScriptedSseTransport
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -107,8 +108,8 @@ class ThreadReattachTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String) =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadReconnectTeardownTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadReconnectTeardownTest.kt
@@ -24,6 +24,7 @@ import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.ScriptedSseTransport
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -95,8 +96,8 @@ class ThreadReconnectTeardownTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String) =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadStreamingEdgeTest.kt
@@ -21,6 +21,7 @@ import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -94,8 +95,8 @@ class ThreadStreamingEdgeTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String = "conversation_completed.json") =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadTerminalPathTest.kt
@@ -21,6 +21,7 @@ import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -95,8 +96,8 @@ class ThreadTerminalPathTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String = "conversation_completed.json") =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadToolsTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadToolsTest.kt
@@ -19,6 +19,7 @@ import com.hpz.llmdockchat.testing.FakeDraftStore
 import com.hpz.llmdockchat.testing.FakeServerUrlStore
 import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
 import kotlinx.coroutines.CompletableDeferred
@@ -94,8 +95,8 @@ class ThreadToolsTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String = "conversation_completed.json") =
@@ -366,7 +367,15 @@ private class OutOfOrderMcpWrites(api: ApiClient) : ConversationsRepository(api)
     override suspend fun setMcpServers(id: String, serverIds: List<String>): Result<Unit> =
         withContext(NonCancellable) {
             val index = nextIndex.getAndIncrement()
-            gates[index].await()
+            // Bounded on purpose. NonCancellable models "a request already on
+            // the wire is not recalled by cancelling its coroutine" — which
+            // also means `store.clear()` cannot kill this, so an unbounded
+            // await on a gate the test never releases parks a coroutine on
+            // Dispatchers.Main *forever*. The next class to call
+            // `Dispatchers.setMain` then dies with "Main is used concurrently
+            // with setting it", and the flake gets blamed on that class.
+            // Reproduced at ~1 run in 5 across the full suite.
+            runCatching { withTimeout(GATE_TIMEOUT_MS) { gates[index].await() } }
             stored = serverIds
             settled.send(index)
             Result.success(Unit)
@@ -385,5 +394,11 @@ private class OutOfOrderMcpWrites(api: ApiClient) : ConversationsRepository(api)
         const val GATE_COUNT = 8
         /** A deadlock guard, not a timing assumption — every await here is signalled, not slept on. */
         const val AWAIT_TIMEOUT_MS = 10_000L
+
+        /**
+         * Ceiling on a *non-cancellable* park, so it must be shorter than the
+         * teardown's `awaitTermination` or a leaked write outlives the class.
+         */
+        const val GATE_TIMEOUT_MS = 2_000L
     }
 }

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/thread/ThreadViewModelTest.kt
@@ -25,6 +25,7 @@ import com.hpz.llmdockchat.testing.FakeSseTransport
 import com.hpz.llmdockchat.testing.FakeTokenStore
 import com.hpz.llmdockchat.testing.baseUrl
 import com.hpz.llmdockchat.testing.readFixture
+import com.hpz.llmdockchat.testing.quiesceAndRelease
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -96,8 +97,8 @@ class ThreadViewModelTest {
     fun tearDown() {
         store.clear()
         server.close()
+        mainExecutor.quiesceAndRelease()
         Dispatchers.resetMain()
-        mainExecutor.shutdownNow()
     }
 
     private fun conversation(fixture: String = "conversation_completed.json") =

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/testing/MainDrain.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/testing/MainDrain.kt
@@ -1,0 +1,52 @@
+package com.hpz.llmdockchat.testing
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Quiesce the executor backing `Dispatchers.Main`, then hand it back.
+ *
+ * Call this *instead of* `Dispatchers.resetMain()` + `shutdownNow()` in an
+ * `@After`. The original order was wrong in both halves:
+ *
+ * ```
+ * store.clear()              // only *marks* the scope cancelled
+ * Dispatchers.resetMain()    // dispatcher yanked while coroutines still unwind
+ * mainExecutor.shutdownNow() // interrupts; does not wait for them to stop
+ * ```
+ *
+ * Cancellation is cooperative and asynchronous: `store.clear()` marks the
+ * scope, and every cancelled coroutine still has to be dispatched back onto
+ * Main to unwind its `finally` blocks. Resetting before that finishes leaves
+ * work running on the old dispatcher, and the *next* class to call
+ * `Dispatchers.setMain` dies with `IllegalStateException: Dispatchers.Main is
+ * used concurrently with setting it` — which then cascades into `lateinit
+ * property server has not been initialized`, because that class's `@Before`
+ * aborted half-way.
+ *
+ * The flake therefore always blamed whichever class ran *next*, never the one
+ * that leaked. It reproduced about once in five full-suite runs; draining
+ * alone only cut it to one in eight, which is not a fix.
+ *
+ * So: drain what is queued, stop accepting work, and **wait for termination**
+ * before releasing Main. The executor is single-threaded and FIFO, so a
+ * submitted no-op completing proves everything ahead of it has run; several
+ * rounds because a `finally` may suspend and re-dispatch. No sleeps, no
+ * wall-clock assertions.
+ */
+fun ExecutorService.quiesceAndRelease(rounds: Int = 3, timeoutSeconds: Long = 5) {
+    repeat(rounds) {
+        if (isShutdown) return@repeat
+        runCatching { submit { }.get(timeoutSeconds, TimeUnit.SECONDS) }
+    }
+    shutdown()
+    if (!awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) shutdownNow()
+}
+
+/** Runs the queue dry without shutting the executor down — for use mid-test. */
+fun ExecutorService.drainMain(rounds: Int = 1, timeoutSeconds: Long = 10) {
+    repeat(rounds) {
+        if (isShutdown) return@repeat
+        runCatching { submit { }.get(timeoutSeconds, TimeUnit.SECONDS) }
+    }
+}


### PR DESCRIPTION
The second tab: what is loaded and what the GPU is doing. Read-and-observe only — it can never create, edit or reconfigure a service.

## A real bug, found and fixed here

Both streams were launched in `viewModelScope`. Navigation Compose's tab-switch idiom (`popUpTo … saveState` + `restoreState`) keeps the ViewModel alive across a switch, so **both SSE connections survived leaving the tab** — confirmed as `ESTAB` in `ss -tnp`. A leaked GPU stream polls the host every 3 s forever.

They are now collected by `LaunchedEffect`s in `ModelsScreen`, which Compose disposes when the destination stops being current. Independently re-verified in review: both sockets to `:3399` reach `FIN-WAIT-2` and vanish within ~3 s of switching to Chats. (Filter `ss -tnp` on `qemu-system-x86` — the emulator's host-side sockets are NAT'd through it.)

## Honesty over prettiness, twice

- **One total VRAM bar, not per-container segments.** The API has no per-process breakdown and `model_size` is weights-on-disk, so segments would present an estimate as a measurement. The used/total figure is the real one.
- **"created X ago", never "uptime"** — the payload carries `created`, not a start time, so a restarted container would show a wrong figure.

## Beyond the spec, at the owner's request

Favourites sort first within each group, and a name/port filter appears at 8+ services. The spec described a list, not a searchable one. Favouriting stays on the dashboard — F10-R7 forbids this tab any mutating call but start/stop.

Also fixes the GPU header layout: the name had `maxLines = 1` but no width constraint, so it measured at full intrinsic width, shoved the VRAM figure off the edge and left it wrapping one character per line.

## Deferred

**F10-R5 (start/stop from a row) is carried forward to F11** — it depends on F11's confirm path, and start/stop is F11's to define. Nothing was stubbed.

## Also in here: a pre-existing suite flake, reduced

`Dispatchers.resetMain()` ran before the main executor had quiesced, so a still-unwinding coroutine leaked onto the next test class, which then died in `setMain` and got the blame. Adds `testing/MainDrain.kt`, rewrites 8 teardowns to quiesce-then-release, and bounds a `NonCancellable` gate await in `ThreadToolsTest` that could park forever by construction. Roughly 1-run-in-5 down to 1-in-10 — improved, not eliminated.

## Verification

414 tests pass. Every Must verified, most on device against the live dashboard, and the review re-verified the stream teardown independently rather than trusting the claim.

**Known issue, recorded not fixed:** the GPU header can stick on "unavailable" after a network blip (remounting the tab recovers it). Likely `readTimeout(0)` letting a half-open socket hang inside `open()` so the reconnect loop never runs. The honest fix is a read timeout in shared SSE plumbing every feature uses — not something to slip into this PR.