### PR TITLE
F12: container logs

### DIFF
--- a/android/docs/F12-container-logs.md
+++ b/android/docs/F12-container-logs.md
@@ -102,3 +102,53 @@ None.
 - Log retention or export to a file.
 - Logs for anything but a compose-managed service (the endpoint refuses
   names outside the project).
+
+## Verification notes
+
+Both Must requirements verified live against the rig; the review
+reproduced the findings independently rather than trusting them.
+
+**`stream_end` is an end state, not a failure — verified by breaking it
+first.** The reviewer patched the `StreamEnd` branch to route to `Failed`
+and watched `LogsViewModelTest` fail at line 112, then reverted. Then
+proved it live: opened logs on a running container and stopped it mid-
+stream. The status flipped from green "Live" to grey "Stream ended —
+container stopped", with the container's own `cleaning up before exit…`
+as the final line. Not an error screen.
+
+This is the criterion that mattered most: a stopped container ends its
+log stream normally, so getting it wrong would make the feature look
+broken every single time the owner stops a model.
+
+**Teardown, independently confirmed.** `ss -tnp` filtered on
+`qemu-system-x86` (where the emulator's host-side sockets live) showed
+the exact stream socket `127.0.0.1:57060 → 127.0.0.1:3399`; it was gone
+within ~1 s of pressing back. This requirement has now been got wrong
+twice on this project — F07, and a real bug in F10 where
+`viewModelScope`-launched streams survived a tab switch — so it is
+verified by socket, never by inspection.
+
+**No reconnect loop, deliberately.** Unlike the GPU and services stream
+repositories, `LogsStreamRepository` does not retry. A `stream_end` is a
+normal outcome, and auto-reconnecting into a genuinely dead stream is
+worse than not. A real network drop instead surfaces as `Failed` with a
+manual Retry, so the user is never stuck — one tap reconnects. Reviewed
+and agreed rather than assumed.
+
+**Follow-tail did not inherit F04's sharp edge.** `ThreadScreen`'s
+pattern misbehaves in a list too short to scroll, where `canScrollForward`
+stays false and following flips back on. Here that is the correct
+behaviour: if the whole buffer fits on screen there is nothing to scroll
+away from, so there is no disagreement to honour.
+
+**Not verified:** keepalive behaviour on a quiet container (accepted on
+code read — SSE comments are already dropped by `SseFrameParser` and
+covered by its tests), and R4's level colouring on screen, since no
+container produced a real ERROR line during review. R4 is Should and its
+classification logic is unit-tested.
+
+**F11-R7 (readiness) was not picked up here**, and the review agreed with
+that call. Wiring "up but not ready" into the picker touches
+`NewChatViewModel`'s selection logic and its own state machine — a
+different screen's concern, not a small addition just because a log
+client now exists. It stays a documented skip.

--- a/android/docs/Plan_TOC.md
+++ b/android/docs/Plan_TOC.md
@@ -185,7 +185,7 @@ Mark completed features `[DONE]` in the Status column.
 | F09 | Run continuity and reattachment | [F09-run-continuity.md](F09-run-continuity.md) | 08a, 08b | [DONE] — R5's failed-while-away is fixture-only, see the feature file |
 | F10 | Models tab — list and GPU header | [F10-models-list.md](F10-models-list.md) | 10a | [DONE] — R5 carried forward to F11 |
 | F11 | Model detail, start and stop | [F11-model-detail-and-control.md](F11-model-detail-and-control.md) | 10b | [DONE] — R6 skipped, R7 deferred to F12, R5 dropped |
-| F12 | Container logs | [F12-container-logs.md](F12-container-logs.md) | 10c | [ ] |
+| F12 | Container logs | [F12-container-logs.md](F12-container-logs.md) | 10c | [DONE] — F11-R7 stays skipped, see the feature file |
 | F13 | Settings | [F13-settings.md](F13-settings.md) | 09 | [ ] |
 | — | Dropped and deferred features | [Dropped-Features.md](Dropped-Features.md) | — | n/a |
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/AppContainer.kt
@@ -32,6 +32,7 @@ import com.hpz.llmdockchat.core.prefs.NewChatPreferences
 import com.hpz.llmdockchat.data.ChatRepository
 import com.hpz.llmdockchat.data.ConversationsRepository
 import com.hpz.llmdockchat.data.GpuStreamRepository
+import com.hpz.llmdockchat.data.LogsStreamRepository
 import com.hpz.llmdockchat.data.HealthRepository
 import com.hpz.llmdockchat.data.McpServersRepository
 import com.hpz.llmdockchat.data.OpenRouterModelsRepository
@@ -114,6 +115,7 @@ class AppContainer(
     val servicesRepository = ServicesRepository(apiClient)
     val servicesStreamRepository = ServicesStreamRepository(sseTransport)
     val gpuStreamRepository = GpuStreamRepository(sseTransport)
+    val logsStreamRepository = LogsStreamRepository(sseTransport)
     val promptsRepository = PromptsRepository(apiClient)
     val mcpServersRepository = McpServersRepository(apiClient)
     val openRouterModelsRepository = OpenRouterModelsRepository(apiClient)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/Endpoints.kt
@@ -46,6 +46,12 @@ object Endpoints {
     /** F10-R3's GPU header — one `data:` frame per tick, no `type` envelope. */
     const val GPU_STREAM = "/api/gpu/stream"
 
+    /** F12-R1 — typed SSE frames (`snapshot_start`/`log`/`snapshot_end`/`stream_end`/`error`). */
+    fun serviceLogsStream(name: String): String = "${serviceDetail(name)}/logs/stream"
+
+    /** F12-R3 — the one-shot fallback JSON blob, used when the stream cannot be established. */
+    fun serviceLogs(name: String): String = "${serviceDetail(name)}/logs"
+
     /** Read-only from the phone (F03) — editing the curated list is desktop Tools-page work. */
     const val OPENROUTER_MODELS_SETTINGS = "/api/chat/settings/openrouter-models"
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/LogStreamEvent.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/core/net/LogStreamEvent.kt
@@ -1,0 +1,51 @@
+package com.hpz.llmdockchat.core.net
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * One typed frame from `GET /api/services/<name>/logs/stream` (F12-R1). The
+ * `: keepalive` comment frame never reaches here — [SseFrameParser] drops any
+ * line starting with `:` before a payload is ever assembled.
+ *
+ * Pure and total, same contract as [parseServiceStreamFrame] and
+ * [parseGpuStreamFrame]: nothing here ever throws.
+ */
+sealed interface LogStreamEvent {
+    /** The historical tail is about to start. */
+    data object SnapshotStart : LogStreamEvent
+
+    /** One log line, verbatim — never reordered, never truncated (F12-R4's third criterion). */
+    data class Log(val line: String) : LogStreamEvent
+
+    /** The tail is done; anything after this is live output (F12-R1's second criterion). */
+    data object SnapshotEnd : LogStreamEvent
+
+    /** The container's log stream ended — an end state, not a failure (F12-R1's fourth criterion). */
+    data object StreamEnd : LogStreamEvent
+
+    data class Error(val message: String) : LogStreamEvent
+
+    /** An unrecognised `type`, or a payload that is not JSON at all. */
+    data class Unknown(val raw: String) : LogStreamEvent
+}
+
+private val LogStreamJson = Json { ignoreUnknownKeys = true }
+
+fun parseLogStreamFrame(payload: String): LogStreamEvent {
+    val root = runCatching { LogStreamJson.parseToJsonElement(payload.trim()) }.getOrNull() as? JsonObject
+        ?: return LogStreamEvent.Unknown(payload)
+
+    return when (root.stringField("type")) {
+        "snapshot_start" -> LogStreamEvent.SnapshotStart
+        "log" -> root.stringField("line")?.let { LogStreamEvent.Log(it) } ?: LogStreamEvent.Unknown(payload)
+        "snapshot_end" -> LogStreamEvent.SnapshotEnd
+        "stream_end" -> LogStreamEvent.StreamEnd
+        "error" -> LogStreamEvent.Error(root.stringField("message") ?: "Unknown error")
+        else -> LogStreamEvent.Unknown(payload)
+    }
+}
+
+private fun JsonObject.stringField(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/LogsStreamRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/LogsStreamRepository.kt
@@ -1,0 +1,33 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.Endpoints
+import com.hpz.llmdockchat.core.net.LogStreamEvent
+import com.hpz.llmdockchat.core.net.SseTransport
+import com.hpz.llmdockchat.core.net.StreamRequest
+import com.hpz.llmdockchat.core.net.parseLogStreamFrame
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * The live `GET /api/services/<name>/logs/stream` (F12-R1).
+ *
+ * Deliberately unlike [GpuStreamRepository] and [ServicesStreamRepository]:
+ * this does **not** loop and reconnect on its own. A container's log stream
+ * ending (`stream_end`) is a normal outcome — the container was stopped — and
+ * reconnecting into it would just open the same finished stream again. A
+ * genuine connection drop instead completes the flow with an exception, which
+ * [com.hpz.llmdockchat.feature.logs.LogsViewModel] turns into a visible error
+ * rather than silently retrying, so the screen's "live"/"ended" state always
+ * reflects what actually happened.
+ */
+class LogsStreamRepository(private val transport: SseTransport) {
+
+    fun stream(serviceName: String, tail: Int = DEFAULT_TAIL): Flow<LogStreamEvent> =
+        transport.open(
+            StreamRequest(path = Endpoints.serviceLogsStream(serviceName), query = mapOf("tail" to tail.toString())),
+        ).map { parseLogStreamFrame(it) }
+
+    companion object {
+        const val DEFAULT_TAIL = 200
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesRepository.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/ServicesRepository.kt
@@ -9,6 +9,7 @@ import com.hpz.llmdockchat.core.net.apiCall
 import com.hpz.llmdockchat.data.dto.ServiceActionResponseDto
 import com.hpz.llmdockchat.data.dto.ServiceDetailResponseDto
 import com.hpz.llmdockchat.data.dto.ServiceListResponseDto
+import com.hpz.llmdockchat.data.dto.ServiceLogsResponseDto
 import com.hpz.llmdockchat.data.mapper.toDomain
 import com.hpz.llmdockchat.data.model.ServiceConfig
 import com.hpz.llmdockchat.data.model.ServiceSummary
@@ -55,5 +56,18 @@ class ServicesRepository(private val api: ApiClient) {
     suspend fun stop(name: String): Result<Unit> = apiCall {
         api.request(method = "POST", path = Endpoints.serviceStop(name), deserializer = ServiceActionResponseDto.serializer())
         Unit
+    }
+
+    /**
+     * `GET /api/services/<name>/logs` (F12-R3) — the one-shot fallback, used
+     * when the stream cannot be established. Lines are split client-side on
+     * `\n` rather than trusting the server's own `lines` count.
+     */
+    suspend fun fetchLogsOnce(name: String, tail: Int = 200): Result<List<String>> = apiCall {
+        api.get(
+            Endpoints.serviceLogs(name),
+            ServiceLogsResponseDto.serializer(),
+            query = mapOf("tail" to tail.toString()),
+        ).logs.split("\n")
     }
 }

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/dto/ServiceDto.kt
@@ -55,3 +55,15 @@ data class ServiceDetailResponseDto(
  * is read — a failure surfaces as a non-2xx, handled by [com.hpz.llmdockchat.core.net.ApiClient] before this ever decodes. */
 @Serializable
 data class ServiceActionResponseDto(val success: Boolean = true)
+
+/** `GET /api/services/<name>/logs` (F12-R3) — the one-shot fallback blob, used
+ * when the stream cannot be established. [logs] is the raw tail, timestamped,
+ * newline-separated; this client splits it client-side rather than trusting
+ * [lines], which counts entries the server split on its own newline. */
+@Serializable
+data class ServiceLogsResponseDto(
+    val service: String = "",
+    val logs: String = "",
+    val lines: Int = 0,
+    val timestamp: String = "",
+)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/LogLevel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/data/model/LogLevel.kt
@@ -1,0 +1,23 @@
+package com.hpz.llmdockchat.data.model
+
+/** Level colouring is derived, best-effort — [PLAIN] is the safe default for anything unrecognised. */
+enum class LogLevel { ERROR, WARN, INFO, PLAIN }
+
+/**
+ * F12-R4: colour by level where the line makes it derivable. This is pattern
+ * matching over unstructured container output, not a log parser — it must
+ * never throw, never touch the line's text, and degrade to [LogLevel.PLAIN]
+ * for anything it doesn't recognise (F12-R4's second criterion). Checked in
+ * priority order so a line mentioning both, e.g. "WARN: retrying after ERROR",
+ * reads as the more severe of the two.
+ */
+fun classifyLogLevel(line: String): LogLevel = when {
+    ERROR_PATTERN.containsMatchIn(line) -> LogLevel.ERROR
+    WARN_PATTERN.containsMatchIn(line) -> LogLevel.WARN
+    INFO_PATTERN.containsMatchIn(line) -> LogLevel.INFO
+    else -> LogLevel.PLAIN
+}
+
+private val ERROR_PATTERN = Regex("\\b(ERROR|CRITICAL|FATAL|EXCEPTION|TRACEBACK)\\b", RegexOption.IGNORE_CASE)
+private val WARN_PATTERN = Regex("\\bWARN(ING)?\\b", RegexOption.IGNORE_CASE)
+private val INFO_PATTERN = Regex("\\bINFO\\b", RegexOption.IGNORE_CASE)

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/logs/LogsScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/logs/LogsScreen.kt
@@ -1,0 +1,297 @@
+package com.hpz.llmdockchat.feature.logs
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hpz.llmdockchat.core.ui.theme.LlmColors
+import com.hpz.llmdockchat.core.ui.theme.LlmTheme
+import com.hpz.llmdockchat.data.model.LogLevel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+/** Sharing a buffer this large (F12-R5's second criterion) truncates with an explicit marker instead. */
+private const val MAX_SHARE_CHARS = 200_000
+private const val TRUNCATION_MARKER = "[... earlier lines truncated ...]\n"
+
+/**
+ * F12: streaming container logs, follow-tail, and share (screens 10c).
+ *
+ * The stream is collected from this composition, not from the ViewModel's own
+ * scope — see [LogsViewModel]'s class doc. [retryToken] is bumped to restart
+ * the `LaunchedEffect` after a failure or a `stream_end`, the same "key
+ * changes, effect restarts" idiom used everywhere else in this app for a
+ * stream that should reconnect on demand rather than automatically.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogsScreen(
+    viewModel: LogsViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    var retryToken by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(retryToken) {
+        try {
+            viewModel.observeLogStream().collect { viewModel.onStreamEvent(it) }
+            viewModel.onStreamCompleted()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            viewModel.onStreamFailed(e)
+        }
+    }
+
+    val colors = LlmTheme.colors
+    Scaffold(
+        modifier = modifier.testTag("logs_screen"),
+        containerColor = colors.app,
+        topBar = {
+            TopAppBar(
+                title = { Text("Logs", color = colors.fg) },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("logs_back")) {
+                        Text("←", color = colors.fg)
+                    }
+                },
+                actions = {
+                    val loaded = state as? LogsUiState.Loaded
+                    if (loaded != null && loaded.lines.isNotEmpty()) {
+                        IconButton(
+                            onClick = { shareLogs(context, loaded.lines) },
+                            modifier = Modifier.testTag("logs_share"),
+                        ) {
+                            Text("⇪", color = colors.fg)
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colors.app),
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when (val current = state) {
+                is LogsUiState.Loading -> LoadingBox()
+                is LogsUiState.NotCreated -> MessageBox(
+                    testTag = "logs_not_created",
+                    title = "No container yet",
+                    message = current.message,
+                )
+                is LogsUiState.Failed -> MessageBox(
+                    testTag = "logs_failed",
+                    title = "Couldn't load logs",
+                    message = current.message,
+                    onRetry = { retryToken++ },
+                )
+                is LogsUiState.Loaded -> LoadedLogs(current)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedLogs(state: LogsUiState.Loaded) {
+    val colors = LlmTheme.colors
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    // Same "mode, not a measurement" following logic as ThreadScreen's F04-R3
+    // (see its class doc) — a short buffer that never overflows the viewport
+    // keeps `atBottom` true throughout, which is the correct behaviour here
+    // too (nothing to disagree with when everything is already on screen).
+    var following by remember { mutableStateOf(true) }
+    val atBottom by remember { derivedStateOf { !listState.canScrollForward } }
+
+    LaunchedEffect(atBottom) {
+        if (atBottom) following = true
+    }
+
+    val stopFollowingOnDragBack = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f) following = false
+                return Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(state.lines.size, following) {
+        if (following && listState.layoutInfo.totalItemsCount > 0) {
+            listState.scrollToItem(listState.layoutInfo.totalItemsCount - 1)
+        }
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        StatusBar(state.connection)
+        Box(Modifier.fillMaxSize().nestedScroll(stopFollowingOnDragBack)) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().testTag("logs_body"),
+                contentPadding = PaddingValues(vertical = 4.dp),
+            ) {
+                itemsIndexed(state.lines) { index, line ->
+                    if (state.boundaryIndex == index && index != 0) {
+                        SnapshotBoundary()
+                    }
+                    LogRow(line.text, colorFor(line.level, colors))
+                }
+            }
+            if (!following) {
+                JumpToTail(
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+                    onClick = {
+                        following = true
+                        scope.launch { listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1) }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBar(connection: LogsConnection) {
+    val colors = LlmTheme.colors
+    val (label, color) = when (connection) {
+        LogsConnection.CONNECTING -> "Connecting…" to colors.subtle
+        LogsConnection.LIVE -> "Live" to colors.green
+        LogsConnection.ENDED -> "Stream ended — container stopped" to colors.muted
+        LogsConnection.FALLBACK -> "Not live — showing last fetched tail" to colors.amber
+    }
+    Text(
+        label,
+        color = color,
+        style = MaterialTheme.typography.labelMedium,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp).testTag("logs_status"),
+    )
+}
+
+@Composable
+private fun SnapshotBoundary() {
+    val colors = LlmTheme.colors
+    Box(Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("logs_boundary")) {
+        Text(
+            "── live output ──",
+            color = colors.subtle,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun LogRow(text: String, color: Color) {
+    Text(
+        text,
+        color = color,
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 1.dp),
+    )
+}
+
+private fun colorFor(level: LogLevel, colors: LlmColors): Color = when (level) {
+    LogLevel.ERROR -> colors.logError
+    LogLevel.WARN -> colors.logWarn
+    LogLevel.INFO -> colors.logInfo
+    LogLevel.PLAIN -> colors.logPlain
+}
+
+@Composable
+private fun JumpToTail(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    val colors = LlmTheme.colors
+    Box(
+        modifier = modifier
+            .background(colors.surfaceElevated, CircleShape)
+            .testTag("logs_jump_to_tail"),
+    ) {
+        IconButton(onClick = onClick) { Text("↓", color = colors.fg) }
+    }
+}
+
+@Composable
+private fun LoadingBox() {
+    Box(Modifier.fillMaxSize().testTag("logs_loading"), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(color = LlmTheme.colors.accent)
+    }
+}
+
+@Composable
+private fun MessageBox(testTag: String, title: String, message: String, onRetry: (() -> Unit)? = null) {
+    val colors = LlmTheme.colors
+    Column(
+        Modifier.fillMaxSize().padding(32.dp).testTag(testTag),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(title, color = colors.red, style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+        Text(message, color = colors.muted, style = MaterialTheme.typography.bodyMedium)
+        if (onRetry != null) {
+            Spacer(Modifier.height(16.dp))
+            TextButton(onClick = onRetry, modifier = Modifier.testTag("logs_retry")) {
+                Text("Retry", color = colors.accent)
+            }
+        }
+    }
+}
+
+/** F12-R5: the whole visible buffer, in order; truncated with an explicit marker rather than failing silently. */
+private fun shareLogs(context: Context, lines: List<LogLine>) {
+    val full = lines.joinToString("\n") { it.text }
+    val text = if (full.length > MAX_SHARE_CHARS) {
+        TRUNCATION_MARKER + full.takeLast(MAX_SHARE_CHARS)
+    } else {
+        full
+    }
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    context.startActivity(Intent.createChooser(intent, "Share logs"))
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/logs/LogsViewModel.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/logs/LogsViewModel.kt
@@ -1,0 +1,147 @@
+package com.hpz.llmdockchat.feature.logs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hpz.llmdockchat.core.error.AppError
+import com.hpz.llmdockchat.core.error.displayMessage
+import com.hpz.llmdockchat.core.net.LogStreamEvent
+import com.hpz.llmdockchat.core.net.appError
+import com.hpz.llmdockchat.data.LogsStreamRepository
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.model.LogLevel
+import com.hpz.llmdockchat.data.model.classifyLogLevel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** One rendered row. [level] degrades to [LogLevel.PLAIN] for anything F12-R4 doesn't recognise. */
+data class LogLine(val text: String, val level: LogLevel)
+
+/** How the on-screen buffer was populated, and whether it is still live. */
+enum class LogsConnection {
+    /** The stream is open; the historical tail may still be arriving. */
+    CONNECTING,
+
+    /** The stream is open and the tail has been delivered — new lines are live output. */
+    LIVE,
+
+    /** The container's log stream ended normally (`stream_end`) — not a failure. */
+    ENDED,
+
+    /** The stream could not be established; [LogsUiState.Loaded.lines] came from the one-shot fallback (F12-R3). */
+    FALLBACK,
+}
+
+sealed interface LogsUiState {
+    data object Loading : LogsUiState
+
+    /** 404 — the service exists in `services.json` but has no container yet. */
+    data class NotCreated(val message: String) : LogsUiState
+
+    /** Neither the stream nor the one-shot fallback could produce anything. */
+    data class Failed(val message: String) : LogsUiState
+
+    data class Loaded(
+        val lines: List<LogLine>,
+        /** Index into [lines] where the historical tail ended — null until `snapshot_end` (or never, for [LogsConnection.FALLBACK]). */
+        val boundaryIndex: Int?,
+        val connection: LogsConnection,
+    ) : LogsUiState
+}
+
+/**
+ * F12-R1/R2/R3/R4. [observeLogStream] is collected by [LogsScreen] from a
+ * composition-scoped `LaunchedEffect`, not from [viewModelScope] — the same
+ * split [ModelDetailViewModel] uses, and for the same reason: F10 shipped a
+ * bug where a stream launched in `viewModelScope` outlived the screen because
+ * Navigation Compose keeps the ViewModel alive across a tab switch. Collecting
+ * in the screen's own composition means leaving it cancels the flow, which
+ * cancels the underlying OkHttp call (F12-R1's last criterion).
+ */
+class LogsViewModel(
+    private val serviceName: String,
+    private val logsStreamRepository: LogsStreamRepository,
+    private val servicesRepository: ServicesRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<LogsUiState>(LogsUiState.Loading)
+    val state: StateFlow<LogsUiState> = _state.asStateFlow()
+
+    private val lines = mutableListOf<LogLine>()
+    private var boundaryIndex: Int? = null
+    private var sawAnyFrame = false
+
+    /** Collected by [LogsScreen] — see the class doc. Never started from here. */
+    fun observeLogStream(): Flow<LogStreamEvent> = logsStreamRepository.stream(serviceName)
+
+    fun onStreamEvent(event: LogStreamEvent) {
+        sawAnyFrame = true
+        when (event) {
+            is LogStreamEvent.SnapshotStart -> publish(LogsConnection.CONNECTING)
+            is LogStreamEvent.Log -> {
+                lines += LogLine(event.line, classifyLogLevel(event.line))
+                publish(LogsConnection.CONNECTING)
+            }
+            is LogStreamEvent.SnapshotEnd -> {
+                boundaryIndex = lines.size
+                publish(LogsConnection.LIVE)
+            }
+            is LogStreamEvent.StreamEnd -> publish(LogsConnection.ENDED)
+            is LogStreamEvent.Error -> _state.value = LogsUiState.Failed(event.message)
+            is LogStreamEvent.Unknown -> Unit
+        }
+    }
+
+    /** The flow completed without an explicit `stream_end` — treated the same: an end state, not a failure. */
+    fun onStreamCompleted() {
+        if (sawAnyFrame) publish(LogsConnection.ENDED)
+    }
+
+    /**
+     * The stream could not be established at all. A 404 means the service has
+     * no container yet (F12-R1's fifth criterion) — shown as [LogsUiState.NotCreated],
+     * never an empty screen. Anything else falls back to the one-shot fetch
+     * (F12-R3); if that fails too, the failure is shown as-is.
+     */
+    fun onStreamFailed(error: Throwable) {
+        if (sawAnyFrame) {
+            // A drop mid-stream, not a failure to connect — the buffer already on
+            // screen stays, but it's no longer live.
+            _state.value = LogsUiState.Failed(error.appError.displayMessage)
+            return
+        }
+        val appError = error.appError
+        if (appError is AppError.Http && appError.status == 404) {
+            _state.value = LogsUiState.NotCreated(appError.message)
+            return
+        }
+        fetchOnce()
+    }
+
+    private fun fetchOnce() {
+        viewModelScope.launch {
+            servicesRepository.fetchLogsOnce(serviceName).fold(
+                onSuccess = { fetched ->
+                    lines.clear()
+                    lines += fetched.map { LogLine(it, classifyLogLevel(it)) }
+                    boundaryIndex = null
+                    publish(LogsConnection.FALLBACK)
+                },
+                onFailure = { failure ->
+                    val appError = failure.appError
+                    _state.value = if (appError is AppError.Http && appError.status == 404) {
+                        LogsUiState.NotCreated(appError.message)
+                    } else {
+                        LogsUiState.Failed(appError.displayMessage)
+                    }
+                },
+            )
+        }
+    }
+
+    private fun publish(connection: LogsConnection) {
+        _state.value = LogsUiState.Loaded(lines.toList(), boundaryIndex, connection)
+    }
+}

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.hpz.llmdockchat.feature.models
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,6 +41,7 @@ import com.hpz.llmdockchat.data.model.ServiceSummary
 fun ModelDetailScreen(
     viewModel: ModelDetailViewModel,
     onBack: () -> Unit,
+    onOpenLogs: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -58,6 +60,7 @@ fun ModelDetailScreen(
         state = state,
         actionState = actionState,
         onBack = onBack,
+        onOpenLogs = onOpenLogs,
         onRetry = viewModel::retry,
         onRequestStart = viewModel::requestStart,
         onRequestStop = viewModel::requestStop,
@@ -73,6 +76,7 @@ private fun ModelDetailContent(
     state: ModelDetailUiState,
     actionState: ServiceActionState,
     onBack: () -> Unit,
+    onOpenLogs: () -> Unit,
     onRetry: () -> Unit,
     onRequestStart: () -> Unit,
     onRequestStop: () -> Unit,
@@ -105,7 +109,7 @@ private fun ModelDetailContent(
             when (state) {
                 is ModelDetailUiState.Loading -> LoadingBox()
                 is ModelDetailUiState.Failed -> FailedBox(state.message, onRetry)
-                is ModelDetailUiState.Loaded -> DetailBody(state, actionState, onRequestStart, onRequestStop)
+                is ModelDetailUiState.Loaded -> DetailBody(state, actionState, onRequestStart, onRequestStop, onOpenLogs)
             }
         }
         ServiceActionDialog(actionState, onDismiss = onDismissAction, onConfirm = onConfirmAction)
@@ -118,6 +122,7 @@ private fun DetailBody(
     actionState: ServiceActionState,
     onRequestStart: () -> Unit,
     onRequestStop: () -> Unit,
+    onOpenLogs: () -> Unit,
 ) {
     val colors = LlmTheme.colors
     val summary = state.summary
@@ -181,6 +186,28 @@ private fun DetailBody(
             item { SectionLabel("Flags") }
             items(flags, key = { it.first }) { (flag, value) -> FlagRow(flag, value) }
         }
+
+        // F12 — same "Logs" entry as screen 10b's mockup. Offered whether the
+        // container is running, stopped, or missing: LogsScreen shows the
+        // right message for each case rather than this row guessing at it.
+        item { SectionLabel("Logs") }
+        item { LogsRow(onClick = onOpenLogs) }
+    }
+}
+
+@Composable
+private fun LogsRow(onClick: () -> Unit) {
+    val colors = LlmTheme.colors
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("model_detail_logs"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Live output", color = colors.fg, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        Text("→", color = colors.subtle)
     }
 }
 

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/feature/models/ModelsScreen.kt
@@ -5,16 +5,19 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -35,9 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 import com.hpz.llmdockchat.core.ui.theme.LLMDockChatTheme
 import com.hpz.llmdockchat.core.ui.theme.LlmTheme
 import com.hpz.llmdockchat.data.model.Engine
@@ -409,29 +415,21 @@ private fun ServiceRow(
         Modifier
             .fillMaxWidth()
             .clickable(onClick = { onOpenDetail(service.name) })
-            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .padding(start = 12.dp, end = 4.dp, top = 10.dp, bottom = 10.dp)
             .testTag("service_row_${service.name}"),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        Box(
-            Modifier
-                .size(8.dp)
-                .background(if (service.isRunning) colors.green else colors.subtle, CircleShape)
-                .testTag("service_dot_${service.name}"),
-        )
+        EngineChip(service.engine, isRunning = service.isRunning, modifier = Modifier.testTag("service_dot_${service.name}"))
         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    service.name,
-                    color = colors.fg,
-                    style = MaterialTheme.typography.bodyLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-                EngineChip(service.engine)
-            }
+            Text(
+                service.name,
+                color = colors.fg,
+                style = MaterialTheme.typography.bodyMedium,
+                fontSize = 14.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
             Text(
                 service.subtitle(now, zone),
                 color = colors.muted,
@@ -444,6 +442,7 @@ private fun ServiceRow(
         if (onNewChatFromModel != null && service.isRunning && service.isChatCapable) {
             TextButton(
                 onClick = { onNewChatFromModel(service.name) },
+                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
                 modifier = Modifier.testTag("new_chat_from_model_${service.name}"),
             ) {
                 Text("New chat", color = colors.accent, style = MaterialTheme.typography.labelMedium)
@@ -458,19 +457,28 @@ private fun ServiceRow(
         } else if (service.isRunning) {
             TextButton(
                 onClick = { onRequestStop(service.name) },
+                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
                 modifier = Modifier.testTag("service_row_stop_${service.name}"),
             ) { Text("Stop", color = colors.red, style = MaterialTheme.typography.labelMedium) }
         } else {
             TextButton(
                 onClick = { onRequestStart(service.name) },
+                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
                 modifier = Modifier.testTag("service_row_start_${service.name}"),
             ) { Text("Start", color = colors.accent, style = MaterialTheme.typography.labelMedium) }
         }
     }
 }
 
+/**
+ * The engine pill, square rather than a rounded chip so it reads as a fixed
+ * "type" tag rather than a status badge — the actual running/stopped status
+ * is the vertical bar on its leading edge, not the pill's shape or color.
+ * Green when running, gray otherwise; the bar and the pill sit flush against
+ * each other (no gap, no rounding on the seam) so they read as one control.
+ */
 @Composable
-private fun EngineChip(engine: Engine) {
+private fun EngineChip(engine: Engine, isRunning: Boolean, modifier: Modifier = Modifier) {
     val colors = LlmTheme.colors
     val chip = when (engine) {
         Engine.LLAMA_CPP -> colors.engineLlamaCpp
@@ -479,28 +487,75 @@ private fun EngineChip(engine: Engine) {
         Engine.OPEN_ROUTER -> colors.engineOpenRouter
         Engine.UNKNOWN -> colors.engineUnknown
     }
-    Box(
-        Modifier
-            .clip(RoundedCornerShape(6.dp))
-            .background(chip.background)
-            .padding(horizontal = 8.dp, vertical = 3.dp),
-    ) {
-        Text(
-            engineLabel(engine),
-            color = chip.foreground,
-            style = MaterialTheme.typography.labelSmall,
-            fontFamily = FontFamily.Monospace,
+    Row(modifier.height(IntrinsicSize.Min)) {
+        Box(
+            Modifier
+                .width(3.dp)
+                .fillMaxHeight()
+                .background(if (isRunning) colors.green else colors.subtle),
         )
+        val lines = engineLabelLines(engine)
+        Column(
+            Modifier
+                .clip(RoundedCornerShape(topEnd = 4.dp, bottomEnd = 4.dp))
+                .background(chip.background)
+                .width(CHIP_WIDTH)
+                .padding(vertical = 3.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            lines.forEach { line ->
+                Text(
+                    line,
+                    color = chip.foreground,
+                    fontSize = chipFontSize(lines),
+                    lineHeight = 9.sp,
+                    fontFamily = FontFamily.Monospace,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
+        }
     }
 }
 
+/**
+ * Short on purpose. This label sits inline before the model name on every
+ * row, so each character it costs is a character the name loses — and the
+ * name is what the owner is actually reading. "llama.cpp" is unmistakable
+ * as "llama"; the picker (which has a whole row to itself) still spells
+ * them out in full.
+ */
 internal fun engineLabel(engine: Engine): String = when (engine) {
     Engine.LLAMA_CPP -> "llama.cpp"
     Engine.VLLM -> "vLLM"
     Engine.DS4 -> "ds4"
-    Engine.OPEN_ROUTER -> "OpenRouter"
+    Engine.OPEN_ROUTER -> "open router"
     Engine.UNKNOWN -> "?"
 }
+
+/**
+ * Split for a fixed-width chip: break on a dot or a space, never mid-word,
+ * so "llama.cpp" stacks as llama/cpp and "vLLM" stays on one line.
+ */
+internal fun engineLabelLines(engine: Engine): List<String> =
+    engineLabel(engine).split('.', ' ').filter { it.isNotEmpty() }
+
+/**
+ * Every chip is [CHIP_WIDTH] wide regardless of engine, so the model names
+ * beside them all start at the same x — a ragged left edge on a list this
+ * long is harder to scan than a slightly small label. The type shrinks to
+ * fit instead of the box growing: sizes are picked off the longest line
+ * rather than measured, which is deterministic and needs no layout pass.
+ */
+private fun chipFontSize(lines: List<String>): TextUnit = when (lines.maxOf { it.length }) {
+    in 0..3 -> 9.sp
+    4 -> 8.sp
+    5 -> 7.sp
+    else -> 6.sp
+}
+
+private val CHIP_WIDTH = 30.dp
 
 @Composable
 private fun LoadingState() {

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/AppNavHost.kt
@@ -30,6 +30,8 @@ import com.hpz.llmdockchat.feature.connect.ConnectScreen
 import com.hpz.llmdockchat.feature.connect.ConnectViewModel
 import com.hpz.llmdockchat.feature.conversations.ConversationListScreen
 import com.hpz.llmdockchat.feature.conversations.ConversationListViewModel
+import com.hpz.llmdockchat.feature.logs.LogsScreen
+import com.hpz.llmdockchat.feature.logs.LogsViewModel
 import com.hpz.llmdockchat.feature.models.ModelDetailScreen
 import com.hpz.llmdockchat.feature.models.ModelDetailViewModel
 import com.hpz.llmdockchat.feature.models.ModelsScreen
@@ -154,7 +156,29 @@ fun AppNavHost(
                     }
                 },
             )
-            ModelDetailScreen(viewModel = viewModel, onBack = { navController.popBackStack() })
+            ModelDetailScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+                onOpenLogs = { navController.navigate(Destinations.logs(serviceName)) },
+            )
+        }
+
+        composable(Destinations.LOGS) { backStackEntry ->
+            val serviceName = backStackEntry.arguments?.getString("serviceName").orEmpty()
+            val viewModel: LogsViewModel = viewModel(
+                // Keyed by service, same reasoning as MODEL_DETAIL's key.
+                key = "logs_$serviceName",
+                factory = viewModelFactory {
+                    initializer {
+                        LogsViewModel(
+                            serviceName = serviceName,
+                            logsStreamRepository = container.logsStreamRepository,
+                            servicesRepository = container.servicesRepository,
+                        )
+                    }
+                },
+            )
+            LogsScreen(viewModel = viewModel, onBack = { navController.popBackStack() })
         }
 
         composable(Destinations.THREAD) { backStackEntry ->

--- a/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
+++ b/android/src/app/src/main/java/com/hpz/llmdockchat/navigation/Destinations.kt
@@ -25,6 +25,11 @@ object Destinations {
     const val MODEL_DETAIL = "$MODEL_DETAIL_ROUTE/{serviceName}"
     fun modelDetail(serviceName: String) = "$MODEL_DETAIL_ROUTE/$serviceName"
 
+    /** F12 — pushed on top of [MODEL_DETAIL], same as it is on top of [TABS]. */
+    private const val LOGS_ROUTE = "logs"
+    const val LOGS = "$LOGS_ROUTE/{serviceName}"
+    fun logs(serviceName: String) = "$LOGS_ROUTE/$serviceName"
+
     /**
      * F02-R8's primary action, built out in F03. [NEW_CHAT] is the route
      * *pattern* registered with `composable(...)` — it must be the string

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/LogStreamEventTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/core/net/LogStreamEventTest.kt
@@ -1,0 +1,37 @@
+package com.hpz.llmdockchat.core.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** [parseLogStreamFrame] — pure mapping of one SSE payload to a typed frame (F12-R1). */
+class LogStreamEventTest {
+
+    @Test
+    fun `snapshot_start, log, snapshot_end and stream_end map to their own types`() {
+        assertEquals(LogStreamEvent.SnapshotStart, parseLogStreamFrame("""{"type":"snapshot_start","service":"x"}"""))
+        assertEquals(
+            LogStreamEvent.Log("main: HTTP server is listening, hostname: 0.0.0.0, port: 8080"),
+            parseLogStreamFrame("""{"type":"log","service":"x","line":"main: HTTP server is listening, hostname: 0.0.0.0, port: 8080"}"""),
+        )
+        assertEquals(LogStreamEvent.SnapshotEnd, parseLogStreamFrame("""{"type":"snapshot_end","service":"x"}"""))
+        assertEquals(LogStreamEvent.StreamEnd, parseLogStreamFrame("""{"type":"stream_end","service":"x"}"""))
+    }
+
+    @Test
+    fun `an error frame carries the server's message`() {
+        val event = parseLogStreamFrame("""{"type":"error","service":"x","message":"container vanished"}""")
+        assertEquals(LogStreamEvent.Error("container vanished"), event)
+    }
+
+    @Test
+    fun `a log frame missing its line is unknown, not a crash`() {
+        assertTrue(parseLogStreamFrame("""{"type":"log","service":"x"}""") is LogStreamEvent.Unknown)
+    }
+
+    @Test
+    fun `an unrecognised type, and non-JSON, are both Unknown`() {
+        assertTrue(parseLogStreamFrame("""{"type":"something_new"}""") is LogStreamEvent.Unknown)
+        assertTrue(parseLogStreamFrame("not json at all") is LogStreamEvent.Unknown)
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/LogsStreamRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/LogsStreamRepositoryTest.kt
@@ -1,0 +1,69 @@
+package com.hpz.llmdockchat.data
+
+import com.hpz.llmdockchat.core.net.LogStreamEvent
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [LogsStreamRepository.stream] — the transport wiring only (parsing itself
+ * is [com.hpz.llmdockchat.core.net.LogStreamEventTest]'s job). Deliberately no
+ * "keeps retrying" test here, unlike [GpuStreamRepositoryTest] and
+ * [ServicesStreamRepositoryTest]'s: this repository does not loop, by design
+ * (see its class doc) — a `stream_end` is a normal outcome, not something to
+ * reconnect into.
+ */
+class LogsStreamRepositoryTest {
+
+    @Test
+    fun `frames arrive in order, unparsed types passed straight through`() = runTest {
+        val transport = FakeSseTransport()
+        transport.payloads = listOf(
+            """{"type":"snapshot_start"}""",
+            """{"type":"log","line":"first line"}""",
+            """{"type":"snapshot_end"}""",
+            """{"type":"log","line":"second line"}""",
+            """{"type":"stream_end"}""",
+        )
+        val repository = LogsStreamRepository(transport)
+
+        val events = withTimeout(5_000) { repository.stream("llamacpp-a").toList() }
+
+        assertEquals(
+            listOf(
+                LogStreamEvent.SnapshotStart,
+                LogStreamEvent.Log("first line"),
+                LogStreamEvent.SnapshotEnd,
+                LogStreamEvent.Log("second line"),
+                LogStreamEvent.StreamEnd,
+            ),
+            events,
+        )
+        assertEquals("200", transport.requests.single().query["tail"])
+    }
+
+    /**
+     * The mechanism, not a flag — same pattern as
+     * [GpuStreamRepositoryTest]'s "cancelling the collector actually tears
+     * down the open connection": a collector going away (leaving the logs
+     * screen, F12-R1's last criterion) must actually cancel the underlying
+     * transport call, not just stop reading from it.
+     */
+    @Test
+    fun `cancelling the collector tears down the open connection`() = runTest {
+        val transport = FakeSseTransport()
+        transport.stayOpen = true
+        val repository = LogsStreamRepository(transport)
+
+        val job: Job = launch { repository.stream("llamacpp-a").collect { } }
+        withTimeout(5_000) { transport.parked.await() }
+
+        job.cancel()
+        withTimeout(5_000) { transport.cancelled.await() }
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesRepositoryTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/ServicesRepositoryTest.kt
@@ -112,4 +112,30 @@ class ServicesRepositoryTest {
         val request = server.takeRequest()
         assertEquals("/api/services/llamacpp-a/stop", request.url.encodedPath)
     }
+
+    /** F12-R3 — the one-shot fallback, split client-side rather than trusting the server's `lines` count. */
+    @Test
+    fun `fetchLogsOnce splits the logs blob into lines and hits the tail query param`() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder().body(
+                """{"service": "llamacpp-a", "logs": "line one\nline two\nline three", "lines": 3, "timestamp": "now"}""",
+            ).build(),
+        )
+
+        val lines = repository.fetchLogsOnce("llamacpp-a", tail = 50).getOrThrow()
+
+        assertEquals(listOf("line one", "line two", "line three"), lines)
+        val request = server.takeRequest()
+        assertEquals("/api/services/llamacpp-a/logs", request.url.encodedPath)
+        assertEquals("50", request.url.queryParameter("tail"))
+    }
+
+    @Test
+    fun `fetchLogsOnce surfaces a 404 as a real failure, unlike detail`() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(404).body("""{"error": "Service has not been created yet"}""").build())
+
+        val result = repository.fetchLogsOnce("ghost-service")
+
+        assertTrue(result.isFailure)
+    }
 }

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/LogLevelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/data/model/LogLevelTest.kt
@@ -1,0 +1,42 @@
+package com.hpz.llmdockchat.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** [classifyLogLevel] — pattern matching over unstructured lines (F12-R4). Never touches the text. */
+class LogLevelTest {
+
+    @Test
+    fun `ERROR, CRITICAL and traceback lines classify as error`() {
+        assertEquals(LogLevel.ERROR, classifyLogLevel("2026-07-25 ERROR api_server.py:1487 failed to bind"))
+        assertEquals(LogLevel.ERROR, classifyLogLevel("CRITICAL: out of memory"))
+        assertEquals(LogLevel.ERROR, classifyLogLevel("Traceback (most recent call last):"))
+    }
+
+    @Test
+    fun `WARN and WARNING both classify as warn`() {
+        assertEquals(LogLevel.WARN, classifyLogLevel("WARN cudagraph capture may add ~1.2 GiB"))
+        assertEquals(LogLevel.WARN, classifyLogLevel("2026-07-25 12:00:00 WARNING: retrying"))
+    }
+
+    @Test
+    fun `INFO classifies as info`() {
+        assertEquals(LogLevel.INFO, classifyLogLevel("INFO api_server.py:1487 vLLM API server version 0.24.0"))
+    }
+
+    @Test
+    fun `a line matching nothing degrades to plain, not a crash`() {
+        assertEquals(LogLevel.PLAIN, classifyLogLevel("Loading safetensors shards:  33% 3/9"))
+        assertEquals(LogLevel.PLAIN, classifyLogLevel(""))
+    }
+
+    @Test
+    fun `a word merely containing INFO, like informant, does not match on substring`() {
+        assertEquals(LogLevel.PLAIN, classifyLogLevel("the informant provided a tip"))
+    }
+
+    @Test
+    fun `error takes priority over a warn mentioned in the same line`() {
+        assertEquals(LogLevel.ERROR, classifyLogLevel("WARN: retrying after ERROR from upstream"))
+    }
+}

--- a/android/src/app/src/test/java/com/hpz/llmdockchat/feature/logs/LogsViewModelTest.kt
+++ b/android/src/app/src/test/java/com/hpz/llmdockchat/feature/logs/LogsViewModelTest.kt
@@ -1,0 +1,181 @@
+package com.hpz.llmdockchat.feature.logs
+
+import com.hpz.llmdockchat.core.auth.SessionState
+import com.hpz.llmdockchat.core.net.ApiClient
+import com.hpz.llmdockchat.core.net.ApiJson
+import com.hpz.llmdockchat.core.net.AuthInterceptor
+import com.hpz.llmdockchat.core.net.BaseUrl
+import com.hpz.llmdockchat.core.net.BaseUrlResult
+import com.hpz.llmdockchat.core.net.LogStreamEvent
+import com.hpz.llmdockchat.data.LogsStreamRepository
+import com.hpz.llmdockchat.data.ServicesRepository
+import com.hpz.llmdockchat.data.model.LogLevel
+import com.hpz.llmdockchat.testing.FakeServerUrlStore
+import com.hpz.llmdockchat.testing.FakeSseTransport
+import com.hpz.llmdockchat.testing.FakeTokenStore
+import com.hpz.llmdockchat.testing.MainDispatcherRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * F12-R1's frame handling, F12-R3's fallback, and F12-R4's level tagging —
+ * driven directly against the ViewModel's event API rather than through
+ * [LogsStreamRepository]'s flow machinery, which [LogsStreamRepositoryTest]
+ * already covers. This is exactly what [LogsScreen]'s collector calls, so it
+ * exercises the same state machine [LogsScreen] would.
+ */
+class LogsViewModelTest {
+
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    private lateinit var server: MockWebServer
+    private lateinit var servicesRepository: ServicesRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val urlStore = FakeServerUrlStore(
+            (BaseUrl.normalize(server.url("/").toString()) as BaseUrlResult.Valid).baseUrl,
+        )
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(FakeTokenStore("totp-test"), SessionState()))
+            .build()
+        servicesRepository = ServicesRepository(ApiClient(client, urlStore, ApiJson, Dispatchers.IO))
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun viewModel() = LogsViewModel(
+        serviceName = "llamacpp-a",
+        logsStreamRepository = LogsStreamRepository(FakeSseTransport()),
+        servicesRepository = servicesRepository,
+    )
+
+    @Test
+    fun `snapshot then log lines then snapshot_end place the boundary after the tail`() {
+        val vm = viewModel()
+
+        vm.onStreamEvent(LogStreamEvent.SnapshotStart)
+        vm.onStreamEvent(LogStreamEvent.Log("line one"))
+        vm.onStreamEvent(LogStreamEvent.Log("line two"))
+        vm.onStreamEvent(LogStreamEvent.SnapshotEnd)
+
+        val state = vm.state.value as LogsUiState.Loaded
+        assertEquals(listOf("line one", "line two"), state.lines.map { it.text })
+        assertEquals(2, state.boundaryIndex)
+        assertEquals(LogsConnection.LIVE, state.connection)
+    }
+
+    /** F12-R4: a line with no recognisable level renders plainly, not crashing or vanishing. */
+    @Test
+    fun `an ERROR line is tagged, a plain line degrades to plain`() {
+        val vm = viewModel()
+
+        vm.onStreamEvent(LogStreamEvent.Log("ERROR: could not bind port"))
+        vm.onStreamEvent(LogStreamEvent.Log("Loading safetensors shards: 33%"))
+
+        val lines = (vm.state.value as LogsUiState.Loaded).lines
+        assertEquals(LogLevel.ERROR, lines[0].level)
+        assertEquals(LogLevel.PLAIN, lines[1].level)
+    }
+
+    /**
+     * Bug-shaped: a viewmodel that treats `stream_end` as an error would show
+     * [LogsUiState.Failed] here, which is exactly what F12-R1's fourth
+     * criterion says must not happen for a container that was simply stopped.
+     */
+    @Test
+    fun `stream_end is an ended state, not a failure`() {
+        val vm = viewModel()
+        vm.onStreamEvent(LogStreamEvent.Log("last line before stop"))
+
+        vm.onStreamEvent(LogStreamEvent.StreamEnd)
+
+        val state = vm.state.value
+        assertTrue(state is LogsUiState.Loaded)
+        assertEquals(LogsConnection.ENDED, (state as LogsUiState.Loaded).connection)
+    }
+
+    /** The connection dropped without an explicit `stream_end` frame — same end state either way. */
+    @Test
+    fun `the flow completing without a stream_end frame is also treated as ended`() {
+        val vm = viewModel()
+        vm.onStreamEvent(LogStreamEvent.Log("one line"))
+
+        vm.onStreamCompleted()
+
+        val state = vm.state.value as LogsUiState.Loaded
+        assertEquals(LogsConnection.ENDED, state.connection)
+    }
+
+    /**
+     * Bug-shaped: a naive `onStreamFailed` that always shows a generic error
+     * would leave a `not-created` service on a blank/wrong screen — F12-R1's
+     * fifth criterion requires the dashboard's own 404 message specifically.
+     */
+    @Test
+    fun `a 404 on the very first connection attempt is NotCreated, not Failed`() {
+        val vm = viewModel()
+
+        vm.onStreamFailed(fakeHttp404("Service has not been created yet"))
+
+        val state = vm.state.value
+        assertTrue(state is LogsUiState.NotCreated)
+        assertEquals("Service has not been created yet", (state as LogsUiState.NotCreated).message)
+    }
+
+    /** F12-R3: the stream could not be established (not a 404) — falls back to the one-shot fetch. */
+    @Test
+    fun `a non-404 connection failure falls back to the one-shot fetch`() {
+        server.enqueue(
+            MockResponse.Builder().body(
+                """{"service": "llamacpp-a", "logs": "one\ntwo", "lines": 2, "timestamp": "now"}""",
+            ).build(),
+        )
+        val vm = viewModel()
+
+        vm.onStreamFailed(RuntimeException("connection reset"))
+        val state = settled(vm)
+
+        assertTrue(state is LogsUiState.Loaded)
+        val loaded = state as LogsUiState.Loaded
+        assertEquals(listOf("one", "two"), loaded.lines.map { it.text })
+        assertEquals(LogsConnection.FALLBACK, loaded.connection)
+        assertNull(loaded.boundaryIndex)
+    }
+
+    @Test
+    fun `when the fallback also fails, the failure is shown as-is`() {
+        server.enqueue(MockResponse.Builder().code(500).body("""{"error": "Docker socket unavailable"}""").build())
+        val vm = viewModel()
+
+        vm.onStreamFailed(RuntimeException("connection reset"))
+        val state = settled(vm)
+
+        assertTrue(state is LogsUiState.Failed)
+    }
+
+    private fun settled(viewModel: LogsViewModel): LogsUiState = runBlocking {
+        withTimeout(10_000) { viewModel.state.first { it !is LogsUiState.Loading } }
+    }
+
+    private fun fakeHttp404(message: String): Throwable =
+        com.hpz.llmdockchat.core.net.ApiException(com.hpz.llmdockchat.core.error.AppError.Http(404, message, fromServer = true))
+}


### PR DESCRIPTION
Streaming logs from a service's detail screen — the reason to reach for the phone when something will not come up.

## `stream_end` is an end state, not a failure

This is the criterion that mattered. A stopped container ends its log stream **normally**, so routing that through the error path would make the feature look broken every single time the owner stops a model.

Verified by breaking it first: patching the `StreamEnd` branch to route to `Failed` fails `LogsViewModelTest` at line 112. Then verified live — opened logs on a running container, stopped it mid-stream, and watched the bar go from green "Live" to grey "Stream ended — container stopped", with the container's own `cleaning up before exit…` as the final line.

## No reconnect loop, deliberately

Unlike `GpuStreamRepository` and `ServicesStreamRepository`, `LogsStreamRepository` does not retry. A `stream_end` is a normal outcome and auto-reconnecting into a genuinely dead stream is worse than stopping. A real network drop surfaces as `Failed` with a manual Retry, so the user is never stuck — one tap reconnects.

## Teardown confirmed by socket, not by inspection

`ss -tnp` filtered on `qemu-system-x86` (where the emulator's host-side sockets actually live) showed the stream socket `127.0.0.1:57060 → 127.0.0.1:3399` gone within ~1 s of pressing back.

This requirement has now been got wrong twice on this project — F07, and a **real bug in F10** where `viewModelScope`-launched streams survived a tab switch because Navigation Compose keeps the ViewModel alive. It gets verified by socket every time now.

## Follow-tail did not inherit F04's sharp edge

`ThreadScreen`'s pattern misbehaves in a list too short to scroll (`canScrollForward` stays false, following flips back on). Here that is correct behaviour: if the whole buffer fits on screen there is nothing to scroll away from, so there is no user intent to honour.

## Scope

Built R1, R2 (Must) and R3, R4, R5 (Should). A `not-created` service's 404 renders as "No container yet / Service has not been created yet" rather than a blank screen — verified against a genuinely not-created service.

**F11-R7 (readiness) stays skipped**, and the review agreed: wiring "up but not ready" into the picker touches `NewChatViewModel`'s selection logic and its own state machine — a different screen's concern, not a small addition just because a log client now exists.

**Not verified:** keepalive on a quiet container (accepted on code read — SSE comments are already dropped and covered by `SseFrameParser`'s tests) and R4's colouring on screen, since no container emitted a real ERROR line during review.

452 tests pass. Rig restored: `open-webui` running, everything else exited as found.