### PR TITLE
F11: model detail, start and stop

### DIFF
--- a/android/docs/F11-model-detail-and-control.md
+++ b/android/docs/F11-model-detail-and-control.md
@@ -163,3 +163,57 @@ app must not call them. A bad tap must not be able to corrupt
 
 - Anything that writes `services.json`.
 - Benchmarks (`/api/benchmarks/*`).
+
+## Verification notes
+
+All Must criteria verified, most on device against the live rig. The
+review reproduced the implementer's findings independently rather than
+trusting them.
+
+**One shared confirm path, structurally.** `ServiceControlController` is
+a single sealed state machine (Idle / Confirming / InFlight / Failed).
+Both `ModelsViewModel` (the row actions, F10-R5) and
+`ModelDetailViewModel` hold an instance and only ever call
+`requestStart` / `requestStop` / `confirm` / `dismiss`. Verified by grep:
+the repository's `start`/`stop` are reached from exactly one place,
+inside `confirm()`. There is no second path that could fire without a
+confirm — which is the property F10-R5's "same confirmation path"
+criterion actually wanted.
+
+`InFlight` refuses a second request; the test asserts the state is
+unchanged after a second `requestStart`, not that a button looked
+disabled.
+
+**Dropping the VRAM guard was exercised for real, twice.** With the GPU
+at 94.1 / 95.6 GB, starting `llamacpp-gemma-4-26b-a4b-it-q8` (27 GB) from
+the app failed in ~0.6 s with exit code 139 — a genuine `cudaMalloc
+failed: out of memory` in `docker logs`. The app never showed "running"
+at any point; it went straight back to "Exited (code 139)" live, with no
+manual refresh. This is the behaviour the owner asked for in place of a
+guard.
+
+**The start confirm's wording was corrected.** It said *"you'll see the
+error here"*. It will not: the screen only ever learns the **exit code**.
+The reason lives in the container's log, which is exactly the split
+F11-R5's own reasoning assumed. Now says the status shows the exit code
+and the reason is in the logs.
+
+**A long `model_path` broke the detail rows** — the label had `weight(1f)`
+and the value none, so "Model path" wrapped one character per line. The
+same failure mode as F10's GPU card, and neither was caught by a JVM test,
+because layout is not what they measure. Fixed by swapping which side
+takes the weight; confirmed on device against a real
+`/hf-cache/hub/models--unsloth--…` path.
+
+**Skipped, both Should**
+
+| Item | Why |
+|---|---|
+| R6 · Restart | Deprioritised. A clean extension of the same controller if it is ever wanted. |
+| R7 · Readiness | **Blocked on F12.** Readiness means watching the container log for the server's listening line, and no log-stream client exists until F12 builds one. Picked up there. |
+
+**Rig state after review:** unchanged. `llamacpp-laguna-s-2.1-q4` and
+`open-webui` running as before; `llamacpp-gemma-4-26b-a4b-it-q8` still
+exited, its exit code moved 0 → 139 by the deliberate OOM tests. Every
+action went through the app's own confirm → start/stop, never `docker`
+directly and never a configuration endpoint.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -184,7 +184,7 @@ Mark completed features `[DONE]` in the Status column.
 | F08 | Per-conversation tools | [F08-conversation-tools.md](F08-conversation-tools.md) | 07b | [DONE] — R5 (Should) unexercised, see the feature file |
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [DONE] — R5's failed-while-away is fixture-only, see the feature file |
 | F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [DONE] — R5 carried forward to F11 |
-| F11 | Model detail, start and stop | [F11-model-detail-and-control.md](F11-model-detail-and-control.md) | 10b, 10d | [ ] |
+| F11 | Model detail, start and stop | [F11-model-detail-and-control.md](F11-model-detail-and-control.md) | 10b | [DONE] — R6 skipped, R7 deferred to F12, R5 dropped |
 | F12 | Container logs | [F12-container-logs.md](F12-container-logs.md) | 10c | [ ] |
 | F13 | Settings | [F13-settings.md](F13-settings.md) | 09 | [ ] |
 | — | Dropped and deferred features | [Dropped-Features.md](Dropped-Features.md) | — | n/a |

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
@@ -35,6 +35,14 @@ object Endpoints {
     /** F07-R1's third criterion — a snapshot, then deltas as containers start/stop. */
     const val SERVICES_STREAM = "/api/services/stream"
 
+    /** F11-R2 — the stored config for one service. 404 when Docker knows the
+     * container but `services.json` does not (F11-R2's fourth criterion). */
+    fun serviceDetail(name: String): String = "/api/services/$name"
+
+    /** F11-R4 / F10-R5 — the only two mutating service calls this app makes. */
+    fun serviceStart(name: String): String = "/api/services/$name/start"
+    fun serviceStop(name: String): String = "/api/services/$name/stop"
+
     /** F10-R3's GPU header — one `data:` frame per tick, no `type` envelope. */
     const val GPU_STREAM = "/api/gpu/stream"
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesRepository.kt
@@ -1,11 +1,18 @@
 package com.hpz.llmdockchat.data
 
+import com.hpz.llmdockchat.core.error.AppError
 import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiException
 import com.hpz.llmdockchat.core.net.Endpoints
+import com.hpz.llmdockchat.core.net.appError
 import com.hpz.llmdockchat.core.net.apiCall
+import com.hpz.llmdockchat.data.dto.ServiceActionResponseDto
+import com.hpz.llmdockchat.data.dto.ServiceDetailResponseDto
 import com.hpz.llmdockchat.data.dto.ServiceListResponseDto
 import com.hpz.llmdockchat.data.mapper.toDomain
+import com.hpz.llmdockchat.data.model.ServiceConfig
 import com.hpz.llmdockchat.data.model.ServiceSummary
+import kotlinx.coroutines.CancellationException
 
 /**
  * `GET /api/services` (F03's model picker, later F10's models list). Returns
@@ -17,5 +24,36 @@ import com.hpz.llmdockchat.data.model.ServiceSummary
 class ServicesRepository(private val api: ApiClient) {
     suspend fun list(): Result<List<ServiceSummary>> = apiCall {
         api.get(Endpoints.SERVICES, ServiceListResponseDto.serializer()).services.map { it.toDomain() }
+    }
+
+    /**
+     * `GET /api/services/<name>` (F11-R2). A 404 is not a failure here — it
+     * means Docker knows the container but `services.json` doesn't, F11-R2's
+     * fourth criterion — so it comes back as `Result.success(null)` rather
+     * than an error the detail screen would otherwise have to special-case
+     * out of a [Result.failure].
+     */
+    suspend fun detail(name: String): Result<ServiceConfig?> = try {
+        Result.success(
+            api.get(Endpoints.serviceDetail(name), ServiceDetailResponseDto.serializer()).config.toDomain(),
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: ApiException) {
+        if ((e.error as? AppError.Http)?.status == 404) Result.success(null) else Result.failure(e)
+    } catch (e: Throwable) {
+        Result.failure(ApiException(e.appError))
+    }
+
+    /** `POST /api/services/<name>/start` (F11-R4, F10-R5). */
+    suspend fun start(name: String): Result<Unit> = apiCall {
+        api.request(method = "POST", path = Endpoints.serviceStart(name), deserializer = ServiceActionResponseDto.serializer())
+        Unit
+    }
+
+    /** `POST /api/services/<name>/stop` (F11-R3, F10-R5). */
+    suspend fun stop(name: String): Result<Unit> = apiCall {
+        api.request(method = "POST", path = Endpoints.serviceStop(name), deserializer = ServiceActionResponseDto.serializer())
+        Unit
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
@@ -2,6 +2,7 @@ package com.hpz.llmdockchat.data.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 /**
  * One row of `GET /api/services` (`dashboard/docker_utils.py:get_docker_services`). F03's and
@@ -26,3 +27,31 @@ data class ServiceDto(
 
 @Serializable
 data class ServiceListResponseDto(val services: List<ServiceDto> = emptyList())
+
+/**
+ * `GET /api/services/<name>` (F11-R2) — the stored config, not live status;
+ * the detail screen gets status from the same stream as the list (F11-R1).
+ * `api_key` is on this payload too and is deliberately not modeled here, same
+ * reasoning as [ServiceDto].
+ */
+@Serializable
+data class ServiceConfigDto(
+    val alias: String? = null,
+    @SerialName("model_path") val modelPath: String? = null,
+    @SerialName("model_name") val modelName: String? = null,
+    val params: Map<String, JsonElement> = emptyMap(),
+    @SerialName("template_type") val templateType: String? = null,
+    val port: Int? = null,
+    @SerialName("model_size_str") val modelSizeStr: String? = null,
+)
+
+@Serializable
+data class ServiceDetailResponseDto(
+    @SerialName("service_name") val serviceName: String = "",
+    val config: ServiceConfigDto = ServiceConfigDto(),
+)
+
+/** `{"success": true, ...}` from `control_service` (F11-R3/R4). Only [success]
+ * is read — a failure surfaces as a non-2xx, handled by [com.hpz.llmdockchat.core.net.ApiClient] before this ever decodes. */
+@Serializable
+data class ServiceActionResponseDto(val success: Boolean = true)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ServiceConfigMapper.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/mapper/ServiceConfigMapper.kt
@@ -1,0 +1,21 @@
+package com.hpz.llmdockchat.data.mapper
+
+import com.hpz.llmdockchat.data.dto.ServiceConfigDto
+import com.hpz.llmdockchat.data.model.ServiceConfig
+import kotlinx.serialization.json.JsonPrimitive
+
+fun ServiceConfigDto.toDomain(): ServiceConfig = ServiceConfig(
+    modelPath = modelPath,
+    modelName = modelName,
+    // `params`' values are usually plain strings ("" for a bare flag), but the
+    // server never guarantees that on the wire, so render the same way the
+    // stream parser does elsewhere rather than assume and risk a decode crash.
+    flags = params.map { (flag, value) -> flag to value.render() },
+    templateType = templateType,
+    modelSizeStr = modelSizeStr,
+)
+
+private fun kotlinx.serialization.json.JsonElement.render(): String = when (this) {
+    is JsonPrimitive -> content
+    else -> toString()
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceConfig.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/ServiceConfig.kt
@@ -1,0 +1,16 @@
+package com.hpz.llmdockchat.data.model
+
+/**
+ * The stored config behind one service (F11-R2), read-only. [flags] renders
+ * `params` as flag/value pairs in server order — good enough to read as the
+ * equivalent command line without this client re-implementing
+ * `flag_metadata.render_cli_flag`. Never carries `api_key`: [[F11-model-detail-and-control.md]]'s
+ * R2 says it must not appear, so the mapper never reads it off the wire.
+ */
+data class ServiceConfig(
+    val modelPath: String?,
+    val modelName: String?,
+    val flags: List<Pair<String, String>>,
+    val templateType: String?,
+    val modelSizeStr: String?,
+)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailScreen.kt
@@ -1,0 +1,263 @@
+package com.hpz.llmdockchat.feature.models
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.ServiceSummary
+
+/**
+ * Screen 10b · Model detail (F11-R1). Screen 10d (the start-conflict dialog)
+ * is not implemented — F11-R5 is dropped, see the feature file.
+ */
+@Composable
+fun ModelDetailScreen(
+    viewModel: ModelDetailViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    val actionState by viewModel.actionState.collectAsState()
+    LaunchedEffect(Unit) { viewModel.start() }
+
+    // Same ownership split as ModelsScreen's two LaunchedEffects: this stream
+    // lives only as long as this composable does, so leaving the screen
+    // (back, or navigating past it) tears it down (F11-R7's third criterion
+    // reasoning applies here too, even though R7 itself is not built).
+    LaunchedEffect(Unit) {
+        viewModel.observeServicesStream().collect { viewModel.applyLiveSummary(it) }
+    }
+
+    ModelDetailContent(
+        state = state,
+        actionState = actionState,
+        onBack = onBack,
+        onRetry = viewModel::retry,
+        onRequestStart = viewModel::requestStart,
+        onRequestStop = viewModel::requestStop,
+        onDismissAction = viewModel::dismissAction,
+        onConfirmAction = viewModel::confirmAction,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModelDetailContent(
+    state: ModelDetailUiState,
+    actionState: ServiceActionState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onRequestStart: () -> Unit,
+    onRequestStop: () -> Unit,
+    onDismissAction: () -> Unit,
+    onConfirmAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LlmTheme.colors
+    Scaffold(
+        modifier = modifier.testTag("model_detail_screen"),
+        containerColor = colors.app,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        (state as? ModelDetailUiState.Loaded)?.summary?.name ?: "Model",
+                        color = colors.fg,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("model_detail_back")) {
+                        Text("←", color = colors.fg)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when (state) {
+                is ModelDetailUiState.Loading -> LoadingBox()
+                is ModelDetailUiState.Failed -> FailedBox(state.message, onRetry)
+                is ModelDetailUiState.Loaded -> DetailBody(state, actionState, onRequestStart, onRequestStop)
+            }
+        }
+        ServiceActionDialog(actionState, onDismiss = onDismissAction, onConfirm = onConfirmAction)
+    }
+}
+
+@Composable
+private fun DetailBody(
+    state: ModelDetailUiState.Loaded,
+    actionState: ServiceActionState,
+    onRequestStart: () -> Unit,
+    onRequestStop: () -> Unit,
+) {
+    val colors = LlmTheme.colors
+    val summary = state.summary
+    val pending = actionState is ServiceActionState.InFlight && actionState.serviceName == summary.name
+
+    LazyColumn(Modifier.fillMaxSize().testTag("model_detail_body")) {
+        item {
+            Column(Modifier.fillMaxWidth().padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(engineLabel(summary.engine), color = colors.subtle, style = MaterialTheme.typography.labelLarge)
+                    Text("·", color = colors.subtle)
+                    Text(
+                        statusLabelFor(summary),
+                        color = if (summary.isRunning) colors.green else colors.muted,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.testTag("model_detail_status"),
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+                DetailRow("Host port", if (summary.port > 0) summary.port.toString() else "—")
+                summary.modelSizeStr?.let { DetailRow("Model size", it) }
+                if (summary.isExited) DetailRow("Exit code", summary.exitCode?.toString() ?: "—")
+
+                state.config?.let { config ->
+                    config.modelPath?.let { DetailRow("Model path", it) }
+                    config.modelName?.let { DetailRow("Model", it) }
+                    config.templateType?.let { DetailRow("Engine template", it) }
+                }
+                if (state.configMissing) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "No stored configuration for this container — it isn't in services.json.",
+                        color = colors.muted,
+                        style = MaterialTheme.typography.labelMedium,
+                        modifier = Modifier.testTag("model_detail_config_missing"),
+                    )
+                }
+
+                Spacer(Modifier.height(16.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    if (pending) {
+                        CircularProgressIndicator(color = colors.accent, modifier = Modifier.testTag("model_detail_pending"))
+                    } else if (summary.isRunning) {
+                        TextButton(onClick = onRequestStop, modifier = Modifier.testTag("model_detail_stop")) {
+                            Text("Stop", color = colors.red)
+                        }
+                    } else {
+                        TextButton(onClick = onRequestStart, modifier = Modifier.testTag("model_detail_start")) {
+                            Text("Start", color = colors.accent)
+                        }
+                    }
+                }
+            }
+        }
+
+        // F11-R2 (Should): the flags rendered as a readable list, strictly
+        // read-only — no field here is ever editable and api_key never
+        // appears (ServiceConfig's mapper never reads it off the wire).
+        val flags = state.config?.flags.orEmpty()
+        if (flags.isNotEmpty()) {
+            item { SectionLabel("Flags") }
+            items(flags, key = { it.first }) { (flag, value) -> FlagRow(flag, value) }
+        }
+    }
+}
+
+private fun statusLabelFor(summary: ServiceSummary): String = summary.statusLabel()
+
+/**
+ * Label fixed and single-line, value takes the rest of the row and wraps —
+ * not the other way around. A first cut gave the label the `weight(1f)` and
+ * left the value unconstrained; a long `model_path` (F11-R2) then measured at
+ * its full intrinsic width, squeezed the label down to nothing, and "Model
+ * path" wrapped one character per line — the same failure mode as the GPU
+ * card's name column (see [ModelsScreen]'s `GpuCard` doc). Caught on-device
+ * rather than in a JVM test, since Compose text layout isn't exercised there.
+ */
+@Composable
+private fun DetailRow(label: String, value: String) {
+    val colors = LlmTheme.colors
+    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Text(
+            label,
+            color = colors.subtle,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            modifier = Modifier.padding(end = 12.dp),
+        )
+        Text(
+            value,
+            color = colors.fg,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun SectionLabel(title: String) {
+    val colors = LlmTheme.colors
+    Text(
+        title,
+        color = colors.subtle,
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun FlagRow(flag: String, value: String) {
+    val colors = LlmTheme.colors
+    Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 2.dp)) {
+        Text(flag, color = colors.fg, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
+        if (value.isNotEmpty()) {
+            Text(" $value", color = colors.muted, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
+        }
+    }
+}
+
+@Composable
+private fun LoadingBox() {
+    Box(Modifier.fillMaxSize().testTag("model_detail_loading"), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(color = LlmTheme.colors.accent)
+    }
+}
+
+@Composable
+private fun FailedBox(message: String, onRetry: () -> Unit) {
+    val colors = LlmTheme.colors
+    Column(
+        Modifier.fillMaxSize().padding(32.dp).testTag("model_detail_failed"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text("Couldn't load this model", color = colors.red, style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+        Text(message, color = colors.muted, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = onRetry, modifier = Modifier.testTag("model_detail_retry")) {
+            Text("Retry", color = colors.accent)
+        }
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailViewModel.kt
@@ -1,0 +1,104 @@
+package com.hpz.llmdockchat.feature.models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.data.model.ServiceConfig
+import com.hpz.llmdockchat.data.model.ServiceSummary
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+sealed interface ModelDetailUiState {
+    data object Loading : ModelDetailUiState
+
+    data class Loaded(
+        val summary: ServiceSummary,
+        val config: ServiceConfig? = null,
+        /** F11-R2's fourth criterion: Docker knows this container but
+         * `services.json` doesn't (a 404 on the config fetch). Shown as a
+         * graceful partial view, never as [Failed]. */
+        val configMissing: Boolean = false,
+    ) : ModelDetailUiState
+
+    data class Failed(val message: String) : ModelDetailUiState
+}
+
+/**
+ * F11-R1's detail screen. [summary] tracks the same live services stream the
+ * Models list uses (F11-R1's first two criteria) — [ModelDetailScreen]
+ * collects [observeServicesStream] from a composition-scoped `LaunchedEffect`,
+ * the same ownership split [ModelsViewModel] uses and for the same reason
+ * (F11-R1's third criterion: navigating back and forward must not lose the
+ * live connection, which only holds if the stream is re-subscribed by a
+ * fresh composition each time, not kept in this ViewModel's own scope across
+ * a back-then-forward that recreates it).
+ */
+class ModelDetailViewModel(
+    private val serviceName: String,
+    private val servicesRepository: ServicesRepository,
+    private val servicesStreamRepository: ServicesStreamRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<ModelDetailUiState>(ModelDetailUiState.Loading)
+    val state: StateFlow<ModelDetailUiState> = _state.asStateFlow()
+
+    val controller = ServiceControlController(servicesRepository, viewModelScope)
+    val actionState: StateFlow<ServiceActionState> = controller.actionState
+
+    fun requestStart() = controller.requestStart(serviceName)
+    fun requestStop() = controller.requestStop(serviceName)
+    fun dismissAction() = controller.dismiss()
+    fun confirmAction() = controller.confirm()
+
+    private var started = false
+
+    fun start() {
+        if (started) return
+        started = true
+        viewModelScope.launch {
+            val services = servicesRepository.list().getOrElse { failure ->
+                started = false
+                _state.value = ModelDetailUiState.Failed(failure.appError.displayMessage)
+                return@launch
+            }
+            val summary = services.firstOrNull { it.name == serviceName }
+            if (summary == null) {
+                started = false
+                _state.value = ModelDetailUiState.Failed("Service \"$serviceName\" not found.")
+                return@launch
+            }
+
+            val config = servicesRepository.detail(serviceName).getOrElse {
+                // A failed config fetch is not fatal to the screen — F11-R1
+                // still needs to show live status even if the read-only
+                // config (F11-R2, Should) could not be loaded.
+                null
+            }
+            _state.value = ModelDetailUiState.Loaded(summary = summary, config = config, configMissing = config == null)
+        }
+    }
+
+    fun retry() {
+        started = false
+        start()
+    }
+
+    /** Collected by [ModelDetailScreen] from a composition-scoped `LaunchedEffect` — see the class doc. */
+    fun observeServicesStream(): Flow<ServiceSummary?> =
+        servicesStreamRepository.streamWithStatus().map { live -> live.services.firstOrNull { it.name == serviceName } }
+
+    fun applyLiveSummary(summary: ServiceSummary?) {
+        if (summary == null) return
+        val current = _state.value
+        if (current is ModelDetailUiState.Loaded) {
+            _state.value = current.copy(summary = summary)
+        }
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
@@ -1,6 +1,7 @@
 package com.hpz.llmdockchat.feature.models
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,9 +58,11 @@ import java.time.ZoneId
 fun ModelsScreen(
     viewModel: ModelsViewModel,
     onNewChatFromModel: (String) -> Unit,
+    onOpenDetail: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val actionState by viewModel.actionState.collectAsState()
     LaunchedEffect(Unit) { viewModel.start() }
 
     // F10-R3's third criterion: these two run only while this composable is
@@ -77,9 +80,15 @@ fun ModelsScreen(
 
     ModelsContent(
         state = state,
+        actionState = actionState,
         onRetry = viewModel::retry,
         onNewChatFromModel = onNewChatFromModel,
+        onOpenDetail = onOpenDetail,
         onQueryChange = viewModel::onQueryChange,
+        onRequestStart = viewModel::requestStart,
+        onRequestStop = viewModel::requestStop,
+        onDismissAction = viewModel::dismissAction,
+        onConfirmAction = viewModel::confirmAction,
         modifier = modifier,
     )
 }
@@ -88,9 +97,15 @@ fun ModelsScreen(
 @Composable
 private fun ModelsContent(
     state: ModelsUiState,
+    actionState: ServiceActionState,
     onRetry: () -> Unit,
     onNewChatFromModel: (String) -> Unit,
+    onOpenDetail: (String) -> Unit,
     onQueryChange: (String) -> Unit,
+    onRequestStart: (String) -> Unit,
+    onRequestStop: (String) -> Unit,
+    onDismissAction: () -> Unit,
+    onConfirmAction: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LlmTheme.colors
@@ -108,9 +123,18 @@ private fun ModelsContent(
             when (state) {
                 is ModelsUiState.Loading -> LoadingState()
                 is ModelsUiState.Failed -> FailedState(state.message, onRetry)
-                is ModelsUiState.Loaded -> ModelsList(state, onNewChatFromModel, onQueryChange)
+                is ModelsUiState.Loaded -> ModelsList(
+                    state = state,
+                    onNewChatFromModel = onNewChatFromModel,
+                    onOpenDetail = onOpenDetail,
+                    onQueryChange = onQueryChange,
+                    actionState = actionState,
+                    onRequestStart = onRequestStart,
+                    onRequestStop = onRequestStop,
+                )
             }
         }
+        ServiceActionDialog(actionState, onDismiss = onDismissAction, onConfirm = onConfirmAction)
     }
 }
 
@@ -118,7 +142,11 @@ private fun ModelsContent(
 private fun ModelsList(
     state: ModelsUiState.Loaded,
     onNewChatFromModel: (String) -> Unit,
+    onOpenDetail: (String) -> Unit,
     onQueryChange: (String) -> Unit,
+    actionState: ServiceActionState,
+    onRequestStart: (String) -> Unit,
+    onRequestStop: (String) -> Unit,
 ) {
     val now = remember { Instant.now() }
     val zone = remember { ZoneId.systemDefault() }
@@ -151,15 +179,89 @@ private fun ModelsList(
         if (running.isNotEmpty()) {
             item(key = "running_header") { SectionHeader("Running", running.size) }
             items(running, key = { "running_${it.name}" }) { service ->
-                ServiceRow(service, now, zone, onNewChatFromModel)
+                ServiceRow(
+                    service, now, zone, onNewChatFromModel, onOpenDetail,
+                    pending = actionState.pendingFor(service.name),
+                    onRequestStart = onRequestStart, onRequestStop = onRequestStop,
+                )
             }
         }
         if (stopped.isNotEmpty()) {
             item(key = "stopped_header") { SectionHeader("Stopped", stopped.size) }
             items(stopped, key = { "stopped_${it.name}" }) { service ->
-                ServiceRow(service, now, zone, onNewChatFromModel = null)
+                ServiceRow(
+                    service, now, zone, onNewChatFromModel = null, onOpenDetail = onOpenDetail,
+                    pending = actionState.pendingFor(service.name),
+                    onRequestStart = onRequestStart, onRequestStop = onRequestStop,
+                )
             }
         }
+    }
+}
+
+/** Whether an action on [name] is mid-flight — the row's pending state
+ * (F10-R5's third criterion). */
+private fun ServiceActionState.pendingFor(name: String): Boolean =
+    this is ServiceActionState.InFlight && serviceName == name
+
+/**
+ * The one confirm surface for both F11-R3 (stop) and F11-R4 (start), reused
+ * verbatim from the row and from the detail screen (F10-R5's second
+ * criterion). Naming the service and, for a stop, warning about in-flight
+ * chats is the entire point of the dialog (F11-R3) — it never blocks the
+ * action, only makes sure the person tapping it knows what it does.
+ */
+@Composable
+fun ServiceActionDialog(
+    actionState: ServiceActionState,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val colors = LlmTheme.colors
+    when (actionState) {
+        is ServiceActionState.Confirming -> androidx.compose.material3.AlertDialog(
+            onDismissRequest = onDismiss,
+            modifier = Modifier.testTag("service_action_confirm"),
+            title = {
+                Text(
+                    if (actionState.action == ServiceAction.STOP) "Stop ${actionState.serviceName}?" else "Start ${actionState.serviceName}?",
+                    color = colors.fg,
+                )
+            },
+            text = {
+                Text(
+                    if (actionState.action == ServiceAction.STOP) {
+                        "Any chat streaming on ${actionState.serviceName} right now will fail."
+                    } else {
+                        // Deliberately does not promise the reason. There is no
+                        // VRAM guard (F11-R5 was dropped), so an oversubscribed
+                        // start really does fail — but all this screen learns is
+                        // the exit code. The actual "cudaMalloc failed: out of
+                        // memory" only exists in the container's log, so saying
+                        // "you'll see the error here" overclaimed.
+                        "This starts the container. If the model doesn't fit in memory it will exit " +
+                            "almost immediately — the status shows the exit code, the reason is in the logs."
+                    },
+                    color = colors.muted,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onConfirm, modifier = Modifier.testTag("service_action_confirm_button")) {
+                    Text(if (actionState.action == ServiceAction.STOP) "Stop" else "Start", color = colors.accent)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) { Text("Cancel", color = colors.muted) }
+            },
+        )
+        is ServiceActionState.Failed -> androidx.compose.material3.AlertDialog(
+            onDismissRequest = onDismiss,
+            modifier = Modifier.testTag("service_action_failed"),
+            title = { Text("Couldn't ${if (actionState.action == ServiceAction.STOP) "stop" else "start"} ${actionState.serviceName}", color = colors.red) },
+            text = { Text(actionState.message, color = colors.muted) },
+            confirmButton = { TextButton(onClick = onDismiss) { Text("OK", color = colors.accent) } },
+        )
+        ServiceActionState.Idle, is ServiceActionState.InFlight -> Unit
     }
 }
 
@@ -295,13 +397,18 @@ private fun ServiceRow(
     now: Instant,
     zone: ZoneId,
     onNewChatFromModel: ((String) -> Unit)?,
+    onOpenDetail: (String) -> Unit,
+    pending: Boolean,
+    onRequestStart: (String) -> Unit,
+    onRequestStop: (String) -> Unit,
 ) {
     val colors = LlmTheme.colors
-    // F10-R5 is deferred to F11: the row body has no click handler at all —
-    // there is no detail screen yet to navigate to.
+    // F11: the row body opens detail; the trailing icon is F10-R5's row
+    // start/stop, sharing the same confirm dialog as the detail screen.
     Row(
         Modifier
             .fillMaxWidth()
+            .clickable(onClick = { onOpenDetail(service.name) })
             .padding(horizontal = 16.dp, vertical = 12.dp)
             .testTag("service_row_${service.name}"),
         verticalAlignment = Alignment.CenterVertically,
@@ -342,6 +449,23 @@ private fun ServiceRow(
                 Text("New chat", color = colors.accent, style = MaterialTheme.typography.labelMedium)
             }
         }
+        if (pending) {
+            CircularProgressIndicator(
+                color = colors.accent,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(20.dp).testTag("service_row_pending_${service.name}"),
+            )
+        } else if (service.isRunning) {
+            TextButton(
+                onClick = { onRequestStop(service.name) },
+                modifier = Modifier.testTag("service_row_stop_${service.name}"),
+            ) { Text("Stop", color = colors.red, style = MaterialTheme.typography.labelMedium) }
+        } else {
+            TextButton(
+                onClick = { onRequestStart(service.name) },
+                modifier = Modifier.testTag("service_row_start_${service.name}"),
+            ) { Text("Start", color = colors.accent, style = MaterialTheme.typography.labelMedium) }
+        }
     }
 }
 
@@ -370,7 +494,7 @@ private fun EngineChip(engine: Engine) {
     }
 }
 
-private fun engineLabel(engine: Engine): String = when (engine) {
+internal fun engineLabel(engine: Engine): String = when (engine) {
     Engine.LLAMA_CPP -> "llama.cpp"
     Engine.VLLM -> "vLLM"
     Engine.DS4 -> "ds4"
@@ -467,9 +591,15 @@ private fun ModelsPopulatedPreview() {
                     listOf(GpuSummary(0, "RTX PRO 6000 Blackwell", memoryUsedMiB = 62873, memoryTotalMiB = 97887, utilizationPercent = 84, temperatureC = 71, powerDrawW = 318.0, powerLimitW = 300.0)),
                 ),
             ),
+            actionState = ServiceActionState.Idle,
             onRetry = {},
             onNewChatFromModel = {},
+            onOpenDetail = {},
             onQueryChange = {},
+            onRequestStart = {},
+            onRequestStop = {},
+            onDismissAction = {},
+            onConfirmAction = {},
         )
     }
 }
@@ -484,9 +614,15 @@ private fun ModelsGpuUnavailablePreview() {
                 stopped = listOf(ServiceSummary("llamacpp-a", "not-created", "chat", port = 3301)),
                 gpu = GpuState.Unavailable("nvidia-smi command failed"),
             ),
+            actionState = ServiceActionState.Idle,
             onRetry = {},
             onNewChatFromModel = {},
+            onOpenDetail = {},
             onQueryChange = {},
+            onRequestStart = {},
+            onRequestStop = {},
+            onDismissAction = {},
+            onConfirmAction = {},
         )
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsViewModel.kt
@@ -102,6 +102,16 @@ class ModelsViewModel(
     private val _state = MutableStateFlow<ModelsUiState>(ModelsUiState.Loading)
     val state: StateFlow<ModelsUiState> = _state.asStateFlow()
 
+    /** F10-R5's row start/stop, sharing its confirm path with the detail
+     * screen's — see [ServiceControlController]'s class doc. */
+    val controller = ServiceControlController(servicesRepository, viewModelScope)
+    val actionState: StateFlow<ServiceActionState> = controller.actionState
+
+    fun requestStart(serviceName: String) = controller.requestStart(serviceName)
+    fun requestStop(serviceName: String) = controller.requestStop(serviceName)
+    fun dismissAction() = controller.dismiss()
+    fun confirmAction() = controller.confirm()
+
     /** One-shot, same guard as [com.hpz.llmdockchat.feature.newchat.NewChatViewModel.load]. */
     private var started = false
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ServiceControlController.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ServiceControlController.kt
@@ -1,0 +1,82 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.data.ServicesRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class ServiceAction { START, STOP }
+
+/**
+ * One confirm-then-act flow, shared by [ModelsViewModel]'s row actions
+ * (F10-R5) and the detail screen's (F11-R3/R4) — both must "go through the
+ * same confirmation path", which is easiest to guarantee by them sharing the
+ * same class rather than two hand-written copies drifting apart.
+ */
+sealed interface ServiceActionState {
+    data object Idle : ServiceActionState
+    data class Confirming(val serviceName: String, val action: ServiceAction) : ServiceActionState
+    data class InFlight(val serviceName: String, val action: ServiceAction) : ServiceActionState
+
+    /** A failed start/stop — F11-R3's "leaves the status as it actually is" and
+     * F11-R4's "shows the server's error": neither pretends success. */
+    data class Failed(val serviceName: String, val action: ServiceAction, val message: String) : ServiceActionState
+}
+
+/**
+ * [scope] is the caller's `viewModelScope` — unlike the SSE streams, a
+ * start/stop POST is a one-shot call and is fine to let ride out a
+ * navigation away exactly like any other in-flight request in this codebase
+ * (e.g. [com.hpz.llmdockchat.feature.thread.ThreadViewModel]'s send).
+ */
+class ServiceControlController(
+    private val servicesRepository: ServicesRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _actionState = MutableStateFlow<ServiceActionState>(ServiceActionState.Idle)
+    val actionState: StateFlow<ServiceActionState> = _actionState.asStateFlow()
+
+    /** Opens the confirm dialog. A no-op while something is already in flight —
+     * F11-R4's third criterion, "cannot be double-fired" — a second tap on a
+     * different row while one is running is refused the same way. */
+    fun requestStart(serviceName: String) = requestConfirm(serviceName, ServiceAction.START)
+
+    fun requestStop(serviceName: String) = requestConfirm(serviceName, ServiceAction.STOP)
+
+    private fun requestConfirm(serviceName: String, action: ServiceAction) {
+        if (_actionState.value is ServiceActionState.InFlight) return
+        _actionState.value = ServiceActionState.Confirming(serviceName, action)
+    }
+
+    /** Back out of the confirm dialog, or dismiss a failure, without acting. */
+    fun dismiss() {
+        if (_actionState.value is ServiceActionState.InFlight) return
+        _actionState.value = ServiceActionState.Idle
+    }
+
+    /** The confirm button. Only fires the request from [ServiceActionState.Confirming] —
+     * called from any other state (already in flight, already idle) it does nothing. */
+    fun confirm() {
+        val pending = _actionState.value as? ServiceActionState.Confirming ?: return
+        _actionState.value = ServiceActionState.InFlight(pending.serviceName, pending.action)
+        scope.launch {
+            val result = when (pending.action) {
+                ServiceAction.START -> servicesRepository.start(pending.serviceName)
+                ServiceAction.STOP -> servicesRepository.stop(pending.serviceName)
+            }
+            _actionState.value = result.fold(
+                onSuccess = { ServiceActionState.Idle },
+                onFailure = { ServiceActionState.Failed(pending.serviceName, pending.action, it.appError.displayMessage) },
+            )
+        }
+    }
+
+    /** Whether [serviceName] specifically is mid-request — what a row/button
+     * checks to show its own pending state (F10-R5's third criterion). */
+    fun isInFlight(serviceName: String): Boolean =
+        (_actionState.value as? ServiceActionState.InFlight)?.serviceName == serviceName
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -30,6 +30,8 @@ import com.hpz.llmdockchat.feature.connect.ConnectScreen
 import com.hpz.llmdockchat.feature.connect.ConnectViewModel
 import com.hpz.llmdockchat.feature.conversations.ConversationListScreen
 import com.hpz.llmdockchat.feature.conversations.ConversationListViewModel
+import com.hpz.llmdockchat.feature.models.ModelDetailScreen
+import com.hpz.llmdockchat.feature.models.ModelDetailViewModel
 import com.hpz.llmdockchat.feature.models.ModelsScreen
 import com.hpz.llmdockchat.feature.models.ModelsViewModel
 import com.hpz.llmdockchat.feature.newchat.NewChatScreen
@@ -127,9 +129,32 @@ fun AppNavHost(
                         onNewChatFromModel = { serviceName ->
                             navController.navigate(Destinations.newChatWithService(serviceName))
                         },
+                        onOpenDetail = { serviceName ->
+                            navController.navigate(Destinations.modelDetail(serviceName))
+                        },
                     )
                 }
             }
+        }
+
+        composable(Destinations.MODEL_DETAIL) { backStackEntry ->
+            val serviceName = backStackEntry.arguments?.getString("serviceName").orEmpty()
+            val viewModel: ModelDetailViewModel = viewModel(
+                // Keyed by service so opening a second model's detail from the
+                // first (via Back then a different row) never shares state,
+                // same reasoning as THREAD's key.
+                key = "model_detail_$serviceName",
+                factory = viewModelFactory {
+                    initializer {
+                        ModelDetailViewModel(
+                            serviceName = serviceName,
+                            servicesRepository = container.servicesRepository,
+                            servicesStreamRepository = container.servicesStreamRepository,
+                        )
+                    }
+                },
+            )
+            ModelDetailScreen(viewModel = viewModel, onBack = { navController.popBackStack() })
         }
 
         composable(Destinations.THREAD) { backStackEntry ->

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
@@ -20,6 +20,11 @@ object Destinations {
     const val THREAD = "$THREAD_ROUTE/{conversationId}"
     fun thread(conversationId: String) = "$THREAD_ROUTE/$conversationId"
 
+    /** F11 — pushed on top of [TABS] without the bottom bar, same as [THREAD]. */
+    private const val MODEL_DETAIL_ROUTE = "model_detail"
+    const val MODEL_DETAIL = "$MODEL_DETAIL_ROUTE/{serviceName}"
+    fun modelDetail(serviceName: String) = "$MODEL_DETAIL_ROUTE/$serviceName"
+
     /**
      * F02-R8's primary action, built out in F03. [NEW_CHAT] is the route
      * *pattern* registered with `composable(...)` — it must be the string

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesRepositoryTest.kt
@@ -1,0 +1,115 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/** F11-R2's detail fetch and F11-R3/R4's start/stop calls. */
+class ServicesRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var repository: ServicesRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(
+            (BaseUrl.normalize(server.url("/").toString()) as BaseUrlResult.Valid).baseUrl,
+        )
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        repository = ServicesRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    @Test
+    fun `detail decodes the config and renders params as flag-value pairs`() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder().body(
+                """{"service_name": "llamacpp-a", "config": {"model_path": "/models/a.gguf",
+                    "params": {"-ngl": "99", "--enable-x": ""}, "template_type": "llamacpp",
+                    "model_size_str": "26.1 GB", "api_key": "secret"}}""",
+            ).build(),
+        )
+
+        val config = repository.detail("llamacpp-a").getOrThrow()
+
+        assertEquals("/models/a.gguf", config?.modelPath)
+        assertEquals("llamacpp", config?.templateType)
+        assertEquals("26.1 GB", config?.modelSizeStr)
+        assertEquals(setOf("-ngl" to "99", "--enable-x" to ""), config?.flags?.toSet())
+        val request = server.takeRequest()
+        assertEquals("/api/services/llamacpp-a", request.url.encodedPath)
+        assertEquals("GET", request.method)
+    }
+
+    /**
+     * Bug-shaped: a `detail` that treats every non-2xx the same way would
+     * surface this 404 as a generic failure, which is exactly what F11-R2's
+     * fourth criterion says the detail screen must not show as an error.
+     * This asserts the 404 comes back `Result.success(null)`, not a failure.
+     */
+    @Test
+    fun `a 404 from detail is success with a null config, not a failure`() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(404).body("""{"error": "not found"}""").build())
+
+        val result = repository.detail("ghost-service")
+
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrThrow())
+    }
+
+    @Test
+    fun `a non-404 failure from detail is a real failure`() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(500).body("""{"error": "Docker socket unavailable"}""").build())
+
+        val result = repository.detail("llamacpp-a")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `start posts to the start endpoint`() = runBlocking {
+        server.enqueue(MockResponse.Builder().body("""{"success": true}""").build())
+
+        val result = repository.start("llamacpp-a")
+
+        assertTrue(result.isSuccess)
+        val request = server.takeRequest()
+        assertEquals("/api/services/llamacpp-a/start", request.url.encodedPath)
+        assertEquals("POST", request.method)
+    }
+
+    @Test
+    fun `stop posts to the stop endpoint and surfaces a server failure message`() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(400).body("""{"error": "Container already stopped"}""").build())
+
+        val result = repository.stop("llamacpp-a")
+
+        assertTrue(result.isFailure)
+        val request = server.takeRequest()
+        assertEquals("/api/services/llamacpp-a/stop", request.url.encodedPath)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelDetailViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelDetailViewModelTest.kt
@@ -1,0 +1,185 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.ServicesStreamRepository
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.MainDispatcherRule
+import com.hpz.llmdockchat.testing.ScriptedSseTransport
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * F11-R1 (live status tracking a service that stops while the screen is
+ * open) and F11-R2's fourth criterion (a 404 on the config fetch is a
+ * partial view, not [ModelDetailUiState.Failed]).
+ */
+class ModelDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    private lateinit var server: MockWebServer
+    private lateinit var servicesRepository: ServicesRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(
+            (BaseUrl.normalize(server.url("/").toString()) as BaseUrlResult.Valid).baseUrl,
+        )
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        servicesRepository = ServicesRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun viewModel(transport: ScriptedSseTransport = ScriptedSseTransport()) = ModelDetailViewModel(
+        serviceName = "llamacpp-a",
+        servicesRepository = servicesRepository,
+        servicesStreamRepository = ServicesStreamRepository(transport),
+    )
+
+    private fun settled(viewModel: ModelDetailViewModel): ModelDetailUiState = runBlocking {
+        withTimeout(10_000) { viewModel.state.first { it !is ModelDetailUiState.Loading } }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun ModelDetailViewModel.startStreamLikeTheScreenWould() {
+        GlobalScope.launch(Dispatchers.Main) { observeServicesStream().collect { applyLiveSummary(it) } }
+    }
+
+    private val serviceListBody = """
+        {"services": [{"name": "llamacpp-a", "status": "running", "kind": "chat", "host_port": 3301, "favorite": false}],
+         "total": 1, "running": 1, "stopped": 0}
+    """.trimIndent()
+
+    private val configBody = """
+        {"service_name": "llamacpp-a", "config": {"model_path": "/models/a.gguf", "params": {"-ngl": "99", "-fa": "1"},
+         "template_type": "llamacpp", "model_size_str": "26.1 GB", "api_key": "should-never-appear"}}
+    """.trimIndent()
+
+    @Test
+    fun `loads the live summary and the config together`() {
+        server.enqueue(MockResponse.Builder().body(serviceListBody).build())
+        server.enqueue(MockResponse.Builder().body(configBody).build())
+
+        val vm = viewModel()
+        vm.start()
+        val state = settled(vm) as ModelDetailUiState.Loaded
+
+        assertEquals("llamacpp-a", state.summary.name)
+        assertTrue(state.summary.isRunning)
+        assertEquals(false, state.configMissing)
+        assertEquals("/models/a.gguf", state.config?.modelPath)
+        assertEquals(listOf("-ngl" to "99", "-fa" to "1"), state.config?.flags)
+    }
+
+    /** F11-R2: "api_key does not appear" — the mapper must never read it off
+     * the wire in the first place, so there is no field on [state.config] to
+     * assert is null; this proves the DTO's absence didn't just get lucky. */
+    @Test
+    fun `the config never carries an api key field to expose`() {
+        server.enqueue(MockResponse.Builder().body(serviceListBody).build())
+        server.enqueue(MockResponse.Builder().body(configBody).build())
+
+        val vm = viewModel()
+        vm.start()
+        val state = settled(vm) as ModelDetailUiState.Loaded
+
+        val fields = state.config!!.javaClass.declaredFields.map { it.name }
+        assertTrue(fields.none { it.contains("api", ignoreCase = true) })
+    }
+
+    /**
+     * Bug-shaped: a detail screen that treats any config-fetch failure as
+     * fatal would show [ModelDetailUiState.Failed] for a container Docker
+     * knows about but `services.json` doesn't — exactly the case F11-R2's
+     * fourth criterion calls out as needing a graceful partial view. Confirms
+     * the naive shape (any non-2xx -> Failed) is wrong by checking [Loaded]
+     * comes back with [configMissing] set, not [Failed].
+     */
+    @Test
+    fun `a 404 on the config fetch is a graceful partial view, not a Failed screen`() {
+        server.enqueue(MockResponse.Builder().body(serviceListBody).build())
+        server.enqueue(MockResponse.Builder().code(404).body("""{"error": "Service \"llamacpp-a\" not found"}""").build())
+
+        val vm = viewModel()
+        vm.start()
+        val state = settled(vm)
+
+        assertTrue(state is ModelDetailUiState.Loaded)
+        val loaded = state as ModelDetailUiState.Loaded
+        assertEquals(true, loaded.configMissing)
+        assertEquals(null, loaded.config)
+        assertEquals("llamacpp-a", loaded.summary.name)
+    }
+
+    @Test
+    fun `a service absent from the list entirely is Failed, not a blank detail screen`() {
+        server.enqueue(MockResponse.Builder().body("""{"services": [], "total": 0, "running": 0, "stopped": 0}""").build())
+
+        val vm = viewModel()
+        vm.start()
+        val state = settled(vm)
+
+        assertTrue(state is ModelDetailUiState.Failed)
+    }
+
+    /** F11-R1's first two criteria: status tracks the live stream, including a
+     * stop that happens while the screen is already open. */
+    @Test
+    fun `a status change on the live stream updates the open detail screen in place`() {
+        server.enqueue(MockResponse.Builder().body(serviceListBody).build())
+        server.enqueue(MockResponse.Builder().body(configBody).build())
+        val transport = ScriptedSseTransport()
+        transport.script(
+            ScriptedSseTransport.Leg(
+                payloads = listOf(
+                    """{"type":"snapshot","data":{"services":[
+                        {"name":"llamacpp-a","status":"running","kind":"chat","host_port":3301,"favorite":false}
+                    ],"total":1,"running":1,"stopped":0}}""",
+                    """{"type":"delta","service_name":"llamacpp-a","status":"exited"}""",
+                ),
+                park = true,
+            ),
+        )
+        val vm = viewModel(transport)
+        vm.start()
+        settled(vm)
+        vm.startStreamLikeTheScreenWould()
+
+        val stopped = runBlocking {
+            withTimeout(10_000) {
+                vm.state.first { it is ModelDetailUiState.Loaded && it.summary.isExited }
+            }
+        } as ModelDetailUiState.Loaded
+        assertEquals("exited", stopped.summary.status)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ModelsViewModelTest.kt
@@ -94,7 +94,7 @@ class ModelsViewModelTest {
     }
 
     @Test
-    fun `running services are grouped first, stopped second, each in the payload's host-port order`() {
+    fun `running first, stopped second, favourites first within each, host-port order otherwise`() {
         server.enqueue(MockResponse.Builder().body(readFixture("services_list.json")).build())
         val viewModel = viewModel()
 
@@ -102,11 +102,33 @@ class ModelsViewModelTest {
         val state = settled(viewModel) as ModelsUiState.Loaded
 
         // Fixture: open-webui (3300) and llamacpp-gemma-4-26b-a4b-it-q8 (3301)
-        // are the only two "running" rows; everything else is exited/not-created.
-        assertEquals(listOf("open-webui", "llamacpp-gemma-4-26b-a4b-it-q8"), state.running.map { it.name })
+        // are the only two "running" rows; everything else is exited or
+        // not-created. gemma is `favorite: true` and open-webui is not, so
+        // gemma leads despite the higher port — favourites-first wins over
+        // host-port order, and host-port order is only the tiebreak.
+        assertEquals(listOf("llamacpp-gemma-4-26b-a4b-it-q8", "open-webui"), state.running.map { it.name })
         assertEquals(19, state.stopped.size)
-        assertEquals("vllm-qwen3-6-27b-fp8", state.stopped.first().name) // host_port 3302, first stopped row
         assertEquals(false, state.stale)
+    }
+
+    @Test
+    fun `host-port order still holds between rows of equal favourite-ness`() {
+        server.enqueue(MockResponse.Builder().body(readFixture("services_list.json")).build())
+        val viewModel = viewModel()
+
+        viewModel.start()
+        val state = settled(viewModel) as ModelsUiState.Loaded
+
+        // The sort is `sortedByDescending { favorite }`, which is *stable* —
+        // that stability is the whole reason a service changing status does
+        // not shuffle its neighbours (F10-R2's second criterion). Assert it
+        // rather than trust the name: within each favourite-ness band the
+        // server's own host_port order must survive.
+        listOf(state.running, state.stopped).forEach { group ->
+            group.groupBy { it.favorite }.values.forEach { band ->
+                assertEquals(band.map { it.port }.sorted(), band.map { it.port })
+            }
+        }
     }
 
     @Test

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ServiceControlControllerTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/models/ServiceControlControllerTest.kt
@@ -1,0 +1,163 @@
+package com.hpz.llmdockchat.feature.models
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.MainDispatcherRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * F11-R3/R4/F10-R5's confirm-then-act flow: naming the service, one at a
+ * time, surfacing a failure without pretending success. Uses a real
+ * [MockWebServer] round trip (like [com.hpz.llmdockchat.feature.models.ModelsViewModelTest]) rather than
+ * a fake repository, so a bug in [ServicesRepository]'s own start/stop
+ * wiring would show up here too.
+ */
+class ServiceControlControllerTest {
+
+    // Main is set unconfined (F11-R4's own reasoning, MainDispatcherRule's
+    // doc): `scope.launch { ... }` in ServiceControlController runs eagerly
+    // up to its first real suspension, which is the `withContext(Dispatchers.IO)`
+    // inside ApiClient — a genuine dispatcher hop, not a race. So the state
+    // is already `InFlight` the instant `confirm()` returns, deterministically.
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    private lateinit var server: MockWebServer
+    private lateinit var repository: ServicesRepository
+    private lateinit var scope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(
+            (BaseUrl.normalize(server.url("/").toString()) as BaseUrlResult.Valid).baseUrl,
+        )
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        repository = ServicesRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+        scope = CoroutineScope(Dispatchers.Main + Job())
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        server.close()
+    }
+
+    private fun settled(controller: ServiceControlController) = runBlocking {
+        withTimeout(10_000) { controller.actionState.first { it !is ServiceActionState.InFlight } }
+    }
+
+    /**
+     * Bug-shaped: a naive controller that calls the repository straight from
+     * `requestStop` (no confirm step at all) would stop the container the
+     * instant the row's Stop button is tapped — exactly what F11-R3 forbids.
+     * This asserts the state stays `Confirming` and nothing hit the wire.
+     */
+    @Test
+    fun `requesting stop only opens the confirm dialog, it does not call stop yet`() {
+        val controller = ServiceControlController(repository, scope)
+
+        controller.requestStop("llamacpp-a")
+
+        assertEquals(ServiceActionState.Confirming("llamacpp-a", ServiceAction.STOP), controller.actionState.value)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `confirming sends the stop request and returns to idle on success`() {
+        server.enqueue(MockResponse.Builder().body("""{"success": true}""").build())
+        val controller = ServiceControlController(repository, scope)
+        controller.requestStop("llamacpp-a")
+
+        controller.confirm()
+        val state = settled(controller)
+
+        assertEquals(ServiceActionState.Idle, state)
+        val request = server.takeRequest()
+        assertEquals("/api/services/llamacpp-a/stop", request.url.encodedPath)
+        assertEquals("POST", request.method)
+    }
+
+    @Test
+    fun `a failed start surfaces the server's error and does not claim success`() {
+        server.enqueue(MockResponse.Builder().code(400).body("""{"error": "CUDA out of memory"}""").build())
+        val controller = ServiceControlController(repository, scope)
+        controller.requestStart("vllm-big")
+
+        controller.confirm()
+        val state = settled(controller)
+
+        assertTrue(state is ServiceActionState.Failed)
+        assertEquals("CUDA out of memory", (state as ServiceActionState.Failed).message)
+        assertEquals(ServiceAction.START, state.action)
+    }
+
+    /**
+     * F11-R4's third criterion: "cannot be double-fired". `confirm()` runs
+     * eagerly up to the real dispatcher hop (see the class doc), so by the
+     * time it returns the service is genuinely mid-request — a second
+     * `requestStart` right then must be refused, not queued for after.
+     */
+    @Test
+    fun `a second request is refused while one is already in flight`() {
+        server.enqueue(MockResponse.Builder().body("""{"success": true}""").build())
+        val controller = ServiceControlController(repository, scope)
+        controller.requestStop("llamacpp-a")
+        controller.confirm()
+
+        assertEquals(ServiceActionState.InFlight("llamacpp-a", ServiceAction.STOP), controller.actionState.value)
+        controller.requestStart("llamacpp-b")
+        assertEquals(ServiceActionState.InFlight("llamacpp-a", ServiceAction.STOP), controller.actionState.value)
+
+        settled(controller) // drain, so the server socket isn't left mid-response for tearDown
+    }
+
+    @Test
+    fun `dismiss returns to idle without ever calling the server`() {
+        val controller = ServiceControlController(repository, scope)
+        controller.requestStart("llamacpp-a")
+
+        controller.dismiss()
+
+        assertEquals(ServiceActionState.Idle, controller.actionState.value)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `isInFlight is true only for the service actually being acted on`() {
+        server.enqueue(MockResponse.Builder().body("""{"success": true}""").build())
+        val controller = ServiceControlController(repository, scope)
+        controller.requestStop("llamacpp-a")
+
+        controller.confirm()
+
+        assertTrue(controller.isInFlight("llamacpp-a"))
+        assertTrue(!controller.isInFlight("llamacpp-b"))
+        settled(controller)
+    }
+}


### PR DESCRIPTION
The first feature that changes state on the rig — plus **F10-R5 carried forward**: start and stop from a row without opening detail.

## One confirm path, structurally

`ServiceControlController` is a single sealed state machine (Idle / Confirming / InFlight / Failed). Both `ModelsViewModel` (row actions) and `ModelDetailViewModel` hold an instance and only ever call `requestStart` / `requestStop` / `confirm` / `dismiss`. The repository's `start`/`stop` are reachable from **exactly one place**, inside `confirm()`.

That makes F10-R5's "both go through the same confirmation path" a property of the code rather than something a reviewer happened to observe. `InFlight` refuses a second request, and the test asserts the state is unchanged — not that a button looked disabled.

The stop confirm names the service and says any chat streaming on it will fail, because it will.

## Dropping the VRAM guard, exercised for real

F11-R5 was dropped at the owner's request (*"let it fail if it fails, I'll see it in the logs"*), so an oversubscribed start now fails at the container. With the GPU at 94.1 / 95.6 GB, starting `llamacpp-gemma-4-26b-a4b-it-q8` (27 GB) exited in ~0.6 s with code 139 — a genuine `cudaMalloc failed: out of memory`. Reproduced independently in review.

**The app never claimed "running".** It went straight to "Exited (code 139)" live, no manual refresh.

**Corrected the start confirm's wording**, which promised *"you'll see the error here"*. It will not — the screen only ever learns the exit code; the reason lives in the container log. That split is exactly what dropping the guard assumed, so the copy now says so.

## A layout bug JVM tests cannot catch, twice now

The detail rows gave the **label** `weight(1f)` and the value none, so a long `model_path` wrapped one character per line. Same failure mode as F10's GPU card. Both were found only by opening the screen against real data.

## Also fixes a test I broke

Adding favourites-first to F10's list invalidated its host-port ordering assertion, and I merged F10 without re-running the suite. Replaced with two tests: favourites lead, **and** host-port order still holds *within* each favourite band — that stability is what stops rows shuffling when a service changes status (F10-R2).

## Scope

- **Built:** R1, R2, R3, R4, R8 (Must) + F10-R5.
- **Skipped:** R6 restart (Should, deprioritised — a clean extension of the same controller).
- **Deferred:** R7 readiness (Should) to **F12**, which builds the log stream it needs.
- **Dropped:** R5 VRAM guard and screen 10d.

431 tests pass. Rig restored: laguna and open-webui running as before; gemma's exit code moved 0 → 139 from the deliberate OOM tests. Every action went through the app's confirm → start/stop, never `docker` directly.